### PR TITLE
[codex] Split spectrum debug chart navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ All detailed documentation lives under `docs/`. When adding or updating document
 # App — always use xcodebuild, never swift build / swift test
 # Build configurations: Debug / Release
 xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
-xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
 xed WiFiLens/WiFiLens.xcodeproj                   # open in Xcode GUI
 
 # Website — Vite + Tailwind CSS, outputs to _site/
@@ -38,6 +38,8 @@ npm run preview                          # preview production build
 ```
 
 The product name is `WiFi Lens.app` (with space). Unit tests use Swift Testing (`@Test`) with `TEST_HOST` — the test bundle is injected into the app process for `@testable import` symbol resolution. All test `.swift` files must be added to the WiFiLensTests target's Sources build phase (in `project.pbxproj`) for `xcodebuild test` to compile and run them. The `WiFiLensTests` scheme must reference the test bundle in both `<Testables>` and `<MacroExpansion>`.
+
+Do not run UI test bundles (`WiFiLensUITests`, `WiFiLensProUITests`) or full scheme test commands that include UI tests unless the user explicitly asks for UI tests. Default verification is build plus `-only-testing:WiFiLensTests`.
 
 When adding new test files, ensure they are:
 1. Added as PBXFileReference in project.pbxproj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ All detailed documentation lives under `docs/`. When adding or updating document
 | `docs/COLLABORATION_RULES.md` | AI assistant behavior rules — enforced prohibitions and must-follows |
 | `docs/TODO.md` | Feature roadmap and checked-off items |
 | `docs/ISSUES.md` | Bugs, regressions, and deferred work with status |
+| `docs/superpowers/specs/2026-06-18-debug-multi-ap-chart-design.md` | Design spec for the DebugChartView multi-AP chart workbench |
+| `docs/superpowers/plans/2026-06-18-debug-multi-ap-chart.md` | Implementation plan for the DebugChartView multi-AP chart workbench |
 | `Pro/docs/ARCHITECTURE.md` | Pro feature docs (Recording, Session, StoreKit) — in submodule |
 
 ## Build & Test

--- a/WiFiLens/Sources/WiFiLens/App/SidebarView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SidebarView.swift
@@ -9,6 +9,7 @@ enum SidebarPage: String, CaseIterable {
     case bleScanner
     case settings
 #if DEBUG
+    case spectrumDebugChart
     case debugChart
 #endif
 
@@ -19,7 +20,7 @@ enum SidebarPage: String, CaseIterable {
         case .spectrum, .channels, .interfaces, .roaming:
             true
 #if DEBUG
-        case .debugChart:
+        case .spectrumDebugChart, .debugChart:
             true
 #endif
         }
@@ -32,7 +33,7 @@ enum SidebarPage: String, CaseIterable {
         case .spectrum, .channels, .interfaces, .roaming:
             true
 #if DEBUG
-        case .debugChart:
+        case .spectrumDebugChart, .debugChart:
             true
 #endif
         }
@@ -48,6 +49,7 @@ enum SidebarPage: String, CaseIterable {
         case .bleScanner: String(localized: "nav.ble_scanner", comment: "BLE Scanner sidebar navigation item")
         case .settings:   String(localized: "common.action.settings", comment: "Settings button or menu item")
 #if DEBUG
+        case .spectrumDebugChart: String(localized: "nav.spectrum_debug_chart", comment: "Spectrum Debug Chart sidebar navigation item (dev only)")
         case .debugChart: String(localized: "nav.debug_chart", comment: "Debug Chart sidebar navigation item (dev only)")
 #endif
         }
@@ -63,6 +65,7 @@ enum SidebarPage: String, CaseIterable {
         case .bleScanner: "personalhotspot"
         case .settings:   "gearshape"
 #if DEBUG
+        case .spectrumDebugChart: "antenna.radiowaves.left.and.right"
         case .debugChart: "ladybug"
 #endif
         }
@@ -140,6 +143,10 @@ struct SidebarView: View {
                     }
                 }
 #if DEBUG
+                Label(SidebarPage.spectrumDebugChart.label, systemImage: SidebarPage.spectrumDebugChart.icon)
+                    .tag(SidebarPage.spectrumDebugChart)
+                    .accessibilityIdentifier("sidebar-spectrumDebugChart")
+
                 Label(SidebarPage.debugChart.label, systemImage: SidebarPage.debugChart.icon)
                     .tag(SidebarPage.debugChart)
                     .accessibilityIdentifier("sidebar-debugChart")

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
@@ -2,18 +2,9 @@ import SwiftUI
 
 #if DEBUG
 
-private enum DebugChartMode: String, CaseIterable, Identifiable {
+enum DebugChartMode: String {
     case singleAP
     case multiAP
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .singleAP: "Single AP"
-        case .multiAP: "Multi AP"
-        }
-    }
 }
 
 private struct DebugOscillator {
@@ -29,7 +20,8 @@ private struct DebugOscillator {
 }
 
 struct DebugChartView: View {
-    @State private var mode: DebugChartMode = .singleAP
+    let mode: DebugChartMode
+
     @State private var bandVM = BandChartViewModel(band: .band5GHz)
     @State private var selectedNetworkID: String?
     @State private var timer: Timer?
@@ -54,14 +46,12 @@ struct DebugChartView: View {
         "#2563EB", "#16A34A", "#EA580C", "#7C3AED",
     ]
 
+    init(mode: DebugChartMode = .singleAP) {
+        self.mode = mode
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            modeControls
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-
-            Divider()
-
             switch mode {
             case .singleAP:
                 singleAPWorkbench
@@ -78,14 +68,6 @@ struct DebugChartView: View {
             }
         }
         .onDisappear { stopTimer() }
-        .onChange(of: mode) { _, newMode in
-            switch newMode {
-            case .singleAP:
-                enterSingleAPMode()
-            case .multiAP:
-                enterMultiAPMode()
-            }
-        }
         .onChange(of: isRunning) { _, running in
             guard mode == .singleAP else { return }
             if running { startTimer() } else { stopTimer() }
@@ -97,22 +79,6 @@ struct DebugChartView: View {
     }
 
     // MARK: - Workbenches
-
-    private var modeControls: some View {
-        HStack(spacing: 12) {
-            Picker("Mode", selection: $mode.animation(.bouncy)) {
-                ForEach(DebugChartMode.allCases) { mode in
-                    Text(mode.title).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .controlSize(.small)
-            .frame(width: 210)
-            .accessibilityIdentifier("debug-chart-mode-picker")
-
-            Spacer()
-        }
-    }
 
     private var singleAPWorkbench: some View {
         VStack(spacing: 0) {

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
@@ -19,6 +19,23 @@ private struct DebugOscillator {
     }
 }
 
+enum DebugChartSeriesAdapter {
+    static func seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData] {
+        DebugScenarioBuilder.seriesSources(from: scenario, band: band).map { source in
+            let ap = source.ap
+            let render = ChartSeriesRenderState(
+                displayRSSI: Double(ap.rssi),
+                color: Color(hex: ap.colorHex),
+                isFilteredOut: ap.filtered,
+                isVisible: ap.visible,
+                trendArrow: ap.trend.arrow,
+                trendDelta: ap.trendDelta
+            )
+            return ChartSeriesData(domain: source.domain, render: render)
+        }
+    }
+}
+
 struct DebugChartView: View {
     let mode: DebugChartMode
 
@@ -546,7 +563,7 @@ struct DebugChartView: View {
         if bandVM.band != selectedBand {
             bandVM = BandChartViewModel(band: selectedBand)
         }
-        let series = DebugScenarioBuilder.seriesData(from: multiScenario, band: selectedBand)
+        let series = DebugChartSeriesAdapter.seriesData(from: multiScenario, band: selectedBand)
         bandVM.debugInject(series: series)
         if !bandVM.validateSelection(selectedNetworkID) {
             selectedNetworkID = nil

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift
@@ -2,6 +2,20 @@ import SwiftUI
 
 #if DEBUG
 
+private enum DebugChartMode: String, CaseIterable, Identifiable {
+    case singleAP
+    case multiAP
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .singleAP: "Single AP"
+        case .multiAP: "Multi AP"
+        }
+    }
+}
+
 private struct DebugOscillator {
     var phase: Double = 0
 
@@ -15,14 +29,12 @@ private struct DebugOscillator {
 }
 
 struct DebugChartView: View {
+    @State private var mode: DebugChartMode = .singleAP
     @State private var bandVM = BandChartViewModel(band: .band5GHz)
-    @State private var selectedNetworkID: String? = nil
+    @State private var selectedNetworkID: String?
     @State private var timer: Timer?
 
-    // Oscillator
     @State private var oscillator = DebugOscillator()
-
-    // Adjustable parameters
     @State private var centerRSSI: Double = -50
     @State private var amplitude: Double = 30
     @State private var speed: Double = 1.0
@@ -31,37 +43,124 @@ struct DebugChartView: View {
     @State private var selectedBand: ChannelBand = .band5GHz
     @State private var isRunning: Bool = true
 
+    @State private var scenarioStore = DebugScenarioStore()
+    @State private var multiScenario = DebugScenarioBuilder.scenario(for: .labelCollision)
+    @State private var selectedPreset: DebugScenarioPreset = .labelCollision
+    @State private var didLoadMultiScenario = false
+
+    private let debugPalette = [
+        "#3B82F6", "#10B981", "#F59E0B", "#EF4444",
+        "#8B5CF6", "#0EA5E9", "#22C55E", "#F97316",
+        "#2563EB", "#16A34A", "#EA580C", "#7C3AED",
+    ]
+
     var body: some View {
         VStack(spacing: 0) {
-            controls
+            modeControls
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
 
             Divider()
 
-            BandChartView(
-                model: bandVM.renderModel,
-                selectedNetworkID: $selectedNetworkID,
-                onResetZoom: { bandVM.resetZoom() },
-                onToggleExpand: { bandVM.toggleExpand() },
-                onApplyZoom: { lo, hi in bandVM.applyZoom(lo: lo, hi: hi) }
-            )
-            .padding(.horizontal, 8)
+            switch mode {
+            case .singleAP:
+                singleAPWorkbench
+            case .multiAP:
+                multiAPWorkbench
+            }
         }
-        .onAppear { startTimer() }
+        .onAppear {
+            if mode == .singleAP {
+                startTimer()
+                tick()
+            } else {
+                enterMultiAPMode()
+            }
+        }
         .onDisappear { stopTimer() }
-        .onChange(of: selectedBand) { _, band in
-            bandVM = BandChartViewModel(band: band)
-            oscillator = DebugOscillator()
+        .onChange(of: mode) { _, newMode in
+            switch newMode {
+            case .singleAP:
+                enterSingleAPMode()
+            case .multiAP:
+                enterMultiAPMode()
+            }
         }
         .onChange(of: isRunning) { _, running in
+            guard mode == .singleAP else { return }
             if running { startTimer() } else { stopTimer() }
+        }
+        .onChange(of: centerRSSI) { _, _ in tickIfSingleAP() }
+        .onChange(of: amplitude) { _, _ in tickIfSingleAP() }
+        .onChange(of: channel) { _, _ in tickIfSingleAP() }
+        .onChange(of: channelWidthMHz) { _, _ in tickIfSingleAP() }
+    }
+
+    // MARK: - Workbenches
+
+    private var modeControls: some View {
+        HStack(spacing: 12) {
+            Picker("Mode", selection: $mode.animation(.bouncy)) {
+                ForEach(DebugChartMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .frame(width: 210)
+            .accessibilityIdentifier("debug-chart-mode-picker")
+
+            Spacer()
         }
     }
 
-    // MARK: - Controls
+    private var singleAPWorkbench: some View {
+        VStack(spacing: 0) {
+            singleAPControls
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
 
-    private var controls: some View {
+            Divider()
+
+            chartView
+                .padding(.horizontal, 8)
+        }
+    }
+
+    private var multiAPWorkbench: some View {
+        VStack(spacing: 0) {
+            multiAPControls
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+
+            Divider()
+
+            chartView
+                .frame(minHeight: 280)
+                .padding(.horizontal, 8)
+                .accessibilityIdentifier("debug-multi-ap-chart")
+
+            Divider()
+
+            multiAPTable
+                .frame(minHeight: 190)
+                .accessibilityIdentifier("debug-multi-ap-table")
+        }
+    }
+
+    private var chartView: some View {
+        BandChartView(
+            model: bandVM.renderModel,
+            selectedNetworkID: $selectedNetworkID,
+            onResetZoom: { bandVM.resetZoom() },
+            onToggleExpand: { bandVM.toggleExpand() },
+            onApplyZoom: { lo, hi in bandVM.applyZoom(lo: lo, hi: hi) }
+        )
+    }
+
+    // MARK: - Single AP Controls
+
+    private var singleAPControls: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 16) {
                 Button {
@@ -72,21 +171,14 @@ struct DebugChartView: View {
                 .buttonStyle(.plain)
                 .help(isRunning ? "Pause" : "Resume")
 
-                Picker("Band", selection: $selectedBand.animation(.bouncy)) {
-                    Text("2.4 GHz").tag(ChannelBand.band24GHz)
-                    Text("5 GHz").tag(ChannelBand.band5GHz)
-                    Text("6 GHz").tag(ChannelBand.band6GHz)
-                }
-                .pickerStyle(.segmented)
-                .controlSize(.small)
-                .frame(width: 240)
+                bandPicker
             }
 
             HStack(spacing: 12) {
                 paramSlider(label: "Center", value: $centerRSSI, range: -90...(-20), format: "%.0f dBm")
                 paramSlider(label: "Amplitude", value: $amplitude, range: 0...45, format: "%.0f dB")
-                paramSlider(label: "Speed", value: $speed, range: 0.1...5.0, format: "%.1f×")
-                channelStepper
+                paramSlider(label: "Speed", value: $speed, range: 0.1...5.0, format: "%.1fx")
+                singleAPChannelControls
             }
         }
         .font(.system(size: 10))
@@ -109,7 +201,7 @@ struct DebugChartView: View {
         }
     }
 
-    private var channelStepper: some View {
+    private var singleAPChannelControls: some View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Channel: \(channel)")
@@ -117,23 +209,384 @@ struct DebugChartView: View {
                 Stepper("", value: $channel, in: 1...selectedBand.maxChannel)
                     .controlSize(.mini)
             }
-            widthPicker
+            widthPicker(selection: $channelWidthMHz)
         }
     }
 
-    private var widthPicker: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text("Width: \(channelWidthMHz) MHz")
+    // MARK: - Multi AP Controls
+
+    private var multiAPControls: some View {
+        HStack(spacing: 10) {
+            bandPicker
+
+            Picker("Preset", selection: $selectedPreset.animation(.bouncy)) {
+                ForEach(DebugScenarioPreset.allCases) { preset in
+                    Text(preset.title).tag(preset)
+                }
+            }
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .frame(width: 170)
+            .onChange(of: selectedPreset) { _, preset in
+                loadPreset(preset)
+            }
+
+            Button {
+                addAP()
+            } label: {
+                Label("Add AP", systemImage: "plus")
+            }
+            .controlSize(.small)
+
+            Button {
+                loadPreset(selectedPreset)
+            } label: {
+                Label("Reset", systemImage: "arrow.counterclockwise")
+            }
+            .controlSize(.small)
+
+            Spacer()
+
+            Text("\(activeAPCount) active / \(multiScenario.aps.count) rows")
+                .font(.system(size: 11))
                 .foregroundColor(.secondary)
-            Picker("", selection: $channelWidthMHz.animation(.bouncy)) {
-                Text("20").tag(20)
-                Text("40").tag(40)
-                Text("80").tag(80)
-                Text("160").tag(160)
+        }
+        .font(.system(size: 11))
+    }
+
+    private var bandPicker: some View {
+        Picker("Band", selection: bandSelection.animation(.bouncy)) {
+            Text("2.4 GHz").tag(ChannelBand.band24GHz)
+            Text("5 GHz").tag(ChannelBand.band5GHz)
+            Text("6 GHz").tag(ChannelBand.band6GHz)
+        }
+        .pickerStyle(.segmented)
+        .controlSize(.small)
+        .frame(width: 240)
+    }
+
+    private func widthPicker(selection: Binding<Int>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Width: \(selection.wrappedValue) MHz")
+                .foregroundColor(.secondary)
+            Picker("", selection: selection.animation(.bouncy)) {
+                ForEach(DebugScenarioBuilder.allowedWidths(for: selectedBand), id: \.self) { width in
+                    Text("\(width)").tag(width)
+                }
             }
             .pickerStyle(.segmented)
             .controlSize(.mini)
-            .frame(width: 140)
+            .frame(width: selectedBand == .band24GHz ? 74 : 140)
+        }
+    }
+
+    // MARK: - Multi AP Table
+
+    private var multiAPTable: some View {
+        ScrollView([.horizontal, .vertical]) {
+            VStack(alignment: .leading, spacing: 0) {
+                multiAPTableHeader
+                    .padding(.bottom, 4)
+
+                ForEach(multiScenario.aps) { ap in
+                    multiAPRow(ap)
+                        .accessibilityIdentifier("debug-multi-ap-row-\(ap.id.uuidString)")
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    private var multiAPTableHeader: some View {
+        HStack(spacing: 8) {
+            headerCell("On", width: 34, alignment: .center)
+            headerCell("SSID", width: 130)
+            headerCell("Ch", width: 80, alignment: .center)
+            headerCell("Width", width: 82, alignment: .center)
+            headerCell("RSSI", width: 92, alignment: .center)
+            headerCell("Color", width: 70, alignment: .center)
+            headerCell("Hidden", width: 54, alignment: .center)
+            headerCell("Visible", width: 54, alignment: .center)
+            headerCell("Filtered", width: 58, alignment: .center)
+            headerCell("k", width: 34, alignment: .center)
+            headerCell("r", width: 34, alignment: .center)
+            headerCell("v", width: 34, alignment: .center)
+            headerCell("WPA3", width: 48, alignment: .center)
+            headerCell("CC", width: 44, alignment: .center)
+            headerCell("Trend", width: 86, alignment: .center)
+            headerCell("Delta", width: 78, alignment: .center)
+            headerCell("", width: 62, alignment: .center)
+        }
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundColor(.secondary)
+    }
+
+    private func multiAPRow(_ ap: DebugAPConfig) -> some View {
+        HStack(spacing: 8) {
+            rowCell(width: 34, alignment: .center) {
+                Toggle("", isOn: apBinding(ap.id, \.enabled, default: true))
+                    .labelsHidden()
+            }
+            rowCell(width: 130) {
+                TextField("SSID", text: apBinding(ap.id, \.ssid, default: ""))
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.small)
+            }
+            rowCell(width: 80, alignment: .center) {
+                Stepper(value: apBinding(ap.id, \.channel, default: 1), in: 1...selectedBand.maxChannel) {
+                    Text("\(ap.channel)")
+                        .monospacedDigit()
+                        .frame(width: 28, alignment: .trailing)
+                }
+                .controlSize(.mini)
+            }
+            rowCell(width: 82, alignment: .center) {
+                Picker("", selection: apBinding(ap.id, \.widthMHz, default: 20)) {
+                    ForEach(DebugScenarioBuilder.allowedWidths(for: selectedBand), id: \.self) { width in
+                        Text("\(width)").tag(width)
+                    }
+                }
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .frame(width: 78)
+            }
+            rowCell(width: 92, alignment: .center) {
+                Stepper(value: apBinding(ap.id, \.rssi, default: -55), in: Constants.rssiNoiseFloor...(-1)) {
+                    Text("\(ap.rssi)")
+                        .monospacedDigit()
+                        .frame(width: 34, alignment: .trailing)
+                }
+                .controlSize(.mini)
+            }
+            rowCell(width: 70, alignment: .center) {
+                colorMenu(for: ap)
+            }
+            checkboxCell(width: 54, binding: apBinding(ap.id, \.hiddenSSID, default: false))
+            checkboxCell(width: 54, binding: apBinding(ap.id, \.visible, default: true))
+            checkboxCell(width: 58, binding: apBinding(ap.id, \.filtered, default: false))
+            checkboxCell(width: 34, binding: apBinding(ap.id, \.supportsK, default: false))
+            checkboxCell(width: 34, binding: apBinding(ap.id, \.supportsR, default: false))
+            checkboxCell(width: 34, binding: apBinding(ap.id, \.supportsV, default: false))
+            checkboxCell(width: 48, binding: apBinding(ap.id, \.supportsWPA3, default: false))
+            rowCell(width: 44, alignment: .center) {
+                TextField("CC", text: apBinding(ap.id, \.country, default: ""))
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.small)
+                    .frame(width: 42)
+            }
+            rowCell(width: 86, alignment: .center) {
+                Picker("", selection: apBinding(ap.id, \.trend, default: .none)) {
+                    ForEach(DebugTrend.allCases, id: \.self) { trend in
+                        Text(trend.title).tag(trend)
+                    }
+                }
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .frame(width: 82)
+            }
+            rowCell(width: 78, alignment: .center) {
+                Stepper(value: apBinding(ap.id, \.trendDelta, default: 0), in: -30...30) {
+                    Text("\(ap.trendDelta)")
+                        .monospacedDigit()
+                        .frame(width: 28, alignment: .trailing)
+                }
+                .controlSize(.mini)
+            }
+            rowCell(width: 62, alignment: .center) {
+                HStack(spacing: 6) {
+                    Button {
+                        duplicateAP(ap)
+                    } label: {
+                        Image(systemName: "plus.square.on.square")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Duplicate")
+
+                    Button {
+                        deleteAP(ap.id)
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Delete")
+                }
+            }
+        }
+        .frame(height: 34)
+        .font(.system(size: 11))
+    }
+
+    private func headerCell(_ title: String, width: CGFloat, alignment: Alignment = .leading) -> some View {
+        Text(title)
+            .frame(width: width, alignment: alignment)
+    }
+
+    private func rowCell<Content: View>(
+        width: CGFloat,
+        alignment: Alignment = .leading,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .frame(width: width, alignment: alignment)
+    }
+
+    private func checkboxCell(width: CGFloat, binding: Binding<Bool>) -> some View {
+        rowCell(width: width, alignment: .center) {
+            Toggle("", isOn: binding)
+                .labelsHidden()
+        }
+    }
+
+    private func colorMenu(for ap: DebugAPConfig) -> some View {
+        Menu {
+            ForEach(debugPalette, id: \.self) { colorHex in
+                Button {
+                    updateAP(ap.id) { $0.colorHex = colorHex }
+                } label: {
+                    Text(colorHex)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color(hex: ap.colorHex))
+                    .frame(width: 12, height: 12)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8))
+            }
+            .frame(width: 48)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
+        .help(ap.colorHex)
+    }
+
+    // MARK: - State Updates
+
+    private var activeAPCount: Int {
+        multiScenario.aps.filter(\.enabled).count
+    }
+
+    private var bandSelection: Binding<ChannelBand> {
+        Binding(
+            get: { selectedBand },
+            set: { changeBand($0) }
+        )
+    }
+
+    private func apBinding<Value>(
+        _ id: DebugAPConfig.ID,
+        _ keyPath: WritableKeyPath<DebugAPConfig, Value>,
+        default defaultValue: Value
+    ) -> Binding<Value> {
+        Binding(
+            get: {
+                multiScenario.aps.first(where: { $0.id == id })?[keyPath: keyPath] ?? defaultValue
+            },
+            set: { newValue in
+                updateAP(id) { $0[keyPath: keyPath] = newValue }
+            }
+        )
+    }
+
+    private func updateAP(_ id: DebugAPConfig.ID, edit: (inout DebugAPConfig) -> Void) {
+        guard let index = multiScenario.aps.firstIndex(where: { $0.id == id }) else { return }
+        edit(&multiScenario.aps[index])
+        multiScenario.presetID = nil
+        applyMultiScenario(save: true)
+    }
+
+    private func addAP() {
+        ensureMultiScenarioLoaded()
+        multiScenario.aps.append(DebugScenarioBuilder.defaultAP(for: selectedBand, index: multiScenario.aps.count + 1))
+        multiScenario.presetID = nil
+        applyMultiScenario(save: true)
+    }
+
+    private func duplicateAP(_ ap: DebugAPConfig) {
+        guard let index = multiScenario.aps.firstIndex(where: { $0.id == ap.id }) else { return }
+        var copy = ap
+        copy.id = UUID()
+        copy.ssid = ap.ssid.isEmpty ? "Copy" : "\(ap.ssid) Copy"
+        multiScenario.aps.insert(copy, at: index + 1)
+        multiScenario.presetID = nil
+        applyMultiScenario(save: true)
+    }
+
+    private func deleteAP(_ id: DebugAPConfig.ID) {
+        multiScenario.aps.removeAll { $0.id == id }
+        multiScenario.presetID = nil
+        applyMultiScenario(save: true)
+    }
+
+    private func loadPreset(_ preset: DebugScenarioPreset) {
+        multiScenario = DebugScenarioBuilder.scenario(for: preset)
+        selectedBand = DebugScenarioBuilder.band(for: multiScenario)
+        bandVM = BandChartViewModel(band: selectedBand)
+        selectedNetworkID = nil
+        didLoadMultiScenario = true
+        applyMultiScenario(save: true)
+    }
+
+    private func ensureMultiScenarioLoaded() {
+        guard !didLoadMultiScenario else { return }
+        multiScenario = scenarioStore.load()
+        selectedPreset = DebugScenarioPreset(rawValue: multiScenario.presetID ?? "") ?? .labelCollision
+        didLoadMultiScenario = true
+    }
+
+    private func enterSingleAPMode() {
+        stopTimer()
+        bandVM = BandChartViewModel(band: selectedBand)
+        selectedNetworkID = nil
+        oscillator = DebugOscillator()
+        tick()
+        if isRunning { startTimer() }
+    }
+
+    private func enterMultiAPMode() {
+        stopTimer()
+        ensureMultiScenarioLoaded()
+        selectedBand = DebugScenarioBuilder.band(for: multiScenario)
+        bandVM = BandChartViewModel(band: selectedBand)
+        selectedNetworkID = nil
+        applyMultiScenario(save: false)
+    }
+
+    private func changeBand(_ band: ChannelBand) {
+        guard selectedBand != band || bandVM.band != band else { return }
+        selectedBand = band
+        bandVM = BandChartViewModel(band: band)
+        selectedNetworkID = nil
+        switch mode {
+        case .singleAP:
+            channel = min(channel, band.maxChannel)
+            if !DebugScenarioBuilder.allowedWidths(for: band).contains(channelWidthMHz) {
+                channelWidthMHz = 20
+            }
+            oscillator = DebugOscillator()
+            tick()
+        case .multiAP:
+            ensureMultiScenarioLoaded()
+            multiScenario.bandID = band.id
+            multiScenario.presetID = nil
+            applyMultiScenario(save: true)
+        }
+    }
+
+    private func applyMultiScenario(save: Bool) {
+        multiScenario.bandID = selectedBand.id
+        multiScenario = DebugScenarioBuilder.normalized(multiScenario)
+        if bandVM.band != selectedBand {
+            bandVM = BandChartViewModel(band: selectedBand)
+        }
+        let series = DebugScenarioBuilder.seriesData(from: multiScenario, band: selectedBand)
+        bandVM.debugInject(series: series)
+        if !bandVM.validateSelection(selectedNetworkID) {
+            selectedNetworkID = nil
+        }
+        if save {
+            scenarioStore.save(multiScenario)
         }
     }
 
@@ -151,7 +604,13 @@ struct DebugChartView: View {
         timer = nil
     }
 
+    private func tickIfSingleAP() {
+        guard mode == .singleAP else { return }
+        tick()
+    }
+
     private func tick() {
+        guard mode == .singleAP else { return }
         oscillator.advance(speed: speed)
         let rssi = oscillator.rssi(center: Int(centerRSSI), amplitude: Int(amplitude))
         let block = ChannelSpanCalculator.channelBlock(

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugContainerView.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugContainerView.swift
@@ -2,23 +2,73 @@ import SwiftUI
 
 #if DEBUG
 
+enum SpectrumDebugPage: String, CaseIterable {
+    case singleAP
+    case multiAP
+
+    var label: String {
+        switch self {
+        case .singleAP: "Single AP"
+        case .multiAP:  "Multi AP"
+        }
+    }
+}
+
 enum DebugPage: String, CaseIterable {
-    case spectrum
     case throughput
     case roaming
 
     var label: String {
         switch self {
-        case .spectrum:   "Spectrum"
         case .throughput: "Throughput"
         case .roaming:    "Roaming"
         }
     }
 }
 
+struct SpectrumDebugContainerView: View {
+    @State private var selectedPage: SpectrumDebugPage = .singleAP
+    @State private var visitedTabs: Set<SpectrumDebugPage> = [.singleAP]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $selectedPage.animation(.bouncy)) {
+                ForEach(SpectrumDebugPage.allCases, id: \.self) { page in
+                    Text(page.label).tag(page)
+                }
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.regular)
+            .frame(width: 220)
+            .padding(.vertical, 6)
+            .onChange(of: selectedPage) { _, newTab in
+                visitedTabs.insert(newTab)
+            }
+
+            Divider()
+
+            ZStack {
+                if visitedTabs.contains(.singleAP) {
+                    DebugChartView(mode: .singleAP)
+                        .opacity(selectedPage == .singleAP ? 1 : 0)
+                        .allowsHitTesting(selectedPage == .singleAP)
+                        .disabled(selectedPage != .singleAP)
+                }
+
+                if visitedTabs.contains(.multiAP) {
+                    DebugChartView(mode: .multiAP)
+                        .opacity(selectedPage == .multiAP ? 1 : 0)
+                        .allowsHitTesting(selectedPage == .multiAP)
+                        .disabled(selectedPage != .multiAP)
+                }
+            }
+        }
+    }
+}
+
 struct DebugContainerView: View {
-    @State private var selectedPage: DebugPage = .spectrum
-    @State private var visitedTabs: Set<DebugPage> = [.spectrum]
+    @State private var selectedPage: DebugPage = .throughput
+    @State private var visitedTabs: Set<DebugPage> = [.throughput]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,7 +79,7 @@ struct DebugContainerView: View {
             }
             .pickerStyle(.segmented)
             .controlSize(.regular)
-            .frame(width: 180)
+            .frame(width: 220)
             .padding(.vertical, 6)
             .onChange(of: selectedPage) { _, newTab in
                 visitedTabs.insert(newTab)
@@ -38,13 +88,6 @@ struct DebugContainerView: View {
             Divider()
 
             ZStack {
-                if visitedTabs.contains(.spectrum) {
-                    DebugChartView()
-                        .opacity(selectedPage == .spectrum ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .spectrum)
-                        .disabled(selectedPage != .spectrum)
-                }
-
                 if visitedTabs.contains(.throughput) {
                     DebugThroughputView()
                         .opacity(selectedPage == .throughput ? 1 : 0)

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift
@@ -1,0 +1,289 @@
+import Foundation
+import SwiftUI
+
+#if DEBUG
+
+enum DebugTrend: String, Codable, CaseIterable, Equatable {
+    case none
+    case up
+    case down
+    case stable
+
+    var arrow: String {
+        switch self {
+        case .none: ""
+        case .up: "▲"
+        case .down: "▼"
+        case .stable: "●"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .none: "None"
+        case .up: "Up"
+        case .down: "Down"
+        case .stable: "Stable"
+        }
+    }
+}
+
+enum DebugScenarioPreset: String, CaseIterable, Codable, Identifiable {
+    case labelCollision
+    case dense24GHz
+    case wide5GHzOverlap
+    case sparse6GHz
+    case hiddenAndFiltered
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .labelCollision: "Label collision"
+        case .dense24GHz: "Dense 2.4 GHz"
+        case .wide5GHzOverlap: "5 GHz wide overlap"
+        case .sparse6GHz: "6 GHz sparse"
+        case .hiddenAndFiltered: "Hidden and filtered"
+        }
+    }
+}
+
+struct DebugScenario: Codable, Equatable {
+    var version: Int
+    var bandID: String
+    var presetID: String?
+    var aps: [DebugAPConfig]
+}
+
+struct DebugAPConfig: Codable, Identifiable, Equatable {
+    var id: UUID
+    var enabled: Bool
+    var ssid: String
+    var bssidSuffix: String
+    var channel: Int
+    var widthMHz: Int
+    var rssi: Int
+    var colorHex: String
+    var hiddenSSID: Bool
+    var visible: Bool
+    var filtered: Bool
+    var supportsK: Bool
+    var supportsR: Bool
+    var supportsV: Bool
+    var supportsWPA3: Bool
+    var country: String
+    var trend: DebugTrend
+    var trendDelta: Int
+}
+
+struct DebugScenarioStore {
+    static let storageKey = "debug.multiAPChart.scenario.v1"
+
+    var defaults: UserDefaults = .standard
+
+    func load() -> DebugScenario {
+        guard let data = defaults.data(forKey: Self.storageKey),
+              let scenario = try? JSONDecoder().decode(DebugScenario.self, from: data),
+              scenario.version == DebugScenarioBuilder.currentVersion
+        else {
+            return DebugScenarioBuilder.scenario(for: .labelCollision)
+        }
+        return DebugScenarioBuilder.normalized(scenario)
+    }
+
+    func save(_ scenario: DebugScenario) {
+        guard let data = try? JSONEncoder().encode(DebugScenarioBuilder.normalized(scenario)) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}
+
+enum DebugScenarioBuilder {
+    static let currentVersion = 1
+
+    static func scenario(for preset: DebugScenarioPreset) -> DebugScenario {
+        switch preset {
+        case .labelCollision:
+            return DebugScenario(version: currentVersion, bandID: ChannelBand.band5GHz.id, presetID: preset.id, aps: [
+                ap("Collision-A", suffix: "A1", channel: 52, width: 40, rssi: -45, color: "#3B82F6", trend: .up, delta: 3),
+                ap("Collision-B", suffix: "A2", channel: 56, width: 40, rssi: -47, color: "#10B981", trend: .down, delta: -2),
+                ap("Collision-C", suffix: "A3", channel: 60, width: 40, rssi: -49, color: "#F59E0B", trend: .stable, delta: 0),
+                ap("Collision-D", suffix: "A4", channel: 64, width: 40, rssi: -51, color: "#EF4444"),
+                ap("Collision-E", suffix: "A5", channel: 56, width: 80, rssi: -55, color: "#8B5CF6"),
+            ])
+        case .dense24GHz:
+            return DebugScenario(version: currentVersion, bandID: ChannelBand.band24GHz.id, presetID: preset.id, aps: [
+                ap("Kitchen", suffix: "24", channel: 1, width: 20, rssi: -42, color: "#3B82F6", k: true, v: true),
+                ap("Living", suffix: "25", channel: 6, width: 20, rssi: -48, color: "#10B981", k: true, r: true),
+                ap("Office", suffix: "26", channel: 11, width: 20, rssi: -54, color: "#F59E0B"),
+                ap("Guest", suffix: "27", channel: 6, width: 40, rssi: -62, color: "#EF4444", filtered: true),
+                ap("IoT", suffix: "28", channel: 1, width: 20, rssi: -68, color: "#8B5CF6", hidden: true),
+            ])
+        case .wide5GHzOverlap:
+            return DebugScenario(version: currentVersion, bandID: ChannelBand.band5GHz.id, presetID: preset.id, aps: [
+                ap("DFS-80", suffix: "51", channel: 52, width: 80, rssi: -43, color: "#2563EB", k: true, r: true, v: true, wpa3: true),
+                ap("DFS-40", suffix: "52", channel: 60, width: 40, rssi: -57, color: "#16A34A"),
+                ap("UNII-160", suffix: "53", channel: 100, width: 160, rssi: -64, color: "#EA580C"),
+                ap("Upper-80", suffix: "54", channel: 149, width: 80, rssi: -70, color: "#7C3AED"),
+            ])
+        case .sparse6GHz:
+            return DebugScenario(version: currentVersion, bandID: ChannelBand.band6GHz.id, presetID: preset.id, aps: [
+                ap("6E-Lab-A", suffix: "61", channel: 37, width: 80, rssi: -46, color: "#0EA5E9", wpa3: true),
+                ap("6E-Lab-B", suffix: "62", channel: 85, width: 160, rssi: -58, color: "#22C55E", wpa3: true),
+                ap("6E-Lab-C", suffix: "63", channel: 181, width: 80, rssi: -73, color: "#F97316", wpa3: true),
+            ])
+        case .hiddenAndFiltered:
+            return DebugScenario(version: currentVersion, bandID: ChannelBand.band5GHz.id, presetID: preset.id, aps: [
+                ap("Visible", suffix: "71", channel: 36, width: 80, rssi: -41, color: "#3B82F6", k: true),
+                ap("", suffix: "72", channel: 44, width: 40, rssi: -53, color: "#10B981", hidden: true),
+                ap("Filtered", suffix: "73", channel: 149, width: 80, rssi: -60, color: "#F59E0B", filtered: true),
+                ap("Invisible", suffix: "74", channel: 157, width: 40, rssi: -67, color: "#EF4444", visible: false),
+            ])
+        }
+    }
+
+    static func defaultAP(for band: ChannelBand, index: Int) -> DebugAPConfig {
+        let channel: Int = switch band {
+        case .band24GHz: 6
+        case .band5GHz: 52
+        case .band6GHz: 37
+        }
+        return ap("Debug-\(index)", suffix: String(format: "%02X", index), channel: channel, width: 20, rssi: -55, color: "#3B82F6")
+    }
+
+    static func allowedWidths(for band: ChannelBand) -> [Int] {
+        band == .band24GHz ? [20, 40] : [20, 40, 80, 160]
+    }
+
+    static func normalized(_ scenario: DebugScenario) -> DebugScenario {
+        let band = ChannelBand(id: scenario.bandID) ?? .band5GHz
+        return DebugScenario(
+            version: currentVersion,
+            bandID: band.id,
+            presetID: scenario.presetID,
+            aps: scenario.aps.map { normalized($0, band: band) }
+        )
+    }
+
+    static func normalized(_ ap: DebugAPConfig, band: ChannelBand) -> DebugAPConfig {
+        var copy = ap
+        copy.channel = min(max(copy.channel, 1), band.maxChannel)
+        copy.widthMHz = validWidth(copy.widthMHz, for: band)
+        copy.rssi = min(max(copy.rssi, Constants.rssiNoiseFloor), -1)
+        copy.colorHex = normalizedHex(copy.colorHex)
+        copy.country = String(copy.country.prefix(2)).uppercased()
+        return copy
+    }
+
+    static func seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData] {
+        normalized(scenario).aps
+            .filter(\.enabled)
+            .map { ap in
+                let normalizedAP = normalized(ap, band: band)
+                let block = ChannelSpanCalculator.channelBlock(
+                    primaryChannel: normalizedAP.channel,
+                    widthMHz: normalizedAP.widthMHz,
+                    band: band,
+                    spanDirection: nil
+                )
+                let domain = ChartSeriesDomainData(
+                    id: "\(normalizedAP.id.uuidString)-\(band.id)",
+                    ssid: normalizedAP.ssid,
+                    bssid: bssid(from: normalizedAP.bssidSuffix),
+                    channel: normalizedAP.channel,
+                    left: block.left,
+                    apex: Double(block.left + block.right) / 2.0,
+                    right: block.right,
+                    rssi: normalizedAP.rssi,
+                    phyMode: "ax",
+                    channelWidth: "\(normalizedAP.widthMHz)",
+                    supportsK: normalizedAP.supportsK,
+                    supportsR: normalizedAP.supportsR,
+                    supportsV: normalizedAP.supportsV,
+                    supportsWPA3: normalizedAP.supportsWPA3,
+                    isHiddenSSID: normalizedAP.hiddenSSID,
+                    security: normalizedAP.supportsWPA3 ? "WPA3" : "WPA2",
+                    mcs: "",
+                    nss: "",
+                    country: normalizedAP.country
+                )
+                let render = ChartSeriesRenderState(
+                    displayRSSI: Double(normalizedAP.rssi),
+                    color: Color(hex: normalizedAP.colorHex),
+                    isFilteredOut: normalizedAP.filtered,
+                    isVisible: normalizedAP.visible,
+                    trendArrow: normalizedAP.trend.arrow,
+                    trendDelta: normalizedAP.trendDelta
+                )
+                return ChartSeriesData(domain: domain, render: render)
+            }
+    }
+
+    static func band(for scenario: DebugScenario) -> ChannelBand {
+        ChannelBand(id: scenario.bandID) ?? .band5GHz
+    }
+
+    private static func ap(
+        _ ssid: String,
+        suffix: String,
+        channel: Int,
+        width: Int,
+        rssi: Int,
+        color: String,
+        hidden: Bool = false,
+        visible: Bool = true,
+        filtered: Bool = false,
+        k: Bool = false,
+        r: Bool = false,
+        v: Bool = false,
+        wpa3: Bool = false,
+        trend: DebugTrend = .none,
+        delta: Int = 0
+    ) -> DebugAPConfig {
+        DebugAPConfig(
+            id: UUID(),
+            enabled: true,
+            ssid: ssid,
+            bssidSuffix: suffix,
+            channel: channel,
+            widthMHz: width,
+            rssi: rssi,
+            colorHex: color,
+            hiddenSSID: hidden,
+            visible: visible,
+            filtered: filtered,
+            supportsK: k,
+            supportsR: r,
+            supportsV: v,
+            supportsWPA3: wpa3,
+            country: "",
+            trend: trend,
+            trendDelta: delta
+        )
+    }
+
+    private static func validWidth(_ width: Int, for band: ChannelBand) -> Int {
+        let allowed = allowedWidths(for: band)
+        return allowed.contains(width) ? width : 20
+    }
+
+    private static func normalizedHex(_ colorHex: String) -> String {
+        let trimmed = colorHex.trimmingCharacters(in: CharacterSet(charactersIn: "#")).uppercased()
+        guard trimmed.count == 6, trimmed.allSatisfy(\.isHexDigit) else { return "#3B82F6" }
+        return "#\(trimmed)"
+    }
+
+    private static func bssid(from suffix: String) -> String {
+        let hex = suffix.uppercased().filter(\.isHexDigit)
+        let lastByte = String(hex.suffix(2)).leftPadding(toLength: 2, withPad: "0")
+        return "02:00:00:00:00:\(lastByte)"
+    }
+}
+
+private extension String {
+    func leftPadding(toLength: Int, withPad pad: String) -> String {
+        guard count < toLength else { return self }
+        return String(repeating: pad, count: toLength - count) + self
+    }
+}
+
+#endif

--- a/WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift
+++ b/WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 #if DEBUG
 
@@ -74,6 +73,11 @@ struct DebugAPConfig: Codable, Identifiable, Equatable {
     var country: String
     var trend: DebugTrend
     var trendDelta: Int
+}
+
+struct DebugChartSeriesSource {
+    var ap: DebugAPConfig
+    var domain: ChartSeriesDomainData
 }
 
 struct DebugScenarioStore {
@@ -174,7 +178,7 @@ enum DebugScenarioBuilder {
         return copy
     }
 
-    static func seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData] {
+    static func seriesSources(from scenario: DebugScenario, band: ChannelBand) -> [DebugChartSeriesSource] {
         normalized(scenario).aps
             .filter(\.enabled)
             .map { ap in
@@ -206,15 +210,7 @@ enum DebugScenarioBuilder {
                     nss: "",
                     country: normalizedAP.country
                 )
-                let render = ChartSeriesRenderState(
-                    displayRSSI: Double(normalizedAP.rssi),
-                    color: Color(hex: normalizedAP.colorHex),
-                    isFilteredOut: normalizedAP.filtered,
-                    isVisible: normalizedAP.visible,
-                    trendArrow: normalizedAP.trend.arrow,
-                    trendDelta: normalizedAP.trendDelta
-                )
-                return ChartSeriesData(domain: domain, render: render)
+                return DebugChartSeriesSource(ap: normalizedAP, domain: domain)
             }
     }
 

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -7658,6 +7658,42 @@
         }
       }
     },
+    "nav.spectrum_debug_chart" : {
+      "comment" : "Spectrum Debug Chart sidebar navigation item (dev only)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spektrum-Debug-Diagramm"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spectrum Debug Chart"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gráfico de depuración del espectro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペクトラムデバッグチャート"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "频谱图调试图表"
+          }
+        }
+      }
+    },
     "overview.accessibility.globe_label" : {
       "comment" : "3D visualization of Wi‑Fi networks around the globe",
       "extractionState" : "manual",

--- a/WiFiLens/Sources/WiFiLens/Spectrum/BandChartViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/BandChartViewModel.swift
@@ -58,11 +58,12 @@ final class BandChartViewModel {
         let bandHidden = hiddenBands.contains(band.id)
         return source.map { series in
             var series = series
+            let sourceFilteredOut = series.isFilteredOut
             let textFilter = needle.isEmpty
                 || series.ssid.lowercased().contains(needle)
                 || series.bssid.lowercased().contains(needle)
             let hiddenSSIDFilter = !hideHiddenSSIDs || !series.isHiddenSSID
-            series.isFilteredOut = bandHidden || !textFilter || !hiddenSSIDFilter
+            series.isFilteredOut = sourceFilteredOut || bandHidden || !textFilter || !hiddenSSIDFilter
             return series
         }
     }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -98,6 +98,14 @@ private struct AppRootView: View {
                 }
 
 #if DEBUG
+                if visitedPages.contains(.spectrumDebugChart) {
+                    SpectrumDebugContainerView()
+                        .opacity(selectedPage == .spectrumDebugChart ? 1 : 0)
+                        .allowsHitTesting(selectedPage == .spectrumDebugChart)
+                        .disabled(selectedPage != .spectrumDebugChart)
+                        .accessibilityIdentifier("page-spectrumDebugChart")
+                }
+
                 if visitedPages.contains(.debugChart) {
                     DebugContainerView()
                         .opacity(selectedPage == .debugChart ? 1 : 0)

--- a/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
@@ -83,6 +83,20 @@ import Testing
         #expect(visible.first?.ssid == "Visible")
     }
 
+    @Test func debugInjectPreservesInjectedFilteredState() {
+        let vm = BandChartViewModel(band: .band24GHz)
+        var visibleSeries = makeSeries(id: "1", ssid: "Visible")
+        visibleSeries.isFilteredOut = false
+        var filteredSeries = makeSeries(id: "2", ssid: "Filtered")
+        filteredSeries.isFilteredOut = true
+
+        vm.debugInject(series: [visibleSeries, filteredSeries])
+
+        #expect(vm.displayedSeriesData.count == 2)
+        #expect(vm.displayedSeriesData.first { $0.id == "2" }?.isFilteredOut == true)
+        #expect(vm.visibleSeriesData().map(\.id) == ["1"])
+    }
+
     @Test func clearFilterRestoresAllVisible() {
         let vm = BandChartViewModel(band: .band24GHz)
         vm.debugInject(series: [

--- a/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
@@ -99,7 +99,7 @@ import Testing
             aps: [enabled, disabled]
         )
 
-        let series = DebugScenarioBuilder.seriesData(from: scenario, band: .band5GHz)
+        let series = DebugChartSeriesAdapter.seriesData(from: scenario, band: .band5GHz)
         let block = ChannelSpanCalculator.channelBlock(
             primaryChannel: 52,
             widthMHz: 80,
@@ -137,7 +137,7 @@ import Testing
         )
         let scenario = DebugScenario(version: 1, bandID: ChannelBand.band24GHz.id, presetID: nil, aps: [ap])
 
-        let series = DebugScenarioBuilder.seriesData(from: scenario, band: .band24GHz)
+        let series = DebugChartSeriesAdapter.seriesData(from: scenario, band: .band24GHz)
 
         #expect(series.count == 1)
         #expect(series[0].ssid == "")
@@ -166,8 +166,40 @@ import Testing
 
             #expect(!scenario.aps.isEmpty)
             #expect(scenario.aps.allSatisfy { $0.channel >= 1 && $0.channel <= band.maxChannel })
-            #expect(DebugScenarioBuilder.seriesData(from: scenario, band: band).count > 0)
+            #expect(DebugChartSeriesAdapter.seriesData(from: scenario, band: band).count > 0)
         }
+    }
+
+    @Test func normalizationClampsWideRowsWhenSwitchingTo24GHz() {
+        let ap = DebugAPConfig(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000031")!,
+            enabled: true,
+            ssid: "Wide",
+            bssidSuffix: "31",
+            channel: 149,
+            widthMHz: 80,
+            rssi: -52,
+            colorHex: "#3B82F6",
+            hiddenSSID: false,
+            visible: true,
+            filtered: false,
+            supportsK: false,
+            supportsR: false,
+            supportsV: false,
+            supportsWPA3: false,
+            country: "",
+            trend: .none,
+            trendDelta: 0
+        )
+        let scenario = DebugScenario(version: 1, bandID: ChannelBand.band24GHz.id, presetID: nil, aps: [ap])
+
+        let normalized = DebugScenarioBuilder.normalized(scenario)
+        let series = DebugChartSeriesAdapter.seriesData(from: normalized, band: .band24GHz)
+
+        #expect(normalized.aps[0].channel == ChannelBand.band24GHz.maxChannel)
+        #expect(normalized.aps[0].widthMHz == 20)
+        #expect(series[0].channel == ChannelBand.band24GHz.maxChannel)
+        #expect(series[0].channelWidth == "20")
     }
 
     @Test func storeFallsBackToDefaultPresetWhenPayloadIsInvalid() {

--- a/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
@@ -4,6 +4,33 @@ import Testing
 
 @Suite struct DebugMultiAPScenarioTests {
 
+    @Test func debugNavigationSeparatesSpectrumChartDebugPage() {
+        #expect(SidebarPage.allCases.contains(.spectrumDebugChart))
+        #expect(SidebarPage.allCases.contains(.debugChart))
+        #expect(SidebarPage.spectrumDebugChart.icon == "antenna.radiowaves.left.and.right")
+        #expect(SidebarPage.debugChart.icon == "ladybug")
+        #expect(SidebarPage.spectrumDebugChart.requiresLocationAuthorization)
+        #expect(SidebarPage.spectrumDebugChart.requiresWiFi)
+    }
+
+    @Test func spectrumDebugPagesContainSingleAndMultiAPEntries() {
+        #expect(SpectrumDebugPage.allCases.map(\.rawValue) == [
+            "singleAP",
+            "multiAP",
+        ])
+        #expect(SpectrumDebugPage.singleAP.label == "Single AP")
+        #expect(SpectrumDebugPage.multiAP.label == "Multi AP")
+    }
+
+    @Test func debugPagesKeepOnlyNonSpectrumChartEntries() {
+        #expect(DebugPage.allCases.map(\.rawValue) == [
+            "throughput",
+            "roaming",
+        ])
+        #expect(DebugPage.throughput.label == "Throughput")
+        #expect(DebugPage.roaming.label == "Roaming")
+    }
+
     @Test func scenarioRoundTripsThroughJSON() throws {
         let scenario = DebugScenario(
             version: 1,

--- a/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@Suite struct DebugMultiAPScenarioTests {
+
+    @Test func scenarioRoundTripsThroughJSON() throws {
+        let scenario = DebugScenario(
+            version: 1,
+            bandID: ChannelBand.band5GHz.id,
+            presetID: DebugScenarioPreset.labelCollision.id,
+            aps: [
+                DebugAPConfig(
+                    id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+                    enabled: true,
+                    ssid: "Debug-1",
+                    bssidSuffix: "01",
+                    channel: 52,
+                    widthMHz: 80,
+                    rssi: -48,
+                    colorHex: "#3B82F6",
+                    hiddenSSID: false,
+                    visible: true,
+                    filtered: false,
+                    supportsK: true,
+                    supportsR: true,
+                    supportsV: false,
+                    supportsWPA3: true,
+                    country: "US",
+                    trend: .up,
+                    trendDelta: 4
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(scenario)
+        let decoded = try JSONDecoder().decode(DebugScenario.self, from: data)
+
+        #expect(decoded == scenario)
+    }
+
+    @Test func builderDropsDisabledAPsAndUsesProductionChannelBlocks() {
+        let enabled = DebugAPConfig(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000011")!,
+            enabled: true,
+            ssid: "Wide",
+            bssidSuffix: "11",
+            channel: 52,
+            widthMHz: 80,
+            rssi: -44,
+            colorHex: "#10B981",
+            hiddenSSID: false,
+            visible: true,
+            filtered: false,
+            supportsK: false,
+            supportsR: false,
+            supportsV: false,
+            supportsWPA3: false,
+            country: "",
+            trend: .none,
+            trendDelta: 0
+        )
+        var disabled = enabled
+        disabled.id = UUID(uuidString: "00000000-0000-0000-0000-000000000012")!
+        disabled.enabled = false
+        disabled.ssid = "Disabled"
+
+        let scenario = DebugScenario(
+            version: 1,
+            bandID: ChannelBand.band5GHz.id,
+            presetID: nil,
+            aps: [enabled, disabled]
+        )
+
+        let series = DebugScenarioBuilder.seriesData(from: scenario, band: .band5GHz)
+        let block = ChannelSpanCalculator.channelBlock(
+            primaryChannel: 52,
+            widthMHz: 80,
+            band: .band5GHz,
+            spanDirection: nil
+        )
+
+        #expect(series.count == 1)
+        #expect(series[0].ssid == "Wide")
+        #expect(series[0].left == block.left)
+        #expect(series[0].apex == Double(block.left + block.right) / 2.0)
+        #expect(series[0].right == block.right)
+    }
+
+    @Test func builderMapsDebugMetadataToChartSeriesData() {
+        let ap = DebugAPConfig(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000021")!,
+            enabled: true,
+            ssid: "",
+            bssidSuffix: "21",
+            channel: 6,
+            widthMHz: 40,
+            rssi: -61,
+            colorHex: "#F59E0B",
+            hiddenSSID: true,
+            visible: false,
+            filtered: true,
+            supportsK: true,
+            supportsR: false,
+            supportsV: true,
+            supportsWPA3: true,
+            country: "JP",
+            trend: .down,
+            trendDelta: -7
+        )
+        let scenario = DebugScenario(version: 1, bandID: ChannelBand.band24GHz.id, presetID: nil, aps: [ap])
+
+        let series = DebugScenarioBuilder.seriesData(from: scenario, band: .band24GHz)
+
+        #expect(series.count == 1)
+        #expect(series[0].ssid == "")
+        #expect(series[0].displaySSID == "n/a")
+        #expect(series[0].bssid == "02:00:00:00:00:21")
+        #expect(series[0].channel == 6)
+        #expect(series[0].rssi == -61)
+        #expect(series[0].displayRSSI == -61)
+        #expect(series[0].channelWidth == "40")
+        #expect(series[0].supportsK)
+        #expect(!series[0].supportsR)
+        #expect(series[0].supportsV)
+        #expect(series[0].supportsWPA3)
+        #expect(series[0].isHiddenSSID)
+        #expect(!series[0].isVisible)
+        #expect(series[0].isFilteredOut)
+        #expect(series[0].country == "JP")
+        #expect(series[0].trendArrow == "▼")
+        #expect(series[0].trendDelta == -7)
+    }
+
+    @Test func presetsProduceValidRowsForTheirBands() throws {
+        for preset in DebugScenarioPreset.allCases {
+            let scenario = DebugScenarioBuilder.scenario(for: preset)
+            let band = try #require(ChannelBand(id: scenario.bandID))
+
+            #expect(!scenario.aps.isEmpty)
+            #expect(scenario.aps.allSatisfy { $0.channel >= 1 && $0.channel <= band.maxChannel })
+            #expect(DebugScenarioBuilder.seriesData(from: scenario, band: band).count > 0)
+        }
+    }
+
+    @Test func storeFallsBackToDefaultPresetWhenPayloadIsInvalid() {
+        let defaults = UserDefaults(suiteName: "DebugMultiAPScenarioTests")!
+        defaults.removePersistentDomain(forName: "DebugMultiAPScenarioTests")
+        defaults.set(Data("not json".utf8), forKey: DebugScenarioStore.storageKey)
+        let store = DebugScenarioStore(defaults: defaults)
+
+        let loaded = store.load()
+
+        #expect(loaded.presetID == DebugScenarioPreset.labelCollision.id)
+        #expect(!loaded.aps.isEmpty)
+    }
+}

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		2B79435DB2D70F8EFE1DFDAA /* RegulatoryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE17427BAD036F393D712B6F /* RegulatoryFilterTests.swift */; };
 		2B7B4CBC96F724AA4970AC7F /* SpectrumModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD34695BFD8D4277DF0BDB0 /* SpectrumModelTests.swift */; };
 		2ED34E17AE03E25A409037BD /* NetworkTableRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5143599E254B3367AFD37C /* NetworkTableRowTests.swift */; };
+		ADB001000000000000000004 /* DebugMultiAPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB001000000000000000003 /* DebugMultiAPScenario.swift */; };
+		ADB001000000000000000005 /* DebugMultiAPScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB001000000000000000003 /* DebugMultiAPScenario.swift */; };
+		ADB001000000000000000002 /* DebugMultiAPScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB001000000000000000001 /* DebugMultiAPScenarioTests.swift */; };
 		2FA3CB9C5DD2446AAA549779 /* GatewayPinger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF472346A62545B9866DA8ED /* GatewayPinger.swift */; };
 		318908BC49D244B1EEE68A9A /* ChannelSpanCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA4E8568B0D4661E9B9E71E /* ChannelSpanCalculator.swift */; };
 		3711656F0C3ECD58CA29D407 /* NativeTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A3299502DE1A130760C8A7 /* NativeTableView.swift */; };
@@ -324,6 +327,8 @@
 		CA9F90F78BD04526AE0566CC /* KalmanFilter1D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KalmanFilter1D.swift; sourceTree = "<group>"; };
 		CEDCF8EF1A4D0D355ED657A6 /* BLERSSISample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLERSSISample.swift; sourceTree = "<group>"; };
 		D07A4C1B8DFCDFBA81A6DFFA /* RegulatoryDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegulatoryDatabaseTests.swift; sourceTree = "<group>"; };
+		ADB001000000000000000003 /* DebugMultiAPScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMultiAPScenario.swift; sourceTree = "<group>"; };
+		ADB001000000000000000001 /* DebugMultiAPScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMultiAPScenarioTests.swift; sourceTree = "<group>"; };
 		D6180984B78D4363B6840C79 /* SignalSmoothing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalSmoothing.swift; sourceTree = "<group>"; };
 		D69959B95B194A96FA8D337C /* LocationPermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPermissionManager.swift; sourceTree = "<group>"; };
 		D74387CFA1E33037E9F1888E /* ScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewModel.swift; sourceTree = "<group>"; };
@@ -483,6 +488,7 @@
 			isa = PBXGroup;
 			children = (
 				FB92F91F2FBE208500BCEC67 /* DebugChartView.swift */,
+				ADB001000000000000000003 /* DebugMultiAPScenario.swift */,
 				FB92F9222FBE208500BCEC67 /* DebugContainerView.swift */,
 				FB92F9242FBE208500BCEC67 /* DebugThroughputView.swift */,
 				FB92F9262FBE208500BCEC67 /* DebugRoamingChartView.swift */,
@@ -809,6 +815,7 @@
 				E83547C1A36ADDD9E827B26A /* ChartUtilityTests.swift */,
 				8A7A45AB88716DC3AC18610B /* ChartViewTests.swift */,
 				53CD49099277F06E8FB3E04D /* ColorExtensionTests.swift */,
+				ADB001000000000000000001 /* DebugMultiAPScenarioTests.swift */,
 				3053495094BB40125310557F /* DeviceCompatibilityFilterTests.swift */,
 				39A94372ADF30D10E0F015CD /* IEParserTests.swift */,
 				A5024CBB8BFCAFF56FEF0756 /* MCPServerTests.swift */,
@@ -1063,6 +1070,7 @@
 				FB0573C22FBC47F1005F8214 /* CrashReporter.swift in Sources */,
 				FBD329502FC500000057B038 /* MetricKitManager.swift in Sources */,
 				FB92F9212FBE208500BCEC67 /* DebugChartView.swift in Sources */,
+				ADB001000000000000000004 /* DebugMultiAPScenario.swift in Sources */,
 				FB92F9232FBE208500BCEC67 /* DebugContainerView.swift in Sources */,
 				FB92F9252FBE208500BCEC67 /* DebugThroughputView.swift in Sources */,
 				FB92F9282FBE208500BCEC67 /* DebugRoamingChartView.swift in Sources */,
@@ -1128,6 +1136,7 @@
 				19134AC983FA95FB8033EB8F /* ChartUtilityTests.swift in Sources */,
 				EEF6495F8D90DE97D0C86ADF /* ChartViewTests.swift in Sources */,
 				C1E94A4D89C952711DBDB34E /* ColorExtensionTests.swift in Sources */,
+				ADB001000000000000000002 /* DebugMultiAPScenarioTests.swift in Sources */,
 				FABE49BBA198BBD12DD618F2 /* DeviceCompatibilityFilterTests.swift in Sources */,
 				BAB34552BFD72F7A42CD918A /* IEParserTests.swift in Sources */,
 				13E648DDB1578ECF42926E36 /* MCPServerTests.swift in Sources */,
@@ -1190,6 +1199,7 @@
 				FB1E32672FC7316C009D1BDC /* CrashReporter.swift in Sources */,
 				FB1E32682FC7316C009D1BDC /* MetricKitManager.swift in Sources */,
 				FB1E32692FC7316C009D1BDC /* DebugChartView.swift in Sources */,
+				ADB001000000000000000005 /* DebugMultiAPScenario.swift in Sources */,
 				FB1E326A2FC7316C009D1BDC /* DebugContainerView.swift in Sources */,
 				FB1E326B2FC7316C009D1BDC /* DebugThroughputView.swift in Sources */,
 				FB1E326C2FC7316C009D1BDC /* DebugRoamingChartView.swift in Sources */,

--- a/docs/COLLABORATION_RULES.md
+++ b/docs/COLLABORATION_RULES.md
@@ -35,6 +35,8 @@ The following rules are **hard constraints** and must be followed in all circums
 
 - **Build verification**: All code changes must be verified by running `xcodebuild build` successfully.
 
+- **No UI tests by default**: Do not run `WiFiLensUITests`, `WiFiLensProUITests`, or full scheme `xcodebuild test` commands that include UI test bundles unless the user explicitly asks for UI tests. Use build verification and unit-test-only verification by default.
+
 - **Docs go in `docs/`**: All new `.md` files must be placed under the `docs/` directory. The only exceptions are this file (`docs/COLLABORATION_RULES.md`) and `AGENTS.md`, `CLAUDE.md`, and `README.md` at the repo root.
 
 ## Behavioral Style

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,12 +10,21 @@
 
 ## Running Tests
 
-```sh
-# All tests (unit + UI) — OSS target
-xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+Default verification should use `xcodebuild build` plus unit-test-only runs. Do not run UI test bundles unless the user explicitly asks for UI tests.
 
-# Pro target tests
-xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens Pro" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+```sh
+# Build verification — OSS target
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+
+# Unit tests only — OSS target
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
+
+# Build verification — Pro target
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens Pro" -configuration Debug -destination 'platform=macOS' build
+
+# UI tests — run only when explicitly requested by the user
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensUITests
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens Pro" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensProUITests
 ```
 
 ## Unit Tests (WiFiLensTests)

--- a/docs/superpowers/plans/2026-06-18-debug-multi-ap-chart.md
+++ b/docs/superpowers/plans/2026-06-18-debug-multi-ap-chart.md
@@ -1,0 +1,147 @@
+# Debug Multi-AP Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `DebugChartView` multi-AP mode whose only difference from the Spectrum page chart is that its AP data source is manually configured debug data.
+
+**Architecture:** Keep `WiFiBandChart`, `BandChartViewModel`, `BandChartRenderModel`, `BandChartLayout`, hover, selection, zoom, heatmap, labels, and RSSI animation unchanged. Add debug-only scenario models and an adapter that converts editable table rows into `ChartSeriesData`, then inject those series through `BandChartViewModel.debugInject(series:)`.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing, Xcode project targets, `UserDefaults`, existing chart engine.
+
+## Global Constraints
+
+- App build and tests must use `xcodebuild`, not `swift build` or `swift test`.
+- All new documentation must live under `docs/`.
+- Do not commit or push unless explicitly asked.
+- New Swift source files must be added to both `WiFiLens` and `WiFiLensPro` targets.
+- New test files must be added to the `WiFiLensTests` target sources.
+- New code comments and docs must be English.
+- Debug UI must remain behind `#if DEBUG`.
+- The debug chart must reuse the same rendering mechanism as the Spectrum page; only the source data may differ.
+
+---
+
+## Files
+
+- Create: `WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift`
+  - Owns debug-only scenario models, presets, persistence, and conversion to `ChartSeriesData`.
+- Modify: `WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift`
+  - Adds `Single AP` / `Multi AP` mode picker and the multi-AP chart-over-table editor.
+- Create: `WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift`
+  - Tests model coding, presets, conversion, and persistence fallback.
+- Modify: `WiFiLens/WiFiLens.xcodeproj/project.pbxproj`
+  - Adds the new source file to app and Pro targets; adds the test file to the test target.
+- Modify: `AGENTS.md`
+  - Adds this plan document to the docs table.
+
+## Task 1: Debug Scenario Model and Adapter
+
+**Files:**
+- Create: `WiFiLens/Tests/WiFiLensTests/DebugMultiAPScenarioTests.swift`
+- Create: `WiFiLens/Sources/WiFiLens/Debug/DebugMultiAPScenario.swift`
+- Modify: `WiFiLens/WiFiLens.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Produces: `DebugScenario`, `DebugAPConfig`, `DebugTrend`, `DebugScenarioPreset`, `DebugScenarioBuilder`, `DebugScenarioStore`.
+- Produces: `DebugScenarioBuilder.seriesData(from:band:) -> [ChartSeriesData]`.
+- Consumes: `ChannelBand`, `ChannelSpanCalculator`, `ChartSeriesData`, `ChartSeriesDomainData`, `ChartSeriesRenderState`, `Color(hex:)`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+- `DebugScenario` encode/decode preserves version, band, and AP rows.
+- Disabled AP rows are not converted.
+- Channel span conversion matches `ChannelSpanCalculator.channelBlock`.
+- Hidden, visible, filtered, protocol, country, color, and trend fields map into `ChartSeriesData`.
+- Invalid stored data falls back to the default preset.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```sh
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+```
+
+Expected: build fails because `DebugScenario` and related types do not exist yet.
+
+- [ ] **Step 3: Implement model and adapter**
+
+Add `#if DEBUG` models, default presets, clamping helpers, `UserDefaults` persistence, and the scenario-to-series conversion.
+
+- [ ] **Step 4: Add files to Xcode project and verify GREEN**
+
+Add the new Swift files to the project and run the same `xcodebuild test` command. Expected: tests pass or fail only with concrete implementation issues to fix.
+
+## Task 2: Multi-AP Chart-Over-Table UI
+
+**Files:**
+- Modify: `WiFiLens/Sources/WiFiLens/Debug/DebugChartView.swift`
+
+**Interfaces:**
+- Consumes: `DebugScenario`, `DebugAPConfig`, `DebugScenarioPreset`, `DebugScenarioBuilder`, `DebugScenarioStore`.
+- Consumes: existing `BandChartViewModel.debugInject(series:)` and `BandChartView`.
+
+- [ ] **Step 1: Add mode state**
+
+Add `DebugChartMode.singleAP` and `DebugChartMode.multiAP`, then wrap the current controls in the `singleAP` branch without changing the oscillator behavior.
+
+- [ ] **Step 2: Add multi-AP state and lifecycle**
+
+Load the stored scenario when entering multi-AP mode, keep a `BandChartViewModel` for the selected band, and route all edits through `applyScenario(save:)`.
+
+- [ ] **Step 3: Build the vertical layout**
+
+Render top controls, then `BandChartView`, then the editable AP table. The table must be below the chart and every edit must immediately update the chart.
+
+- [ ] **Step 4: Implement row editing commands**
+
+Support add, duplicate, delete, reset preset, band changes, and per-row bindings for enabled, SSID, channel, width, RSSI, color, hidden, visible, filtered, protocol flags, country, trend, and delta.
+
+- [ ] **Step 5: Build and manually inspect compile output**
+
+Run the app build command and fix SwiftUI type errors:
+
+```sh
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+```
+
+Expected: build succeeds.
+
+## Task 3: Final Verification
+
+**Files:**
+- All changed files.
+
+**Interfaces:**
+- Verifies every explicit requirement from the design spec and user objective.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```sh
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+```
+
+Expected: test action succeeds.
+
+- [ ] **Step 2: Run build**
+
+Run:
+
+```sh
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Audit requirements**
+
+Confirm from code and tests:
+- Multi-AP mode is inside `DebugChartView`.
+- The UI is chart above, editable table below.
+- Edits update `DebugScenario`, save to `UserDefaults`, convert to `[ChartSeriesData]`, and call `debugInject(series:)`.
+- `WiFiBandChart` and `BandChartViewModel` production rendering path is reused.
+- The Spectrum page rendering mechanism is not forked.
+- JSON import/export is not implemented, but the schema is `Codable` and versioned.

--- a/docs/superpowers/plans/2026-06-18-debug-multi-ap-chart.md
+++ b/docs/superpowers/plans/2026-06-18-debug-multi-ap-chart.md
@@ -43,7 +43,8 @@
 
 **Interfaces:**
 - Produces: `DebugScenario`, `DebugAPConfig`, `DebugTrend`, `DebugScenarioPreset`, `DebugScenarioBuilder`, `DebugScenarioStore`.
-- Produces: `DebugScenarioBuilder.seriesData(from:band:) -> [ChartSeriesData]`.
+- Produces: `DebugScenarioBuilder.seriesSources(from:band:) -> [DebugChartSeriesSource]`.
+- Produces: `DebugChartSeriesAdapter.seriesData(from:band:) -> [ChartSeriesData]`.
 - Consumes: `ChannelBand`, `ChannelSpanCalculator`, `ChartSeriesData`, `ChartSeriesDomainData`, `ChartSeriesRenderState`, `Color(hex:)`.
 
 - [ ] **Step 1: Write failing tests**
@@ -60,7 +61,7 @@ Add tests for:
 Run:
 
 ```sh
-xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
 ```
 
 Expected: build fails because `DebugScenario` and related types do not exist yet.
@@ -71,7 +72,7 @@ Add `#if DEBUG` models, default presets, clamping helpers, `UserDefaults` persis
 
 - [ ] **Step 4: Add files to Xcode project and verify GREEN**
 
-Add the new Swift files to the project and run the same `xcodebuild test` command. Expected: tests pass or fail only with concrete implementation issues to fix.
+Add the new Swift files to the project and run the same unit-only `xcodebuild test -only-testing:WiFiLensTests` command. Expected: tests pass or fail only with concrete implementation issues to fix.
 
 ## Task 2: Multi-AP Chart-Over-Table UI
 
@@ -121,10 +122,10 @@ Expected: build succeeds.
 Run:
 
 ```sh
-xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test
+xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
 ```
 
-Expected: test action succeeds.
+Expected: unit test action succeeds. If the local macOS test runner cannot launch, run `build-for-testing` and report the runner failure separately from compile results.
 
 - [ ] **Step 2: Run build**
 

--- a/docs/superpowers/specs/2026-06-18-debug-multi-ap-chart-design.md
+++ b/docs/superpowers/specs/2026-06-18-debug-multi-ap-chart-design.md
@@ -1,0 +1,239 @@
+# Debug Multi-AP Chart Design
+
+## Goal
+
+Add a multi-AP debugging mode to `DebugChartView` so developers can reproduce complex Wi-Fi spectrum rendering cases without relying on live scans. The mode must let developers edit AP parameters in a table and immediately see the production `WiFiBandChart` update above it.
+
+The first implementation stores the current debug scenario in `UserDefaults`. The data model must be `Codable` and versioned so a later JSON import/export feature can reuse the same schema without reworking the core state.
+
+## Non-Goals
+
+- Do not add a new sidebar destination.
+- Do not create a separate chart renderer.
+- Do not edit AP parameters through modal sheets or a side inspector.
+- Do not implement JSON import/export in the first pass.
+- Do not add this debug UI to release builds.
+
+## Existing Context
+
+`DebugChartView` currently injects a single synthetic AP into `BandChartViewModel.debugInject(series:)`. That path is valuable because it exercises the production spectrum chart stack:
+
+```
+Debug data
+  -> ChartSeriesData
+  -> BandChartViewModel.debugInject(series:)
+  -> BandChartRenderModel
+  -> WiFiBandChart
+  -> Chart + BandChartLayout overlays
+```
+
+The new mode should keep this same path. Rendering bugs in labels, heatmap bins, hover hit testing, selection dimming, zoom, and RSSI animation should remain visible through the real production components.
+
+## User Experience
+
+`DebugChartView` gets a top-level mode picker:
+
+- `Single AP`: the current oscillator-based debug chart remains available.
+- `Multi AP`: a new workbench for table-driven custom scenarios.
+
+The `Multi AP` layout is vertical:
+
+```
+[ Mode ] [ Band ] [ Preset ] [ Add AP ] [ Reset ]
+
++-----------------------------------------------+
+|                 WiFiBandChart                 |
+|     updates immediately from table edits       |
++-----------------------------------------------+
+
++-----------------------------------------------+
+| on | ssid | ch | width | rssi | color | ...   |
+| x  | AP-1 | 36 | 80    | -48  | blue  | ...   |
+| x  | AP-2 | 44 | 40    | -67  | mint  | ...   |
++-----------------------------------------------+
+```
+
+The table is the primary editor. Each edit updates the in-memory scenario, persists it to `UserDefaults`, rebuilds `[ChartSeriesData]`, and calls `debugInject(series:)` so the chart above reflects the change immediately.
+
+## Controls
+
+### Top Bar
+
+- Mode picker: `Single AP` / `Multi AP`
+- Band picker: `2.4 GHz` / `5 GHz` / `6 GHz`
+- Preset picker: fills the table with a known rendering scenario
+- Add AP button: appends a default AP valid for the current band
+- Reset button: restores the selected preset
+
+Changing the band should keep rows when possible, but clamp invalid channels to a valid default for the new band.
+
+### Multi-AP Table
+
+Each row represents one synthetic AP:
+
+| Column | Control | Effect |
+|--------|---------|--------|
+| Enabled | checkbox | Included or excluded from injected chart data |
+| SSID | text field | Label and tooltip text |
+| Channel | stepper or numeric text field | Primary channel passed to `ChannelSpanCalculator.channelBlock` |
+| Width | picker | `20`, `40`, `80`, `160` MHz where meaningful for the band |
+| RSSI | stepper or numeric text field | Curve height and strongest RSSI calculation |
+| Color | color well or compact picker | Curve, label, and heatmap color |
+| Hidden | checkbox | Sets `isHiddenSSID` |
+| Visible | checkbox | Sets `isVisible` |
+| Filtered | checkbox | Sets `isFilteredOut` |
+| 11k | checkbox | Sets `supportsK` |
+| 11r | checkbox | Sets `supportsR` |
+| 11v | checkbox | Sets `supportsV` |
+| WPA3 | checkbox | Sets `supportsWPA3` |
+| Country | text field | Debug country code metadata |
+| Trend | segmented control | none, up, down, stable |
+| Delta | stepper | Debug trend delta shown in labels |
+| Actions | icon buttons | duplicate and delete row |
+
+The table can be implemented with SwiftUI `Table` if inline editing is practical. If SwiftUI table editing becomes too constrained, use a `ScrollView` + grid-style rows while preserving table-like alignment and stable column widths.
+
+## Presets
+
+Presets are not separate modes. They only populate the editable table.
+
+Initial presets:
+
+- Label collision: many APs with close apex channels and similar RSSI values.
+- Dense 2.4 GHz: overlapping APs around channels 1, 6, and 11.
+- 5 GHz wide overlap: 40/80/160 MHz APs sharing adjacent channel blocks.
+- 6 GHz sparse: wide but less congested APs across the band.
+- Hidden and filtered: hidden SSIDs plus invisible and filtered rows to verify selection and dimming behavior.
+
+After loading a preset, every row remains editable and auto-saved.
+
+## Data Model
+
+Add debug-only models near `DebugChartView` or in a dedicated debug source file:
+
+```swift
+#if DEBUG
+struct DebugScenario: Codable, Equatable {
+    var version: Int
+    var bandID: String
+    var presetID: String?
+    var aps: [DebugAPConfig]
+}
+
+struct DebugAPConfig: Codable, Identifiable, Equatable {
+    var id: UUID
+    var enabled: Bool
+    var ssid: String
+    var bssidSuffix: String
+    var channel: Int
+    var widthMHz: Int
+    var rssi: Int
+    var colorHex: String
+    var hiddenSSID: Bool
+    var visible: Bool
+    var filtered: Bool
+    var supportsK: Bool
+    var supportsR: Bool
+    var supportsV: Bool
+    var supportsWPA3: Bool
+    var country: String
+    var trend: DebugTrend
+    var trendDelta: Int
+}
+#endif
+```
+
+Use `bandID` instead of encoding `ChannelBand` directly so future JSON files remain stable even if enum internals change.
+
+Use `colorHex` instead of encoding SwiftUI `Color`. Convert at the boundary when building `ChartSeriesRenderState`.
+
+## Persistence
+
+Store one current scenario in `UserDefaults` under a debug-specific key, for example:
+
+```
+debug.multiAPChart.scenario.v1
+```
+
+Persistence behavior:
+
+- Load on `Multi AP` appear or when switching into the mode.
+- If loading fails, fall back to a default preset.
+- Save after every table edit.
+- Keep the schema version in the stored payload.
+- Avoid writing anything in release builds by keeping all code inside `#if DEBUG`.
+
+The future JSON feature should use the same `DebugScenario` encoder and decoder. JSON import/export only adds file IO, schema validation, and user-facing error handling.
+
+## Conversion to Chart Data
+
+Create a small debug-only adapter:
+
+```swift
+DebugScenarioBuilder.seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData]
+```
+
+Rules:
+
+- Drop rows where `enabled == false`.
+- Clamp channel and RSSI values to valid debug ranges before conversion.
+- Use `ChannelSpanCalculator.channelBlock(primaryChannel:widthMHz:band:spanDirection:)` to match production span behavior.
+- Use stable IDs based on `DebugAPConfig.id` and band.
+- Generate deterministic BSSIDs from `bssidSuffix` or the row index.
+- Set `displayRSSI` equal to `rssi` when injecting new rows, then let `BandChartViewModel` preserve animated display values on subsequent injections.
+- Map `trend` to the same arrow strings used by production conversion.
+
+## Real-Time Update Flow
+
+```
+Table edit
+  -> update DebugScenario @State
+  -> save encoded scenario to UserDefaults
+  -> build [ChartSeriesData]
+  -> bandVM.debugInject(series:)
+  -> BandChartRenderModel updates
+  -> WiFiBandChart redraws
+```
+
+Use `onChange` or explicit binding setters to trigger the update. Prefer a single `applyScenario()` function so all edit paths share the same conversion and persistence behavior.
+
+## Error Handling
+
+This is a debug-only view, so errors should be visible but lightweight:
+
+- Invalid saved payload: discard it and load the default preset.
+- Empty AP list: show the normal chart empty/loading state and keep the table visible.
+- Invalid numeric input: clamp to a valid value rather than presenting blocking alerts.
+- All rows disabled: inject an empty series list.
+
+## Testing
+
+Add focused Swift Testing coverage for pure logic:
+
+- `DebugScenario` encode/decode round trip.
+- Preset generation returns valid AP rows for each target band.
+- Scenario-to-series conversion computes expected left/apex/right channel spans.
+- Disabled AP rows are not injected.
+- Hidden, visible, filtered, protocol, country, color, and trend fields map to `ChartSeriesData`.
+- UserDefaults store load failure falls back to default data.
+
+If new test files are added, update `project.pbxproj` so they are included in the `WiFiLensTests` target sources and scheme metadata, following `AGENTS.md`.
+
+## Implementation Notes
+
+- Keep `Single AP` behavior unchanged except for moving it behind the mode picker.
+- Keep new models and helpers inside `#if DEBUG`.
+- Prefer small helper types over expanding `DebugChartView` into a large mixed view/model file.
+- Do not localize debug-only controls unless the existing debug UI already does so.
+- Maintain the existing production chart API boundary. The debug view should not reach into `WiFiBandChart` internals.
+
+## Open Extension Point
+
+JSON import/export can be added later by:
+
+- Reusing `DebugScenario` as the file schema.
+- Adding `version` migration if schema fields change.
+- Adding import validation before replacing the current table.
+- Adding export from the current in-memory scenario.
+
+The first implementation should not include these controls, but the model should make them straightforward.

--- a/docs/superpowers/specs/2026-06-18-debug-multi-ap-chart-design.md
+++ b/docs/superpowers/specs/2026-06-18-debug-multi-ap-chart-design.md
@@ -8,7 +8,6 @@ The first implementation stores the current debug scenario in `UserDefaults`. Th
 
 ## Non-Goals
 
-- Do not add a new sidebar destination.
 - Do not create a separate chart renderer.
 - Do not edit AP parameters through modal sheets or a side inspector.
 - Do not implement JSON import/export in the first pass.
@@ -31,7 +30,9 @@ The new mode should keep this same path. Rendering bugs in labels, heatmap bins,
 
 ## User Experience
 
-`DebugChartView` gets a top-level mode picker:
+The spectrum-specific debug workflow is exposed through its own debug sidebar destination, `Spectrum Debug Chart`. The broader `Debug Chart` destination remains available for non-spectrum debug charts such as Throughput and Roaming. This keeps future debug chart categories from crowding a single page.
+
+`SpectrumDebugContainerView` gets a top-level mode picker:
 
 - `Single AP`: the current oscillator-based debug chart remains available.
 - `Multi AP`: a new workbench for table-driven custom scenarios.
@@ -59,7 +60,8 @@ The table is the primary editor. Each edit updates the in-memory scenario, persi
 
 ### Top Bar
 
-- Mode picker: `Single AP` / `Multi AP`
+- Sidebar destination: `Spectrum Debug Chart`
+- Spectrum mode picker: `Single AP` / `Multi AP`
 - Band picker: `2.4 GHz` / `5 GHz` / `6 GHz`
 - Preset picker: fills the table with a known rendering scenario
 - Add AP button: appends a default AP valid for the current band
@@ -170,7 +172,8 @@ The future JSON feature should use the same `DebugScenario` encoder and decoder.
 Create a small debug-only adapter:
 
 ```swift
-DebugScenarioBuilder.seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData]
+DebugScenarioBuilder.seriesSources(from scenario: DebugScenario, band: ChannelBand) -> [DebugChartSeriesSource]
+DebugChartSeriesAdapter.seriesData(from scenario: DebugScenario, band: ChannelBand) -> [ChartSeriesData]
 ```
 
 Rules:
@@ -180,6 +183,7 @@ Rules:
 - Use `ChannelSpanCalculator.channelBlock(primaryChannel:widthMHz:band:spanDirection:)` to match production span behavior.
 - Use stable IDs based on `DebugAPConfig.id` and band.
 - Generate deterministic BSSIDs from `bssidSuffix` or the row index.
+- Keep `DebugScenarioBuilder` free of SwiftUI dependencies. It returns normalized AP data and chart domain data; `DebugChartSeriesAdapter` converts `colorHex` to SwiftUI `Color` at the view boundary.
 - Set `displayRSSI` equal to `rssi` when injecting new rows, then let `BandChartViewModel` preserve animated display values on subsequent injections.
 - Map `trend` to the same arrow strings used by production conversion.
 
@@ -213,6 +217,7 @@ Add focused Swift Testing coverage for pure logic:
 - `DebugScenario` encode/decode round trip.
 - Preset generation returns valid AP rows for each target band.
 - Scenario-to-series conversion computes expected left/apex/right channel spans.
+- Band switching normalization clamps invalid channels and widths, for example a 5 GHz `80 MHz` row moved to 2.4 GHz becomes a valid 2.4 GHz row.
 - Disabled AP rows are not injected.
 - Hidden, visible, filtered, protocol, country, color, and trend fields map to `ChartSeriesData`.
 - UserDefaults store load failure falls back to default data.


### PR DESCRIPTION
## Summary

- Add a dedicated debug sidebar entry for the spectrum chart debug workflow.
- Move spectrum Single AP and Multi AP debug modes into `SpectrumDebugContainerView`.
- Keep the existing Debug Chart entry focused on non-spectrum debug charts: Throughput and Roaming.
- Document that UI tests should not be run by default unless explicitly requested.

## Validation

- `xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build` passed.
- `xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens Pro" -configuration Debug -destination 'platform=macOS' build` passed.
- `xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates -derivedDataPath /tmp/wifilens-green-dd build-for-testing` passed.
- Unit-only test execution was attempted with `-only-testing:WiFiLensTests/DebugMultiAPScenarioTests`, but the local macOS test runner failed to launch with RunningBoard error 5 before tests executed.

UI tests were not executed.