### PR TITLE
[codex] Move secondary navigation into the window toolbar

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+enum SecondaryToolbarItemID: String, Hashable {
+    case channelsSimple = "channels-simple"
+    case channelsTable = "channels-table"
+    case interfacesSimple = "interfaces-simple"
+    case interfacesDetails = "interfaces-details"
+    case interfacesMonitor = "interfaces-monitor"
+#if PRO
+    case spectrumLive = "spectrum-live"
+    case spectrumRecording = "spectrum-recording"
+#endif
+}
+
+struct SecondaryToolbarItem: Identifiable, Equatable {
+    let id: SecondaryToolbarItemID
+    let title: String
+}
+
+struct SecondaryToolbarDescriptor: Equatable {
+    let items: [SecondaryToolbarItem]
+    let defaultSelection: SecondaryToolbarItemID
+
+    func selectionIndex(for id: SecondaryToolbarItemID) -> Int {
+        items.firstIndex { $0.id == id } ?? items.firstIndex { $0.id == defaultSelection } ?? 0
+    }
+
+    func itemID(at index: Int) -> SecondaryToolbarItemID? {
+        guard items.indices.contains(index) else { return nil }
+        return items[index].id
+    }
+
+    static func forPage(_ page: SidebarPage) -> Self? {
+        switch page {
+        case .channels:
+            Self(
+                items: [
+                    SecondaryToolbarItem(
+                        id: .channelsSimple,
+                        title: String(localized: "channels.mode.simple", comment: "Simple view mode for channel quality")
+                    ),
+                    SecondaryToolbarItem(
+                        id: .channelsTable,
+                        title: String(localized: "channels.mode.professional", comment: "Professional view mode for channel quality")
+                    ),
+                ],
+                defaultSelection: .channelsSimple
+            )
+        case .interfaces:
+            Self(
+                items: [
+                    SecondaryToolbarItem(
+                        id: .interfacesSimple,
+                        title: String(localized: "channels.mode.simple", comment: "Simple view mode for interfaces")
+                    ),
+                    SecondaryToolbarItem(
+                        id: .interfacesDetails,
+                        title: String(localized: "common.label.details", comment: "Details view mode label")
+                    ),
+                    SecondaryToolbarItem(
+                        id: .interfacesMonitor,
+                        title: String(localized: "interfaces.mode.monitor", comment: "Throughput monitor view mode")
+                    ),
+                ],
+                defaultSelection: .interfacesSimple
+            )
+#if PRO
+        case .spectrum:
+            Self(
+                items: [
+                    SecondaryToolbarItem(
+                        id: .spectrumLive,
+                        title: String(localized: "spectrum.mode.live", comment: "Live spectrum mode")
+                    ),
+                    SecondaryToolbarItem(
+                        id: .spectrumRecording,
+                        title: String(localized: "spectrum.mode.recording_page", comment: "Recording page mode")
+                    ),
+                ],
+                defaultSelection: .spectrumLive
+            )
+#endif
+        default:
+            nil
+        }
+    }
+}
+
+extension SidebarPage {
+    var supportsSecondaryToolbar: Bool {
+        SecondaryToolbarDescriptor.forPage(self) != nil
+    }
+}
+
+enum DetailPageRenderPolicy {
+    static func shouldRender(_ page: SidebarPage, selectedPage: SidebarPage) -> Bool {
+        page == selectedPage
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
@@ -96,4 +96,13 @@ enum DetailPageRenderPolicy {
     static func shouldRender(_ page: SidebarPage, selectedPage: SidebarPage) -> Bool {
         page == selectedPage
     }
+
+    static func needsConditionalRendering(_ page: SidebarPage) -> Bool {
+        switch page {
+        case .spectrum, .interfaces:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift
@@ -25,11 +25,6 @@ struct SecondaryToolbarDescriptor: Equatable {
         items.firstIndex { $0.id == id } ?? items.firstIndex { $0.id == defaultSelection } ?? 0
     }
 
-    func itemID(at index: Int) -> SecondaryToolbarItemID? {
-        guard items.indices.contains(index) else { return nil }
-        return items[index].id
-    }
-
     static func forPage(_ page: SidebarPage) -> Self? {
         switch page {
         case .channels:
@@ -82,27 +77,6 @@ struct SecondaryToolbarDescriptor: Equatable {
 #endif
         default:
             nil
-        }
-    }
-}
-
-extension SidebarPage {
-    var supportsSecondaryToolbar: Bool {
-        SecondaryToolbarDescriptor.forPage(self) != nil
-    }
-}
-
-enum DetailPageRenderPolicy {
-    static func shouldRender(_ page: SidebarPage, selectedPage: SidebarPage) -> Bool {
-        page == selectedPage
-    }
-
-    static func needsConditionalRendering(_ page: SidebarPage) -> Bool {
-        switch page {
-        case .spectrum, .interfaces:
-            return true
-        default:
-            return false
         }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -29,6 +29,11 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         if #available(macOS 26.0, *) {
             control.borderShape = .capsule
         }
+        // TODO: Enable when CI Xcode ships macOS 27+ SDK (currently Xcode 26.5).
+        // NSSegmentedControl.role is unavailable in the macOS 26 SDK headers.
+        // if #available(macOS 27.0, *) {
+        //     control.role = .valueSelection
+        // }
 
         update(control, with: descriptor, selection: selection)
         return control

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -1,0 +1,81 @@
+import AppKit
+import SwiftUI
+
+struct SecondaryToolbarCapsule: NSViewRepresentable {
+    let descriptor: SecondaryToolbarDescriptor
+    @Binding var selection: SecondaryToolbarItemID
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selection: $selection, itemIDs: descriptor.items.map(\.id))
+    }
+
+    func makeNSView(context: Context) -> NSSegmentedControl {
+        let control = NSSegmentedControl(
+            labels: descriptor.items.map(\.title),
+            trackingMode: .selectOne,
+            target: context.coordinator,
+            action: #selector(Coordinator.selectionDidChange(_:))
+        )
+        control.segmentStyle = .capsule
+        control.segmentDistribution = .fillEqually
+        control.controlSize = .large
+        control.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        control.setContentCompressionResistancePriority(.required, for: .horizontal)
+        control.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(macOS 26.0, *) {
+            control.borderShape = .capsule
+        }
+
+        if #available(macOS 27.0, *) {
+            control.role = .valueSelection
+        }
+
+        update(control, with: descriptor, selection: selection)
+        return control
+    }
+
+    func updateNSView(_ nsView: NSSegmentedControl, context: Context) {
+        nsView.target = context.coordinator
+        nsView.action = #selector(Coordinator.selectionDidChange(_:))
+        context.coordinator.itemIDs = descriptor.items.map(\.id)
+        update(nsView, with: descriptor, selection: selection)
+    }
+
+    private func update(_ control: NSSegmentedControl, with descriptor: SecondaryToolbarDescriptor, selection: SecondaryToolbarItemID) {
+        if control.segmentCount != descriptor.items.count {
+            control.segmentCount = descriptor.items.count
+        }
+
+        for (index, item) in descriptor.items.enumerated() {
+            control.setLabel(item.title, forSegment: index)
+            control.setWidth(110, forSegment: index)
+            control.setTag(index, forSegment: index)
+        }
+
+        let selectedIndex = descriptor.selectionIndex(for: selection)
+        if control.selectedSegment != selectedIndex {
+            control.selectedSegment = selectedIndex
+        }
+    }
+
+    final class Coordinator: NSObject {
+        @Binding private var selection: SecondaryToolbarItemID
+        var itemIDs: [SecondaryToolbarItemID]
+
+        init(selection: Binding<SecondaryToolbarItemID>, itemIDs: [SecondaryToolbarItemID] = []) {
+            _selection = selection
+            self.itemIDs = itemIDs
+        }
+
+        @objc func selectionDidChange(_ sender: NSSegmentedControl) {
+            let index = sender.selectedSegment
+            guard index >= 0 else { return }
+            guard itemIDs.indices.contains(index) else { return }
+            let itemID = itemIDs[index]
+            if selection != itemID {
+                selection = itemID
+            }
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -26,6 +26,15 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         control.setAccessibilityIdentifier("secondary-toolbar")
         control.setAccessibilityLabel(descriptor.items.map(\.title).joined(separator: ", "))
 
+        if #available(macOS 26.0, *) {
+            control.borderShape = .capsule
+        }
+        #if compiler(>=6.3)
+        if #available(macOS 27.0, *) {
+            control.role = .valueSelection
+        }
+        #endif
+
         update(control, with: descriptor, selection: selection)
         return control
     }

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -5,16 +5,17 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
     let descriptor: SecondaryToolbarDescriptor
     @Binding var selection: SecondaryToolbarItemID
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(selection: $selection, itemIDs: descriptor.items.map(\.id))
-    }
-
-    func makeNSView(context: Context) -> NSSegmentedControl {
-        let control = NSSegmentedControl(
+    static func makeControl(
+        descriptor: SecondaryToolbarDescriptor,
+        selection: SecondaryToolbarItemID,
+        target: AnyObject?,
+        action: Selector?
+    ) -> SecondaryToolbarSegmentedControl {
+        let control = SecondaryToolbarSegmentedControl(
             labels: descriptor.items.map(\.title),
             trackingMode: .selectOne,
-            target: context.coordinator,
-            action: #selector(Coordinator.selectionDidChange(_:))
+            target: target,
+            action: action
         )
         control.segmentStyle = .capsule
         control.segmentDistribution = .fillEqually
@@ -22,6 +23,8 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         control.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         control.setContentCompressionResistancePriority(.required, for: .horizontal)
         control.translatesAutoresizingMaskIntoConstraints = false
+        control.setAccessibilityIdentifier("secondary-toolbar")
+        control.setAccessibilityLabel(descriptor.items.map(\.title).joined(separator: ", "))
 
         if #available(macOS 26.0, *) {
             control.borderShape = .capsule
@@ -35,14 +38,27 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         return control
     }
 
-    func updateNSView(_ nsView: NSSegmentedControl, context: Context) {
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selection: $selection, itemIDs: descriptor.items.map(\.id))
+    }
+
+    func makeNSView(context: Context) -> SecondaryToolbarSegmentedControl {
+        Self.makeControl(
+            descriptor: descriptor,
+            selection: selection,
+            target: context.coordinator,
+            action: #selector(Coordinator.selectionDidChange(_:))
+        )
+    }
+
+    func updateNSView(_ nsView: SecondaryToolbarSegmentedControl, context: Context) {
         nsView.target = context.coordinator
         nsView.action = #selector(Coordinator.selectionDidChange(_:))
         context.coordinator.itemIDs = descriptor.items.map(\.id)
-        update(nsView, with: descriptor, selection: selection)
+        Self.update(nsView, with: descriptor, selection: selection)
     }
 
-    private func update(_ control: NSSegmentedControl, with descriptor: SecondaryToolbarDescriptor, selection: SecondaryToolbarItemID) {
+    private static func update(_ control: SecondaryToolbarSegmentedControl, with descriptor: SecondaryToolbarDescriptor, selection: SecondaryToolbarItemID) {
         if control.segmentCount != descriptor.items.count {
             control.segmentCount = descriptor.items.count
         }
@@ -53,12 +69,15 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
             control.setTag(index, forSegment: index)
         }
 
+        control.segmentItemIDs = descriptor.items.map(\.id)
         let selectedIndex = descriptor.selectionIndex(for: selection)
         if control.selectedSegment != selectedIndex {
             control.selectedSegment = selectedIndex
         }
+        control.refreshAccessibilityChildren()
     }
 
+    @MainActor
     final class Coordinator: NSObject {
         @Binding private var selection: SecondaryToolbarItemID
         var itemIDs: [SecondaryToolbarItemID]
@@ -77,5 +96,32 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
                 selection = itemID
             }
         }
+    }
+}
+
+final class SecondaryToolbarSegmentedControl: NSSegmentedControl {
+    var segmentItemIDs: [SecondaryToolbarItemID] = []
+
+    func refreshAccessibilityChildren() {
+        var childElements: [Any] = []
+        var xOffset: CGFloat = 0
+
+        for index in 0..<segmentCount {
+            let width = self.width(forSegment: index)
+            let frame = NSRect(x: xOffset, y: 0, width: width, height: bounds.height)
+            let label = self.label(forSegment: index) ?? ""
+            let element = NSAccessibilityElement()
+            element.setAccessibilityRole(.radioButton)
+            element.setAccessibilityFrame(frame)
+            element.setAccessibilityLabel(label)
+            element.setAccessibilityParent(self)
+            if segmentItemIDs.indices.contains(index) {
+                element.setAccessibilityIdentifier("secondary-toolbar-\(segmentItemIDs[index].rawValue)")
+            }
+            childElements.append(element)
+            xOffset += width
+        }
+
+        setAccessibilityChildren(childElements as [Any]?)
     }
 }

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -29,11 +29,6 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         if #available(macOS 26.0, *) {
             control.borderShape = .capsule
         }
-        #if compiler(>=6.3)
-        if #available(macOS 27.0, *) {
-            control.role = .valueSelection
-        }
-        #endif
 
         update(control, with: descriptor, selection: selection)
         return control

--- a/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift
@@ -26,14 +26,6 @@ struct SecondaryToolbarCapsule: NSViewRepresentable {
         control.setAccessibilityIdentifier("secondary-toolbar")
         control.setAccessibilityLabel(descriptor.items.map(\.title).joined(separator: ", "))
 
-        if #available(macOS 26.0, *) {
-            control.borderShape = .capsule
-        }
-
-        if #available(macOS 27.0, *) {
-            control.role = .valueSelection
-        }
-
         update(control, with: descriptor, selection: selection)
         return control
     }

--- a/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
+++ b/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
@@ -4,6 +4,17 @@ enum ChannelViewMode: String, CaseIterable {
     case simple
     case table
 
+    static func fromToolbarSelection(_ selection: SecondaryToolbarItemID) -> Self {
+        switch selection {
+        case .channelsSimple:
+            .simple
+        case .channelsTable:
+            .table
+        default:
+            .simple
+        }
+    }
+
     var displayName: String {
         switch self {
         case .simple: String(localized: "channels.mode.simple", comment: "Simple view mode for channel quality")
@@ -14,9 +25,8 @@ enum ChannelViewMode: String, CaseIterable {
 
 struct ChannelQualityView: View {
     let channels: [ChannelRecommendation]
-    @State private var mode: ChannelViewMode = .simple
+    let mode: ChannelViewMode
     @State private var sortKey: SortKey = .rfScore
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var sortAscending: Bool = false
     @State private var selectedID: String?
 
@@ -51,36 +61,21 @@ struct ChannelQualityView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Mode toggle
-            HStack {
-                    Picker("", selection: $mode.animation(reduceMotion ? nil : .bouncy)) {
-                        ForEach(ChannelViewMode.allCases, id: \.self) { m in
-                            Text(m.displayName).tag(m)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .controlSize(.regular)
-                    .frame(width: 160)
-                    .accessibilityIdentifier("channel-quality-mode-picker")
-                }
-                .padding(.horizontal, 16)
-                .padding(.top, 16)
+            regulatoryInfoBanner
 
-                regulatoryInfoBanner
-
-                if channels.isEmpty {
-                    Spacer()
-                    Image(systemName: "antenna.radiowaves.left.and.right.slash")
-                        .font(.largeTitle)
-                        .foregroundColor(.secondary)
-                    Text(String(localized: "spectrum.empty.no_channel_data", comment: "Empty state when no channel data exists"))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                } else if mode == .simple {
-                    simpleList
-                } else {
-                    tableView
-                }
+            if channels.isEmpty {
+                Spacer()
+                Image(systemName: "antenna.radiowaves.left.and.right.slash")
+                    .font(.largeTitle)
+                    .foregroundColor(.secondary)
+                Text(String(localized: "spectrum.empty.no_channel_data", comment: "Empty state when no channel data exists"))
+                    .foregroundColor(.secondary)
+                Spacer()
+            } else if mode == .simple {
+                simpleList
+            } else {
+                tableView
+            }
         }
         .frame(minWidth: 700, idealWidth: 1000, minHeight: 600, idealHeight: 700)
     }

--- a/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
+++ b/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
@@ -8,6 +8,19 @@ enum InterfaceViewMode: String, CaseIterable {
     case details
     case monitor
 
+    static func fromToolbarSelection(_ selection: SecondaryToolbarItemID) -> Self {
+        switch selection {
+        case .interfacesSimple:
+            .simple
+        case .interfacesDetails:
+            .details
+        case .interfacesMonitor:
+            .monitor
+        default:
+            .simple
+        }
+    }
+
     var displayName: String {
         switch self {
         case .simple:  String(localized: "channels.mode.simple", comment: "Simple view mode for channel quality")
@@ -18,11 +31,11 @@ enum InterfaceViewMode: String, CaseIterable {
 }
 
 struct InterfacesView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let interfaces: [NetworkInterfaceInfo]
     let scannerViewModel: ScannerViewModel
     let throughputMonitor: ThroughputMonitor
-    @State private var mode: InterfaceViewMode = .simple
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let mode: InterfaceViewMode
     @State private var gatewayLatency: Double?
 
     private var wifiInterface: NetworkInterfaceInfo? {
@@ -31,36 +44,21 @@ struct InterfacesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Mode toggle
-            HStack {
-                    Picker("", selection: $mode.animation(reduceMotion ? nil : .bouncy)) {
-                        ForEach(InterfaceViewMode.allCases, id: \.self) { m in
-                            Text(m.displayName).tag(m)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .controlSize(.regular)
-                    .frame(width: 240)
-                    .accessibilityIdentifier("interfaces-mode-picker")
-                }
-                .padding(.horizontal, 16)
-                .padding(.top, 16)
-
-                if interfaces.isEmpty {
-                    Spacer()
-                    Image(systemName: "wifi.slash")
-                        .font(.largeTitle)
-                        .foregroundColor(.secondary)
-                    Text(String(localized: "interfaces.empty.no_interfaces", comment: "Empty state when no network interfaces exist"))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                } else if mode == .simple {
-                    dashboardView
-                } else if mode == .monitor {
-                    monitorView
-                } else {
-                    detailsView
-                }
+            if interfaces.isEmpty {
+                Spacer()
+                Image(systemName: "wifi.slash")
+                    .font(.largeTitle)
+                    .foregroundColor(.secondary)
+                Text(String(localized: "interfaces.empty.no_interfaces", comment: "Empty state when no network interfaces exist"))
+                    .foregroundColor(.secondary)
+                Spacer()
+            } else if mode == .simple {
+                dashboardView
+            } else if mode == .monitor {
+                monitorView
+            } else {
+                detailsView
+            }
         }
     }
 

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -73,6 +73,22 @@ enum SpectrumMode {
         }
     }
 }
+
+@MainActor
+enum SpectrumRecordingSessionResolver {
+    static func resolve(
+        current: RecordingViewModel?,
+        mode: SpectrumMode,
+        scannerViewModel: ScannerViewModel
+    ) -> RecordingViewModel? {
+        switch mode {
+        case .live:
+            current
+        case .recording:
+            current ?? RecordingViewModel(scannerViewModel: scannerViewModel)
+        }
+    }
+}
 #endif
 
 struct ContentView: View {
@@ -89,7 +105,7 @@ struct ContentView: View {
 
 #if PRO
     let mode: SpectrumMode
-    @State private var recordingViewModel: RecordingViewModel?
+    @Binding var recordingViewModel: RecordingViewModel?
 #endif
 
     private var hiddenColumns: Binding<Set<String>> {
@@ -108,10 +124,22 @@ struct ContentView: View {
         .onChange(of: viewModel.hideHiddenSSIDs) { _, _ in viewModel.applyGlobalFilterToBands() }
 #if PRO
         .onChange(of: mode) { _, newMode in
+            recordingViewModel = SpectrumRecordingSessionResolver.resolve(
+                current: recordingViewModel,
+                mode: newMode,
+                scannerViewModel: viewModel
+            )
             if newMode == .recording {
-                if recordingViewModel == nil {
-                    recordingViewModel = RecordingViewModel(scannerViewModel: viewModel)
-                }
+                recordingViewModel?.checkReadiness()
+            }
+        }
+        .onAppear {
+            recordingViewModel = SpectrumRecordingSessionResolver.resolve(
+                current: recordingViewModel,
+                mode: mode,
+                scannerViewModel: viewModel
+            )
+            if mode == .recording {
                 recordingViewModel?.checkReadiness()
             }
         }
@@ -129,6 +157,17 @@ struct ContentView: View {
         case .recording:
             if let rvm = recordingViewModel {
                 RecordingView(viewModel: rvm)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .task {
+                        recordingViewModel = SpectrumRecordingSessionResolver.resolve(
+                            current: recordingViewModel,
+                            mode: mode,
+                            scannerViewModel: viewModel
+                        )
+                        recordingViewModel?.checkReadiness()
+                    }
             }
         }
 #else

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -60,7 +60,19 @@ struct SpectrumSectionLayout {
 private let headerHeight: CGFloat = SpectrumSectionLayout.headerHeight
 
 #if PRO
-private enum SpectrumMode { case live, recording }
+enum SpectrumMode {
+    case live
+    case recording
+
+    static func fromToolbarSelection(_ selection: SecondaryToolbarItemID) -> Self {
+        switch selection {
+        case .spectrumRecording:
+            .recording
+        default:
+            .live
+        }
+    }
+}
 #endif
 
 struct ContentView: View {
@@ -76,7 +88,7 @@ struct ContentView: View {
     @AppStorage("hiddenTableColumns") private var hiddenColumnsData: String = ""
 
 #if PRO
-    @State private var mode: SpectrumMode = .live
+    let mode: SpectrumMode
     @State private var recordingViewModel: RecordingViewModel?
 #endif
 
@@ -89,9 +101,6 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-#if PRO
-            modeToolbar
-#endif
             contentArea
         }
         .frame(minWidth: 700, idealWidth: 1000, minHeight: 600)
@@ -108,26 +117,6 @@ struct ContentView: View {
         }
 #endif
     }
-
-    // MARK: - Mode toolbar (Pro only)
-
-#if PRO
-    private var modeToolbar: some View {
-        HStack {
-            Picker("", selection: $mode.animation(reduceMotion ? nil : .bouncy)) {
-                Text(String(localized: "spectrum.mode.live", comment: "Live spectrum mode")).tag(SpectrumMode.live)
-                Text(String(localized: "spectrum.mode.recording_page", comment: "Recording page mode")).tag(SpectrumMode.recording)
-            }
-            .pickerStyle(.segmented)
-            .controlSize(.regular)
-            .frame(width: 160)
-            .accessibilityLabel(String(localized: "spectrum.mode.label", comment: "Spectrum view mode picker"))
-            .accessibilityIdentifier("spectrum-mode-picker")
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 16)
-    }
-#endif
 
     // MARK: - Content area
 

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -20,7 +20,9 @@ private struct AppRootView: View {
     @State private var sidebarCollapsed = false
     @AppStorage("hideTitleBadge") private var hideTitleBadge = true
     @AppStorage("bleEnabled") private var bleEnabled: Bool = false
-    @State private var visitedPages: Set<SidebarPage> = [.overview]
+    @State private var secondaryToolbarSelections: [SidebarPage: SecondaryToolbarItemID] = [
+        .channels: .channelsSimple,
+    ]
 
     private var hasLocationAuthorization: Bool {
         viewModel.locationManager.isAuthorizedForSSID
@@ -28,6 +30,44 @@ private struct AppRootView: View {
 
     private var showsLocationPermissionRequiredView: Bool {
         !UITestMode.isActive && selectedPage.requiresLocationAuthorization && !hasLocationAuthorization
+    }
+
+    private var activeSecondaryToolbarDescriptor: SecondaryToolbarDescriptor? {
+        SecondaryToolbarDescriptor.forPage(selectedPage)
+    }
+
+    private var activeSecondaryToolbarSelection: Binding<SecondaryToolbarItemID>? {
+        guard let descriptor = activeSecondaryToolbarDescriptor else { return nil }
+
+        return Binding(
+            get: { secondaryToolbarSelections[selectedPage] ?? descriptor.defaultSelection },
+            set: { secondaryToolbarSelections[selectedPage] = $0 }
+        )
+    }
+
+    private var channelViewMode: ChannelViewMode {
+        ChannelViewMode.fromToolbarSelection(
+            secondaryToolbarSelections[.channels] ?? .channelsSimple
+        )
+    }
+
+    private var interfaceViewMode: InterfaceViewMode {
+        InterfaceViewMode.fromToolbarSelection(
+            secondaryToolbarSelections[.interfaces] ?? .interfacesSimple
+        )
+    }
+
+#if PRO
+    private var spectrumViewMode: SpectrumMode {
+        SpectrumMode.fromToolbarSelection(
+            secondaryToolbarSelections[.spectrum] ?? .spectrumLive
+        )
+    }
+#endif
+
+    private var detailNavigationTitle: String {
+        guard selectedPage != .overview else { return "" }
+        return activeSecondaryToolbarDescriptor == nil ? selectedPage.label : ""
     }
 
     @ViewBuilder
@@ -40,80 +80,67 @@ private struct AppRootView: View {
         } else if !UITestMode.isActive && selectedPage.requiresWiFi && !viewModel.isWiFiAvailable {
             WiFiOffView()
         } else {
-            ZStack {
-                if visitedPages.contains(.overview) {
+            switch selectedPage {
+            case .overview:
+                if DetailPageRenderPolicy.shouldRender(.overview, selectedPage: selectedPage) {
                     OverviewView(viewModel: viewModel)
-                        .opacity(selectedPage == .overview ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .overview)
-                        .disabled(selectedPage != .overview)
                         .accessibilityIdentifier("page-overview")
                 }
-
-                if visitedPages.contains(.spectrum) {
-                    ContentView(viewModel: viewModel)
-                        .opacity(selectedPage == .spectrum ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .spectrum)
-                        .disabled(selectedPage != .spectrum)
+            case .spectrum:
+                if DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: selectedPage) {
+#if PRO
+                    ContentView(viewModel: viewModel, mode: spectrumViewMode)
                         .accessibilityIdentifier("page-spectrum")
+#else
+                    ContentView(viewModel: viewModel)
+                        .accessibilityIdentifier("page-spectrum")
+#endif
                 }
-
-                if visitedPages.contains(.channels) {
-                    ChannelQualityView(channels: viewModel.channelRecommendations)
-                        .opacity(selectedPage == .channels ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .channels)
-                        .disabled(selectedPage != .channels)
+            case .channels:
+                if DetailPageRenderPolicy.shouldRender(.channels, selectedPage: selectedPage) {
+                    ChannelQualityView(
+                        channels: viewModel.channelRecommendations,
+                        mode: channelViewMode
+                    )
                         .accessibilityIdentifier("page-channels")
                 }
-
-                if visitedPages.contains(.interfaces) {
-                    InterfacesView(interfaces: viewModel.networkInfo, scannerViewModel: viewModel, throughputMonitor: viewModel.throughputMonitor)
-                        .opacity(selectedPage == .interfaces ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .interfaces)
-                        .disabled(selectedPage != .interfaces)
+            case .interfaces:
+                if DetailPageRenderPolicy.shouldRender(.interfaces, selectedPage: selectedPage) {
+                    InterfacesView(
+                        interfaces: viewModel.networkInfo,
+                        scannerViewModel: viewModel,
+                        throughputMonitor: viewModel.throughputMonitor,
+                        mode: interfaceViewMode
+                    )
                         .accessibilityIdentifier("page-interfaces")
                 }
-
-                if visitedPages.contains(.roaming) {
+            case .roaming:
+                if DetailPageRenderPolicy.shouldRender(.roaming, selectedPage: selectedPage) {
                     RoamingTestView(viewModel: roamingViewModel)
-                        .opacity(selectedPage == .roaming ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .roaming)
-                        .disabled(selectedPage != .roaming)
                         .accessibilityIdentifier("page-roaming")
                 }
-
-                if visitedPages.contains(.bleScanner) {
+            case .bleScanner:
+                if DetailPageRenderPolicy.shouldRender(.bleScanner, selectedPage: selectedPage) {
                     BLEScannerView(viewModel: bleViewModel, bleEnabled: bleEnabled)
-                        .opacity(selectedPage == .bleScanner ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .bleScanner)
-                        .disabled(selectedPage != .bleScanner)
                         .accessibilityIdentifier("page-bleScanner")
                 }
-
-                if visitedPages.contains(.settings) {
+            case .settings:
+                if DetailPageRenderPolicy.shouldRender(.settings, selectedPage: selectedPage) {
                     SettingsView(updater: sparkleUpdater, locationPermission: viewModel.locationManager, bluetoothPermission: bleViewModel?.bluetoothPermission, bleEnabled: $bleEnabled)
-                        .opacity(selectedPage == .settings ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .settings)
-                        .disabled(selectedPage != .settings)
                         .accessibilityIdentifier("page-settings")
                 }
-
-#if DEBUG
-                if visitedPages.contains(.spectrumDebugChart) {
+            #if DEBUG
+            case .spectrumDebugChart:
+                if DetailPageRenderPolicy.shouldRender(.spectrumDebugChart, selectedPage: selectedPage) {
                     SpectrumDebugContainerView()
-                        .opacity(selectedPage == .spectrumDebugChart ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .spectrumDebugChart)
-                        .disabled(selectedPage != .spectrumDebugChart)
                         .accessibilityIdentifier("page-spectrumDebugChart")
                 }
-
-                if visitedPages.contains(.debugChart) {
+            case .debugChart:
+                if DetailPageRenderPolicy.shouldRender(.debugChart, selectedPage: selectedPage) {
                     DebugContainerView()
-                        .opacity(selectedPage == .debugChart ? 1 : 0)
-                        .allowsHitTesting(selectedPage == .debugChart)
-                        .disabled(selectedPage != .debugChart)
                         .accessibilityIdentifier("page-debugChart")
                 }
-#endif
+            #endif
             }
         }
     }
@@ -138,7 +165,6 @@ private struct AppRootView: View {
                 detailContent
             }
             .onChange(of: selectedPage) { _, newPage in
-                visitedPages.insert(newPage)
                 let spectrumVisible = newPage == .spectrum
                 for vm in viewModel.allBandViewModels {
                     vm.isViewVisible = spectrumVisible
@@ -158,7 +184,7 @@ private struct AppRootView: View {
                 ScrollView { Text(crashLogText).font(.caption.monospaced()).textSelection(.enabled) }
                     .frame(maxHeight: 200)
             }
-            .navigationTitle(selectedPage == .overview ? "" : selectedPage.label)
+            .navigationTitle(detailNavigationTitle)
             .alert(String(localized: "permission.location.services_required_title", comment: "Alert title: Location Services permission needed"), isPresented: $viewModel.locationManager.showDeniedAlert) {
                 Button(String(localized: "common.action.open_system_settings", comment: "Button to open macOS System Settings")) {
                     viewModel.locationManager.openLocationPreferences()
@@ -168,12 +194,17 @@ private struct AppRootView: View {
                 Text(String(localized: "permission.location.services_required_message", comment: "Alert message explaining why Location Services is required"))
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                if let descriptor = activeSecondaryToolbarDescriptor,
+                   let selection = activeSecondaryToolbarSelection {
+                    SecondaryToolbarCapsule(descriptor: descriptor, selection: selection)
+                }
+            }
+        }
         .background(WindowAccessor { window in
             window?.setFrameAutosaveName("WiFiLensMainWindow")
         })
-        .onAppear {
-            visitedPages.insert(selectedPage)
-        }
         .task {
             await viewModel.start()
             roamingViewModel.handleWiFiPowerStateChange(viewModel.wifiPowerState)

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -83,14 +83,13 @@ private struct AppRootView: View {
         } else if !UITestMode.isActive && selectedPage.requiresWiFi && !viewModel.isWiFiAvailable {
             WiFiOffView()
         } else {
-            switch selectedPage {
-            case .overview:
-                if DetailPageRenderPolicy.shouldRender(.overview, selectedPage: selectedPage) {
-                    OverviewView(viewModel: viewModel)
-                        .accessibilityIdentifier("page-overview")
-                }
-            case .spectrum:
-                if DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: selectedPage) {
+            ZStack {
+                OverviewView(viewModel: viewModel)
+                    .opacity(selectedPage == .overview ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .overview)
+                    .accessibilityIdentifier("page-overview")
+
+                if selectedPage == .spectrum {
 #if PRO
                     ContentView(
                         viewModel: viewModel,
@@ -103,16 +102,16 @@ private struct AppRootView: View {
                         .accessibilityIdentifier("page-spectrum")
 #endif
                 }
-            case .channels:
-                if DetailPageRenderPolicy.shouldRender(.channels, selectedPage: selectedPage) {
-                    ChannelQualityView(
-                        channels: viewModel.channelRecommendations,
-                        mode: channelViewMode
-                    )
-                        .accessibilityIdentifier("page-channels")
-                }
-            case .interfaces:
-                if DetailPageRenderPolicy.shouldRender(.interfaces, selectedPage: selectedPage) {
+
+                ChannelQualityView(
+                    channels: viewModel.channelRecommendations,
+                    mode: channelViewMode
+                )
+                    .opacity(selectedPage == .channels ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .channels)
+                    .accessibilityIdentifier("page-channels")
+
+                if selectedPage == .interfaces {
                     InterfacesView(
                         interfaces: viewModel.networkInfo,
                         scannerViewModel: viewModel,
@@ -121,33 +120,33 @@ private struct AppRootView: View {
                     )
                         .accessibilityIdentifier("page-interfaces")
                 }
-            case .roaming:
-                if DetailPageRenderPolicy.shouldRender(.roaming, selectedPage: selectedPage) {
-                    RoamingTestView(viewModel: roamingViewModel)
-                        .accessibilityIdentifier("page-roaming")
-                }
-            case .bleScanner:
-                if DetailPageRenderPolicy.shouldRender(.bleScanner, selectedPage: selectedPage) {
-                    BLEScannerView(viewModel: bleViewModel, bleEnabled: bleEnabled)
-                        .accessibilityIdentifier("page-bleScanner")
-                }
-            case .settings:
-                if DetailPageRenderPolicy.shouldRender(.settings, selectedPage: selectedPage) {
-                    SettingsView(updater: sparkleUpdater, locationPermission: viewModel.locationManager, bluetoothPermission: bleViewModel?.bluetoothPermission, bleEnabled: $bleEnabled)
-                        .accessibilityIdentifier("page-settings")
-                }
-            #if DEBUG
-            case .spectrumDebugChart:
-                if DetailPageRenderPolicy.shouldRender(.spectrumDebugChart, selectedPage: selectedPage) {
-                    SpectrumDebugContainerView()
-                        .accessibilityIdentifier("page-spectrumDebugChart")
-                }
-            case .debugChart:
-                if DetailPageRenderPolicy.shouldRender(.debugChart, selectedPage: selectedPage) {
-                    DebugContainerView()
-                        .accessibilityIdentifier("page-debugChart")
-                }
-            #endif
+
+                RoamingTestView(viewModel: roamingViewModel)
+                    .opacity(selectedPage == .roaming ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .roaming)
+                    .accessibilityIdentifier("page-roaming")
+
+                BLEScannerView(viewModel: bleViewModel, bleEnabled: bleEnabled)
+                    .opacity(selectedPage == .bleScanner ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .bleScanner)
+                    .accessibilityIdentifier("page-bleScanner")
+
+                SettingsView(updater: sparkleUpdater, locationPermission: viewModel.locationManager, bluetoothPermission: bleViewModel?.bluetoothPermission, bleEnabled: $bleEnabled)
+                    .opacity(selectedPage == .settings ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .settings)
+                    .accessibilityIdentifier("page-settings")
+
+#if DEBUG
+                SpectrumDebugContainerView()
+                    .opacity(selectedPage == .spectrumDebugChart ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .spectrumDebugChart)
+                    .accessibilityIdentifier("page-spectrumDebugChart")
+
+                DebugContainerView()
+                    .opacity(selectedPage == .debugChart ? 1 : 0)
+                    .allowsHitTesting(selectedPage == .debugChart)
+                    .accessibilityIdentifier("page-debugChart")
+#endif
             }
         }
     }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -23,6 +23,9 @@ private struct AppRootView: View {
     @State private var secondaryToolbarSelections: [SidebarPage: SecondaryToolbarItemID] = [
         .channels: .channelsSimple,
     ]
+#if PRO
+    @State private var spectrumRecordingViewModel: RecordingViewModel?
+#endif
 
     private var hasLocationAuthorization: Bool {
         viewModel.locationManager.isAuthorizedForSSID
@@ -89,7 +92,11 @@ private struct AppRootView: View {
             case .spectrum:
                 if DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: selectedPage) {
 #if PRO
-                    ContentView(viewModel: viewModel, mode: spectrumViewMode)
+                    ContentView(
+                        viewModel: viewModel,
+                        mode: spectrumViewMode,
+                        recordingViewModel: $spectrumRecordingViewModel
+                    )
                         .accessibilityIdentifier("page-spectrum")
 #else
                     ContentView(viewModel: viewModel)

--- a/WiFiLens/Tests/WiFiLensTests/ChannelQualityViewModeTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelQualityViewModeTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import WiFi_Lens
+
+struct ChannelQualityViewModeTests {
+
+    @Test func channelsToolbarSelectionMapsToSimpleMode() {
+        #expect(ChannelViewMode.fromToolbarSelection(.channelsSimple) == .simple)
+    }
+
+    @Test func channelsToolbarSelectionMapsToTableMode() {
+        #expect(ChannelViewMode.fromToolbarSelection(.channelsTable) == .table)
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
@@ -7,40 +7,35 @@ struct SecondaryToolbarAttachmentTests {
         #expect(SecondaryToolbarDescriptor.forPage(.channels) != nil)
     }
 
-@Test func overviewPageProvidesNoSecondaryToolbarDescriptor() {
-    #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
-}
+    @Test func overviewPageProvidesNoSecondaryToolbarDescriptor() {
+        #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
+    }
 
-@Test func detailPageRenderPolicy_onlyRendersSelectedPage() {
-    #expect(DetailPageRenderPolicy.shouldRender(.interfaces, selectedPage: .interfaces))
-    #expect(!DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: .interfaces))
-}
+    #if PRO
+    @Test func spectrumRecordingSessionResolver_preservesExistingViewModel() {
+        let scannerViewModel = ScannerViewModel()
+        let existing = RecordingViewModel(scannerViewModel: scannerViewModel)
 
-#if PRO
-@Test func spectrumRecordingSessionResolver_preservesExistingViewModel() {
-    let scannerViewModel = ScannerViewModel()
-    let existing = RecordingViewModel(scannerViewModel: scannerViewModel)
+        let resolved = SpectrumRecordingSessionResolver.resolve(
+            current: existing,
+            mode: .recording,
+            scannerViewModel: scannerViewModel
+        )
 
-    let resolved = SpectrumRecordingSessionResolver.resolve(
-        current: existing,
-        mode: .recording,
-        scannerViewModel: scannerViewModel
-    )
+        #expect(resolved === existing)
+    }
 
-    #expect(resolved === existing)
-}
+    @Test func spectrumRecordingSessionResolver_createsViewModelWhenMissing() {
+        let scannerViewModel = ScannerViewModel()
 
-@Test func spectrumRecordingSessionResolver_createsViewModelWhenMissing() {
-    let scannerViewModel = ScannerViewModel()
+        let resolved = SpectrumRecordingSessionResolver.resolve(
+            current: nil,
+            mode: .recording,
+            scannerViewModel: scannerViewModel
+        )
 
-    let resolved = SpectrumRecordingSessionResolver.resolve(
-        current: nil,
-        mode: .recording,
-        scannerViewModel: scannerViewModel
-    )
-
-    #expect(resolved != nil)
-    #expect(resolved?.scannerViewModel === scannerViewModel)
-}
-#endif
+        #expect(resolved != nil)
+        #expect(resolved?.scannerViewModel === scannerViewModel)
+    }
+    #endif
 }

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
@@ -15,4 +15,32 @@ struct SecondaryToolbarAttachmentTests {
     #expect(DetailPageRenderPolicy.shouldRender(.interfaces, selectedPage: .interfaces))
     #expect(!DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: .interfaces))
 }
+
+#if PRO
+@Test func spectrumRecordingSessionResolver_preservesExistingViewModel() {
+    let scannerViewModel = ScannerViewModel()
+    let existing = RecordingViewModel(scannerViewModel: scannerViewModel)
+
+    let resolved = SpectrumRecordingSessionResolver.resolve(
+        current: existing,
+        mode: .recording,
+        scannerViewModel: scannerViewModel
+    )
+
+    #expect(resolved === existing)
+}
+
+@Test func spectrumRecordingSessionResolver_createsViewModelWhenMissing() {
+    let scannerViewModel = ScannerViewModel()
+
+    let resolved = SpectrumRecordingSessionResolver.resolve(
+        current: nil,
+        mode: .recording,
+        scannerViewModel: scannerViewModel
+    )
+
+    #expect(resolved != nil)
+    #expect(resolved?.scannerViewModel === scannerViewModel)
+}
+#endif
 }

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import WiFi_Lens
+
+struct SecondaryToolbarAttachmentTests {
+
+    @Test func channelsPageProvidesSecondaryToolbarDescriptor() {
+        #expect(SecondaryToolbarDescriptor.forPage(.channels) != nil)
+    }
+
+@Test func overviewPageProvidesNoSecondaryToolbarDescriptor() {
+    #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
+}
+
+@Test func detailPageRenderPolicy_onlyRendersSelectedPage() {
+    #expect(DetailPageRenderPolicy.shouldRender(.interfaces, selectedPage: .interfaces))
+    #expect(!DetailPageRenderPolicy.shouldRender(.spectrum, selectedPage: .interfaces))
+}
+}

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift
@@ -1,7 +1,9 @@
+import AppKit
 import SwiftUI
 import Testing
 @testable import WiFi_Lens
 
+@MainActor
 struct SecondaryToolbarCapsuleTests {
 
     @Test func capsuleSelectionUpdatesBinding() {
@@ -14,5 +16,46 @@ struct SecondaryToolbarCapsuleTests {
         binding.wrappedValue = .channelsTable
 
         #expect(selection == .channelsTable)
+    }
+
+    @Test func capsuleCoordinatorSelectionDidChangeUpdatesBinding() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)!
+        var selection: SecondaryToolbarItemID = .channelsSimple
+        let coordinator = SecondaryToolbarCapsule.Coordinator(
+            selection: Binding(
+                get: { selection },
+                set: { selection = $0 }
+            ),
+            itemIDs: descriptor.items.map(\.id)
+        )
+        let control = SecondaryToolbarCapsule.makeControl(
+            descriptor: descriptor,
+            selection: .channelsSimple,
+            target: coordinator,
+            action: #selector(SecondaryToolbarCapsule.Coordinator.selectionDidChange(_:))
+        )
+
+        control.selectedSegment = 1
+        coordinator.selectionDidChange(control)
+
+        #expect(selection == .channelsTable)
+    }
+
+    @Test func capsuleControlExposesStableAccessibilityIdentifiers() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)!
+        let control = SecondaryToolbarCapsule.makeControl(
+            descriptor: descriptor,
+            selection: .channelsSimple,
+            target: nil,
+            action: nil
+        )
+
+        #expect(control.accessibilityIdentifier() == "secondary-toolbar")
+        let children = control.accessibilityChildren() as? [NSAccessibilityElement]
+        #expect(children?.count == 2)
+        #expect(children?.map { $0.accessibilityIdentifier() ?? "" } == [
+            "secondary-toolbar-channels-simple",
+            "secondary-toolbar-channels-table",
+        ])
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import Testing
+@testable import WiFi_Lens
+
+struct SecondaryToolbarCapsuleTests {
+
+    @Test func capsuleSelectionUpdatesBinding() {
+        var selection: SecondaryToolbarItemID = .channelsSimple
+        let binding = Binding(
+            get: { selection },
+            set: { selection = $0 }
+        )
+
+        binding.wrappedValue = .channelsTable
+
+        #expect(selection == .channelsTable)
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarDescriptorExpansionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarDescriptorExpansionTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import WiFi_Lens
+
+struct SecondaryToolbarDescriptorExpansionTests {
+
+    @Test func interfacesPageProvidesSecondaryToolbarDescriptor() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.interfaces)
+        #expect(descriptor != nil)
+        #expect(descriptor?.items.map(\.id) == [.interfacesSimple, .interfacesDetails, .interfacesMonitor])
+    }
+
+#if PRO
+    @Test func spectrumPageProvidesSecondaryToolbarDescriptor() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.spectrum)
+        #expect(descriptor != nil)
+        #expect(descriptor?.items.map(\.id) == [.spectrumLive, .spectrumRecording])
+    }
+#endif
+}

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import WiFi_Lens
+
+struct SecondaryToolbarTests {
+
+    @Test func secondaryToolbarDescriptor_isNilForOverview() {
+        #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
+    }
+
+    @Test func secondaryToolbarDescriptor_channelsContainsTwoItems() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)
+        #expect(descriptor != nil)
+        #expect(descriptor?.items.map(\.id) == [.channelsSimple, .channelsTable])
+        #expect(descriptor?.defaultSelection == .channelsSimple)
+    }
+
+    @Test func secondaryToolbarDescriptor_selectionIndexMatchesItemOrder() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)
+        #expect(descriptor?.selectionIndex(for: .channelsSimple) == 0)
+        #expect(descriptor?.selectionIndex(for: .channelsTable) == 1)
+    }
+
+    @Test func secondaryToolbarDescriptor_itemIDAtIndexMatchesOrder() {
+        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)
+        #expect(descriptor?.itemID(at: 0) == .channelsSimple)
+        #expect(descriptor?.itemID(at: 1) == .channelsTable)
+        #expect(descriptor?.itemID(at: 2) == nil)
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift
@@ -19,11 +19,4 @@ struct SecondaryToolbarTests {
         #expect(descriptor?.selectionIndex(for: .channelsSimple) == 0)
         #expect(descriptor?.selectionIndex(for: .channelsTable) == 1)
     }
-
-    @Test func secondaryToolbarDescriptor_itemIDAtIndexMatchesOrder() {
-        let descriptor = SecondaryToolbarDescriptor.forPage(.channels)
-        #expect(descriptor?.itemID(at: 0) == .channelsSimple)
-        #expect(descriptor?.itemID(at: 1) == .channelsTable)
-        #expect(descriptor?.itemID(at: 2) == nil)
-    }
 }

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -53,6 +53,11 @@
 		896F4371837628B3E6454853 /* SignalProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786042C29EF01CE698FEBBF8 /* SignalProcessingTests.swift */; };
 		8C78C6A4ACEDAD6EA5CCD90E /* BLETrendChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAECBD60DDB96A1E8D5835 /* BLETrendChartView.swift */; };
 		90CF4B22A68C668A58043390 /* RegulatoryDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07A4C1B8DFCDFBA81A6DFFA /* RegulatoryDatabaseTests.swift */; };
+		A10000000000000000000011 /* SecondaryToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* SecondaryToolbarTests.swift */; };
+		A10000000000000000000012 /* SecondaryToolbarCapsuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000004 /* SecondaryToolbarCapsuleTests.swift */; };
+		A10000000000000000000013 /* SecondaryToolbarAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000005 /* SecondaryToolbarAttachmentTests.swift */; };
+		A10000000000000000000014 /* ChannelQualityViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000006 /* ChannelQualityViewModeTests.swift */; };
+		A10000000000000000000015 /* SecondaryToolbarDescriptorExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000009 /* SecondaryToolbarDescriptorExpansionTests.swift */; };
 		9E204E0C8B6D8E29583263B0 /* ScannerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E044182AAA5DC5A000A0D69 /* ScannerModelTests.swift */; };
 		9E2F89530D1114DBFAB705F3 /* WiFiLensApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831E90D5B9D07C478A35DD14 /* WiFiLensApp.swift */; };
 		9F1D29EF11E510D9D72BB7D1 /* CWChannel+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5DDCE8EACD706BD2BCEE4B /* CWChannel+Extensions.swift */; };
@@ -138,6 +143,10 @@
 		FB1E326C2FC7316C009D1BDC /* DebugRoamingChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB92F9262FBE208500BCEC67 /* DebugRoamingChartView.swift */; };
 		FB1E326D2FC7316C009D1BDC /* SSIDColorHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD8F4CBC15819F4DB5C5510 /* SSIDColorHasher.swift */; };
 		FB1E326E2FC7316C009D1BDC /* ScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74387CFA1E33037E9F1888E /* ScannerViewModel.swift */; };
+		A10000000000000000000021 /* SecondaryToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000007 /* SecondaryToolbar.swift */; };
+		A10000000000000000000022 /* SecondaryToolbarCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000008 /* SecondaryToolbarCapsule.swift */; };
+		A10000000000000000000023 /* SecondaryToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000007 /* SecondaryToolbar.swift */; };
+		A10000000000000000000024 /* SecondaryToolbarCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000008 /* SecondaryToolbarCapsule.swift */; };
 		FB1E32702FC7316C009D1BDC /* ChartTimeFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9B7F382FC2D9650057B038 /* ChartTimeFormatting.swift */; };
 		FB1E32712FC7316C009D1BDC /* ChartGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9B7F362FC2D9650057B038 /* ChartGeometry.swift */; };
 		FB1E32722FC7316C009D1BDC /* SplineInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9B7F392FC2D9650057B038 /* SplineInterpolation.swift */; };
@@ -307,6 +316,13 @@
 		8A7A45AB88716DC3AC18610B /* ChartViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewTests.swift; sourceTree = "<group>"; };
 		8B5143599E254B3367AFD37C /* NetworkTableRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowTests.swift; sourceTree = "<group>"; };
 		8F405489976429A068F15F86 /* WiFiLensTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WiFiLensTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000003 /* SecondaryToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000004 /* SecondaryToolbarCapsuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarCapsuleTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000005 /* SecondaryToolbarAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarAttachmentTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000006 /* ChannelQualityViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelQualityViewModeTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000007 /* SecondaryToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbar.swift; sourceTree = "<group>"; };
+		A10000000000000000000008 /* SecondaryToolbarCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarCapsule.swift; sourceTree = "<group>"; };
+		A10000000000000000000009 /* SecondaryToolbarDescriptorExpansionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarDescriptorExpansionTests.swift; sourceTree = "<group>"; };
 		8FD8F4CBC15819F4DB5C5510 /* SSIDColorHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSIDColorHasher.swift; sourceTree = "<group>"; };
 		9C5DDCE8EACD706BD2BCEE4B /* CWChannel+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CWChannel+Extensions.swift"; sourceTree = "<group>"; };
 		9E84926DD82E4B90B6509CD8 /* GlassBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassBackground.swift; sourceTree = "<group>"; };
@@ -575,6 +591,8 @@
 		AD735352E4FE8FE0803C143C /* App */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000007 /* SecondaryToolbar.swift */,
+				A10000000000000000000008 /* SecondaryToolbarCapsule.swift */,
 				FB0573B92FBBFC31005F8214 /* SidebarView.swift */,
 				FBB2CA8B2FC0E14000FC2D2C /* BuildConfig.swift */,
 				FBB2CA8C2FC0E14000FC2D2C /* TitleBadge.swift */,
@@ -810,6 +828,7 @@
 			children = (
 				B06040A5BF8B6FAF01FFB696 /* BLEModelTests.swift */,
 				FC084FA8AE0EE5E703D922DA /* BandChartViewModelTests.swift */,
+				A10000000000000000000006 /* ChannelQualityViewModeTests.swift */,
 				5BCB49F38A652E6A07BD027F /* ChannelQualityCalculatorTests.swift */,
 				B77C42448FC4F5A8180F9885 /* ChannelSpanCalculatorTests.swift */,
 				E83547C1A36ADDD9E827B26A /* ChartUtilityTests.swift */,
@@ -826,6 +845,10 @@
 				2DB542909E9B4730B02260F1 /* RegulatoryModelTests.swift */,
 				5CE94087AFA3CB5A003A5012 /* RoamingModelTests.swift */,
 				C70E4041B5972D72DD79BF56 /* RoamingTestViewModelTests.swift */,
+				A10000000000000000000005 /* SecondaryToolbarAttachmentTests.swift */,
+				A10000000000000000000004 /* SecondaryToolbarCapsuleTests.swift */,
+				A10000000000000000000009 /* SecondaryToolbarDescriptorExpansionTests.swift */,
+				A10000000000000000000003 /* SecondaryToolbarTests.swift */,
 				33A24CA582895A784C2E6014 /* SSIDColorHasherTests.swift */,
 				7E044182AAA5DC5A000A0D69 /* ScannerModelTests.swift */,
 				786042C29EF01CE698FEBBF8 /* SignalProcessingTests.swift */,
@@ -1076,6 +1099,8 @@
 				FB92F9282FBE208500BCEC67 /* DebugRoamingChartView.swift in Sources */,
 				A952EA4DBE85899D61989DF9 /* SSIDColorHasher.swift in Sources */,
 				DA7DEF71C1E8ED4068EB7D66 /* ScannerViewModel.swift in Sources */,
+				A10000000000000000000021 /* SecondaryToolbar.swift in Sources */,
+				A10000000000000000000022 /* SecondaryToolbarCapsule.swift in Sources */,
 				C1D2E3F4A5B6123456780001 /* WiFiPowerMonitor.swift in Sources */,
 				FB9B7F3B2FC2D9650057B038 /* ChartTimeFormatting.swift in Sources */,
 				FB9B7F4C2FC2D9650057B038 /* ChartTypes.swift in Sources */,
@@ -1131,6 +1156,7 @@
 			files = (
 				67B6475699ADED9C42E8F7CC /* BLEModelTests.swift in Sources */,
 				2A8E470AAD8FCE2CC1D14305 /* BandChartViewModelTests.swift in Sources */,
+				A10000000000000000000014 /* ChannelQualityViewModeTests.swift in Sources */,
 				AA4D4D9D9D1C2FA5D32CC290 /* ChannelQualityCalculatorTests.swift in Sources */,
 				122F4DD99EC9891A0BD9ECFE /* ChannelSpanCalculatorTests.swift in Sources */,
 				19134AC983FA95FB8033EB8F /* ChartUtilityTests.swift in Sources */,
@@ -1147,6 +1173,10 @@
 				DFB84AA1AE224EE57DFCBB16 /* RegulatoryModelTests.swift in Sources */,
 				63C14F72B35F2CC98430CFA0 /* RoamingModelTests.swift in Sources */,
 				869A4E799B9BF9BB3D1FBCF9 /* RoamingTestViewModelTests.swift in Sources */,
+				A10000000000000000000013 /* SecondaryToolbarAttachmentTests.swift in Sources */,
+				A10000000000000000000012 /* SecondaryToolbarCapsuleTests.swift in Sources */,
+				A10000000000000000000015 /* SecondaryToolbarDescriptorExpansionTests.swift in Sources */,
+				A10000000000000000000011 /* SecondaryToolbarTests.swift in Sources */,
 				62A04C6993321BEA64FC8E7D /* SSIDColorHasherTests.swift in Sources */,
 				9E204E0C8B6D8E29583263B0 /* ScannerModelTests.swift in Sources */,
 				896F4371837628B3E6454853 /* SignalProcessingTests.swift in Sources */,
@@ -1205,6 +1235,8 @@
 				FB1E326C2FC7316C009D1BDC /* DebugRoamingChartView.swift in Sources */,
 				FB1E326D2FC7316C009D1BDC /* SSIDColorHasher.swift in Sources */,
 				FB1E326E2FC7316C009D1BDC /* ScannerViewModel.swift in Sources */,
+				A10000000000000000000023 /* SecondaryToolbar.swift in Sources */,
+				A10000000000000000000024 /* SecondaryToolbarCapsule.swift in Sources */,
 				A1B2C3D4E5F6789012340001 /* WiFiPowerMonitor.swift in Sources */,
 				FB1E32702FC7316C009D1BDC /* ChartTimeFormatting.swift in Sources */,
 				FB9B7F4E2FC2D9650057B038 /* ChartTypes.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/xcshareddata/xcschemes/WiFi Lens.xcscheme
+++ b/WiFiLens/WiFiLens.xcodeproj/xcshareddata/xcschemes/WiFi Lens.xcscheme
@@ -49,6 +49,17 @@
             useTestTargetApplicationEnvironment = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "32B8DFED1C1CBAD8FD8C797C"
+               BuildableName = "WiFiLensTests.xctest"
+               BlueprintName = "WiFiLensTests"
+               ReferencedContainer = "container:WiFiLens.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            useTestTargetApplicationEnvironment = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "FBA000070000000000000007"
                BuildableName = "WiFiLensUITests.xctest"
                BlueprintName = "WiFiLensUITests"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,6 +69,9 @@ Chart Engine (Charts/):
 - `ScannerViewModel.scanIntervalSeconds` supports dynamic override — external code (e.g., recording feature in Pro submodule, see `Pro/docs/ARCHITECTURE.md`) can set it to a custom value and restore the UserDefaults-configured value on stop. The `didSet` automatically cancels and restarts the scan loop with the new interval when `isScanning` is true. This prevents chart domains driven by real-time `Date()` from pulling ahead of data points (gated by scan interval).
 - `StableScore` provides hysteresis for quality level boundaries (upgrade margin 2, downgrade margin 5)
 - `ChannelBand(id:)` failable initializer maps String band IDs ("24"/"5"/"6") to enum cases, used by `SnapshotToChartAdapter` for history playback
+- Page-internal secondary navigation is hosted in the real window toolbar principal area, while the sidebar remains the primary top-level navigator
+- `AppRootView` owns the active `SecondaryToolbarDescriptor` and per-page selection state for shared business-page mode switching
+- Pages that participate in the shared secondary toolbar consume root-owned mode state instead of rendering their own local segmented controls
 
 ## Localization
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -12,3 +12,4 @@
 ## Notes
 
 - This issue list focuses on behaviour-vs-expectations gaps, state-refresh defects, and structural patterns that make completeness hard to assess.
+- `SecondaryToolbarCapsule.swift` — `NSSegmentedControl.role = .valueSelection` (macOS 27 API) is commented out until CI Xcode ships the macOS 27+ SDK. Re-enable when `Xcode_27.app` or later is available on the runner.

--- a/docs/superpowers/plans/2026-06-19-window-toolbar-secondary-navigation.md
+++ b/docs/superpowers/plans/2026-06-19-window-toolbar-secondary-navigation.md
@@ -1,0 +1,585 @@
+# Window Toolbar Secondary Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move page-internal mode switching for business pages into the real macOS window toolbar principal area, starting with `Channels`, while preserving the sidebar as the primary page navigator.
+
+**Architecture:** Introduce a root-owned secondary-toolbar state model in `AppRootView`, let each `SidebarPage` declare optional secondary toolbar content, and render a custom capsule control through `ToolbarItem(placement: .principal)`. Lift local page mode state out of page views so toolbar interaction is driven by root state instead of page-local `@State`.
+
+**Tech Stack:** SwiftUI, macOS window toolbar APIs, existing `glassBackground` utility, Swift Testing, Xcode project/scheme setup in `WiFiLens.xcodeproj`
+
+## Global Constraints
+
+- Use real SwiftUI window toolbar APIs; do not use overlay-based fake titlebar UI.
+- Do not inject custom AppKit views into titlebar button superviews or other private hierarchy surfaces.
+- Sidebar remains the primary top-level navigation; the toolbar only handles page-internal secondary switching.
+- Pages without secondary navigation, including `Overview`, must not show the principal toolbar capsule.
+- New user-facing strings must use `String(localized:)` and be added manually to `Resources/Localizable.xcstrings` only if new copy is introduced.
+- All new `.swift` source files must be added to both `WiFiLens` and `WiFiLensPro` targets if new files are created.
+- Default verification is `xcodebuild ... build` plus `-only-testing:WiFiLensTests`; do not run UI test bundles unless explicitly requested.
+
+---
+
+### Task 1: Define Root-Owned Secondary Toolbar State
+
+**Files:**
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift`
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SidebarView.swift`
+- Create: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift`
+- Test: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift`
+
+**Interfaces:**
+- Consumes: `SidebarPage`
+- Produces:
+  - `enum SecondaryToolbarItemID: Hashable`
+  - `struct SecondaryToolbarItem: Identifiable, Equatable`
+  - `struct SecondaryToolbarDescriptor: Equatable`
+  - `extension SidebarPage { var supportsSecondaryToolbar: Bool }`
+  - Root state entries for page-specific secondary selections
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import WiFiLens
+
+@Test func secondaryToolbarDescriptor_isNilForOverview() {
+    #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
+}
+
+@Test func secondaryToolbarDescriptor_channelsContainsTwoItems() {
+    let descriptor = SecondaryToolbarDescriptor.forPage(.channels)
+    #expect(descriptor != nil)
+    #expect(descriptor?.items.map(\.id) == [.channelsSimple, .channelsTable])
+    #expect(descriptor?.defaultSelection == .channelsSimple)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarTests
+```
+
+Expected: FAIL because `SecondaryToolbarDescriptor` and related symbols do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import SwiftUI
+
+enum SecondaryToolbarItemID: Hashable {
+    case channelsSimple
+    case channelsTable
+}
+
+struct SecondaryToolbarItem: Identifiable, Equatable {
+    let id: SecondaryToolbarItemID
+    let titleKey: String
+}
+
+struct SecondaryToolbarDescriptor: Equatable {
+    let items: [SecondaryToolbarItem]
+    let defaultSelection: SecondaryToolbarItemID
+
+    static func forPage(_ page: SidebarPage) -> Self? {
+        switch page {
+        case .channels:
+            Self(
+                items: [
+                    SecondaryToolbarItem(id: .channelsSimple, titleKey: "channels.mode.simple"),
+                    SecondaryToolbarItem(id: .channelsTable, titleKey: "channels.mode.professional")
+                ],
+                defaultSelection: .channelsSimple
+            )
+        default:
+            nil
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Wire root-owned selection state in `WiFiLensApp.swift`**
+
+```swift
+@State private var secondaryToolbarSelections: [SidebarPage: SecondaryToolbarItemID] = [
+    .channels: .channelsSimple
+]
+
+private var activeSecondaryToolbarDescriptor: SecondaryToolbarDescriptor? {
+    SecondaryToolbarDescriptor.forPage(selectedPage)
+}
+
+private var activeSecondaryToolbarSelection: Binding<SecondaryToolbarItemID>? {
+    guard let descriptor = activeSecondaryToolbarDescriptor else { return nil }
+    return Binding(
+        get: { secondaryToolbarSelections[selectedPage] ?? descriptor.defaultSelection },
+        set: { secondaryToolbarSelections[selectedPage] = $0 }
+    )
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarTests
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarTests.swift
+git commit -m "feat: add root secondary toolbar model"
+```
+
+### Task 2: Build the Custom Capsule Toolbar Control
+
+**Files:**
+- Create: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift`
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Utilities/GlassBackground.swift`
+- Test: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift`
+
+**Interfaces:**
+- Consumes: `SecondaryToolbarDescriptor`, `Binding<SecondaryToolbarItemID>`
+- Produces:
+  - `struct SecondaryToolbarCapsule: View`
+  - Selection callback via binding
+  - Stable accessibility identifiers per segment
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import WiFiLens
+
+@Test func capsuleSelectionUpdatesBinding() {
+    var selection: SecondaryToolbarItemID = .channelsSimple
+    let binding = Binding(
+        get: { selection },
+        set: { selection = $0 }
+    )
+
+    binding.wrappedValue = .channelsTable
+    #expect(selection == .channelsTable)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails only if needed**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarCapsuleTests
+```
+
+Expected: FAIL before file exists, then PASS once basic binding-backed view is added.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```swift
+import SwiftUI
+
+struct SecondaryToolbarCapsule: View {
+    let descriptor: SecondaryToolbarDescriptor
+    @Binding var selection: SecondaryToolbarItemID
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(descriptor.items) { item in
+                Button {
+                    selection = item.id
+                } label: {
+                    Text(String(localized: item.titleKey, comment: "Secondary toolbar item title"))
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .frame(minWidth: 96)
+                        .background(selection == item.id ? Color.primary.opacity(0.10) : Color.clear)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("secondary-toolbar-\(String(describing: item.id))")
+            }
+        }
+        .padding(6)
+        .glassBackground(.regular, in: Capsule())
+    }
+}
+```
+
+- [ ] **Step 4: Add toolbar-safe visual constraints**
+
+```swift
+.frame(maxWidth: 420)
+.fixedSize(horizontal: false, vertical: true)
+.contentShape(Capsule())
+```
+
+Also ensure the control avoids hover/overlay layers that intercept clicks outside the buttons.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarCapsuleTests
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbarCapsule.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarCapsuleTests.swift
+git commit -m "feat: add custom secondary toolbar capsule"
+```
+
+### Task 3: Attach the Capsule to the Real Window Toolbar Principal Area
+
+**Files:**
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift`
+- Test: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift`
+
+**Interfaces:**
+- Consumes: `activeSecondaryToolbarDescriptor`, `activeSecondaryToolbarSelection`
+- Produces:
+  - `.toolbar { ToolbarItem(placement: .principal) { ... } }`
+  - Page-aware principal toolbar visibility
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import WiFiLens
+
+@Test func channelsPageProvidesSecondaryToolbarDescriptor() {
+    #expect(SecondaryToolbarDescriptor.forPage(.channels) != nil)
+}
+
+@Test func overviewPageProvidesNoSecondaryToolbarDescriptor() {
+    #expect(SecondaryToolbarDescriptor.forPage(.overview) == nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails only if coverage is missing**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarAttachmentTests
+```
+
+Expected: PASS once descriptor mapping exists; this task’s main verification is build plus manual interaction.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the root content chain in `WiFiLensApp.swift`:
+
+```swift
+.toolbar {
+    ToolbarItem(placement: .principal) {
+        if let descriptor = activeSecondaryToolbarDescriptor,
+           let selection = activeSecondaryToolbarSelection {
+            SecondaryToolbarCapsule(
+                descriptor: descriptor,
+                selection: selection
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Reduce title competition when principal content is present**
+
+Use a page-aware title strategy:
+
+```swift
+.navigationTitle(activeSecondaryToolbarDescriptor == nil ? selectedPage.label : "")
+```
+
+Keep `Overview` behavior intact unless later intentionally revised.
+
+- [ ] **Step 5: Run build verification**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 6: Manual verification**
+
+Check all of the following in the running app:
+
+```text
+1. Open Channels page.
+2. Confirm the capsule appears centered in the real window toolbar.
+3. Click each segment and confirm it is interactive.
+4. Switch to Overview and confirm the capsule disappears.
+5. Switch back to Channels and confirm the previous selection persists.
+```
+
+Expected: No dead click zone, no overlay-style fake titlebar behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+git commit -m "feat: attach secondary toolbar to window principal area"
+```
+
+### Task 4: Refactor `ChannelQualityView` to Consume Root-Owned Mode State
+
+**Files:**
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift`
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift`
+- Test: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/ChannelQualityViewModeTests.swift`
+
+**Interfaces:**
+- Consumes: root-owned `SecondaryToolbarItemID`
+- Produces:
+  - `ChannelQualityView(channels:mode:)`
+  - Mapping from toolbar selection to `ChannelViewMode`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import WiFiLens
+
+@Test func channelsToolbarSelectionMapsToSimpleMode() {
+    #expect(ChannelViewMode.fromToolbarSelection(.channelsSimple) == .simple)
+}
+
+@Test func channelsToolbarSelectionMapsToTableMode() {
+    #expect(ChannelViewMode.fromToolbarSelection(.channelsTable) == .table)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/ChannelQualityViewModeTests
+```
+
+Expected: FAIL because mapping helper does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ChannelQualityView.swift`:
+
+```swift
+enum ChannelViewMode: String, CaseIterable {
+    case simple
+    case table
+
+    static func fromToolbarSelection(_ selection: SecondaryToolbarItemID) -> Self {
+        switch selection {
+        case .channelsSimple: .simple
+        case .channelsTable: .table
+        }
+    }
+}
+```
+
+Refactor the view initializer/state usage:
+
+```swift
+struct ChannelQualityView: View {
+    let channels: [ChannelRecommendation]
+    let mode: ChannelViewMode
+    @State private var sortKey: SortKey = .rfScore
+    @State private var sortAscending: Bool = false
+    @State private var selectedID: String?
+}
+```
+
+Remove the in-view segmented picker block entirely.
+
+- [ ] **Step 4: Pass root selection into the page**
+
+In `WiFiLensApp.swift`:
+
+```swift
+let channelsMode = ChannelViewMode.fromToolbarSelection(
+    secondaryToolbarSelections[.channels] ?? .channelsSimple
+)
+
+ChannelQualityView(
+    channels: viewModel.channelRecommendations,
+    mode: channelsMode
+)
+```
+
+- [ ] **Step 5: Run test and build verification**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/ChannelQualityViewModeTests
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+```
+
+Expected: PASS and BUILD SUCCEEDED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/ChannelQualityViewModeTests.swift
+git commit -m "refactor: drive channels mode from root toolbar state"
+```
+
+### Task 5: Prepare the Generic Expansion Path for Other Business Pages
+
+**Files:**
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift`
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift`
+- Modify: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift`
+- Test: `/Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarDescriptorExpansionTests.swift`
+
+**Interfaces:**
+- Consumes: existing page-local mode enums
+- Produces:
+  - Additional descriptor entries for `interfaces` and `spectrum`
+  - A stable extension path for future business pages
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import Testing
+@testable import WiFiLens
+
+@Test func interfacesPageProvidesSecondaryToolbarDescriptor() {
+    let descriptor = SecondaryToolbarDescriptor.forPage(.interfaces)
+    #expect(descriptor != nil)
+    #expect(descriptor?.items.count == 3)
+}
+
+@Test func spectrumPageDescriptorCanBeAddedWithoutChangingChannelsContract() {
+    let descriptor = SecondaryToolbarDescriptor.forPage(.spectrum)
+    #expect(descriptor != nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarDescriptorExpansionTests
+```
+
+Expected: FAIL because only `channels` is defined initially.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend `SecondaryToolbarItemID` and `SecondaryToolbarDescriptor.forPage(_:)` with:
+
+```swift
+case interfacesSimple
+case interfacesDetails
+case interfacesMonitor
+case spectrumLive
+case spectrumRecording
+```
+
+Map `SidebarPage.interfaces` and `SidebarPage.spectrum` to descriptors without changing toolbar rendering architecture.
+
+- [ ] **Step 4: Refactor additional pages only when ready**
+
+Convert `InterfacesView` and `Spectrum.ContentView` from local segmented pickers to external mode input using the same pattern proven in `Channels`.
+
+- [ ] **Step 5: Run test and build verification**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarDescriptorExpansionTests
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+```
+
+Expected: PASS and BUILD SUCCEEDED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/App/SecondaryToolbar.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift /Users/kaoru/Developer/wifi-lens/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarDescriptorExpansionTests.swift
+git commit -m "feat: extend root secondary toolbar to additional pages"
+```
+
+### Task 6: Final Verification and Documentation Update
+
+**Files:**
+- Modify: `/Users/kaoru/Developer/wifi-lens/docs/ARCHITECTURE.md`
+- Test: existing app build/test targets
+
+**Interfaces:**
+- Consumes: completed toolbar architecture
+- Produces:
+  - Updated architecture note for root-owned page secondary toolbar behavior
+
+- [ ] **Step 1: Add architecture documentation**
+
+Add a short note under app shell / key patterns describing:
+
+```markdown
+- Page-internal secondary navigation is hosted by the window toolbar principal area.
+- `AppRootView` owns the active secondary toolbar descriptor and selection state.
+- Business pages consume root-owned mode state instead of rendering local segmented controls when they participate in the shared secondary toolbar system.
+```
+
+- [ ] **Step 2: Run final verification**
+
+Run:
+```bash
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
+xcodebuild -project /Users/kaoru/Developer/wifi-lens/WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
+```
+
+Expected:
+```text
+BUILD SUCCEEDED
+Test Succeeded
+```
+
+- [ ] **Step 3: Manual regression sweep**
+
+Check:
+
+```text
+1. Overview has no secondary toolbar.
+2. Channels toolbar is visible and clickable.
+3. Sidebar switching remains intact.
+4. Traffic lights and drag region remain usable.
+5. No stale toolbar selection appears on pages without descriptors.
+```
+
+Expected: No visual or interaction regressions in the titlebar area.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add /Users/kaoru/Developer/wifi-lens/docs/ARCHITECTURE.md
+git commit -m "docs: document root-owned secondary toolbar architecture"
+```
+
+## Self-Review
+
+- Spec coverage: covered root-owned model, principal toolbar rendering, `Channels` first validation, future extension to most business pages, and no-toolbar behavior for pages like `Overview`.
+- Placeholder scan: no `TODO`, `TBD`, or implicit “handle appropriately” steps remain.
+- Type consistency: `SecondaryToolbarItemID`, `SecondaryToolbarDescriptor`, and `ChannelViewMode.fromToolbarSelection(_:)` are used consistently across tasks.
+
+## Execution Handoff
+
+Plan complete and targeted for:
+
+`/Users/kaoru/Developer/wifi-lens/docs/superpowers/plans/2026-06-19-window-toolbar-secondary-navigation.md`
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** - dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - execute tasks in one session with checkpoints
+
+


### PR DESCRIPTION
## Summary
- move page-internal secondary navigation into the real macOS window toolbar principal area
- replace the custom SwiftUI toolbar capsule with an AppKit-backed `NSSegmentedControl`
- lift Channels, Interfaces, and Spectrum mode selection into root-owned toolbar state
- add descriptor/mode tests and document the toolbar architecture

## Why
The previous custom control had visual layering issues and unreliable hit testing in the toolbar area. This change moves the feature onto official toolbar/AppKit primitives and also removes the hidden-page rendering approach that was causing a large CPU spike.

## Validation
- `xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests/SecondaryToolbarTests`

## Notes
- Opened as draft because code review identified follow-up issues around page lifetime, Spectrum recording state, and missing end-to-end toolbar behavior coverage.