### PR TITLE
fix: hide unavailable vendor data

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/EditionCompositionContext.swift
+++ b/WiFiLens/Sources/WiFiLens/App/EditionCompositionContext.swift
@@ -9,6 +9,7 @@ struct EditionCompositionContext {
     let mainWindowID: UUID
     let mainWindowState: AnyObject
     let scannerViewModel: ScannerViewModel
+    let macVendorDatabaseManager: MACVendorDatabaseManager
     let selectedPage: Binding<SidebarPage>
     let secondaryToolbarSelections: Binding<SecondaryToolbarSelections>
     let bleEnabled: Binding<Bool>

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -41,6 +41,7 @@ enum EditionComposition {
         case .spectrum:
             OSSSpectrumCompositionView(
                 scannerViewModel: context.scannerViewModel,
+                macVendorDatabaseManager: context.macVendorDatabaseManager,
                 selection: context.secondaryToolbarSelections.wrappedValue.spectrum
             )
             .accessibilityIdentifier("page-spectrum")
@@ -81,6 +82,7 @@ enum EditionComposition {
 
 private struct OSSSpectrumCompositionView: View {
     @Bindable var scannerViewModel: ScannerViewModel
+    @Bindable var macVendorDatabaseManager: MACVendorDatabaseManager
     let selection: SecondaryToolbarItemID
 
     var body: some View {
@@ -92,7 +94,10 @@ private struct OSSSpectrumCompositionView: View {
                 customSkeleton: { RecordingSkeletonView() }
             )
         } else {
-            ContentView(viewModel: scannerViewModel)
+            ContentView(
+                viewModel: scannerViewModel,
+                macVendorDatabaseManager: macVendorDatabaseManager
+            )
         }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/Scanner/MACVendorDatabaseManager.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/MACVendorDatabaseManager.swift
@@ -8,6 +8,15 @@ enum MACVendorDatabaseAvailability: Equatable, Sendable {
     case unavailable(MACVendorDatabaseError)
 }
 
+extension MACVendorDatabaseAvailability {
+    var isVendorColumnAvailable: Bool {
+        if case .installed = self {
+            return true
+        }
+        return false
+    }
+}
+
 enum MACVendorDatabaseOperation: Equatable, Sendable {
     case idle
     case downloading(completed: Int, total: Int)

--- a/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
@@ -249,7 +249,7 @@ final class ScannerViewModel {
         if case let .registered(organization) = vendorResolver.resolve(bssid) {
             return organization
         }
-        return "—"
+        return ""
     }
 
     func vendorDatabaseDidChange() {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -79,6 +79,7 @@ struct SpectrumDashboardLayout {
 
 struct ContentView: View {
     @Bindable var viewModel: ScannerViewModel
+    @Bindable var macVendorDatabaseManager: MACVendorDatabaseManager
 
     @State private var sortOrder: [NSSortDescriptor] = [NSSortDescriptor(key: "ssid", ascending: true)]
     @State private var panel1ChartType: BandPanelSelection = .band24
@@ -90,6 +91,10 @@ struct ContentView: View {
             get: { Set(hiddenColumnsData.split(separator: ",").map(String.init).filter { !$0.isEmpty }) },
             set: { hiddenColumnsData = $0.sorted().joined(separator: ",") }
         )
+    }
+
+    private var isVendorColumnAvailable: Bool {
+        macVendorDatabaseManager.availability.isVendorColumnAvailable
     }
 
     var body: some View {
@@ -208,6 +213,7 @@ struct ContentView: View {
             selectedID: $viewModel.selectedNetworkID,
             sortOrder: $sortOrder,
             hiddenColumns: hiddenColumns,
+            isVendorColumnAvailable: isVendorColumnAvailable,
             onToggleVisibility: { seriesID in viewModel.toggleVisibility(seriesID: seriesID) },
             onToggleVisibilityLocked: { seriesID in viewModel.toggleVisibilityLocked(seriesID: seriesID) }
         )

--- a/WiFiLens/Sources/WiFiLens/Table/NativeTableView.swift
+++ b/WiFiLens/Sources/WiFiLens/Table/NativeTableView.swift
@@ -6,6 +6,7 @@ struct NativeTableView: NSViewRepresentable {
     @Binding var selectedID: String?
     @Binding var sortOrder: [NSSortDescriptor]
     @Binding var hiddenColumns: Set<String>
+    let isVendorColumnAvailable: Bool
     var onToggleVisibility: ((String) -> Void)?
     var onToggleVisibilityLocked: ((String) -> Void)?
 
@@ -53,7 +54,9 @@ struct NativeTableView: NSViewRepresentable {
         }
 
         addColumn(to: tableView, id: "SSID", title: String(localized: "table.column.ssid", comment: "SSID column header in network table"), width: 160, sortKey: "ssid", ascending: true)
-        addColumn(to: tableView, id: "Vendor", title: String(localized: "table.column.vendor", comment: "MAC vendor column header in network table"), width: 140, sortKey: "vendor", ascending: true)
+        if isVendorColumnAvailable {
+            addVendorColumn(to: tableView)
+        }
         addColumn(to: tableView, id: "Hidden", title: String(localized: "table.column.hidden", comment: "Hidden network indicator column header"), width: 20, sortKey: "isHiddenSSID", ascending: false)
         addColumn(to: tableView, id: "Band", title: String(localized: "channels.table.col.band", comment: "Band column header"), width: 80, sortKey: "bandLabel", ascending: true)
         addColumn(to: tableView, id: "Ch", title: String(localized: "table.column.channel", comment: "Channel column header (abbreviated)"), width: 50, sortKey: "channel", ascending: true)
@@ -118,6 +121,8 @@ struct NativeTableView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let tableView = scrollView.documentView as? NSTableView else { return }
 
+        let vendorColumnsChanged = updateVendorColumn(in: tableView)
+
         let rowsChanged = context.coordinator.rows != rows
         let selectionChanged = context.coordinator.previousSelectedID != selectedID
         context.coordinator.rows = rows
@@ -129,6 +134,8 @@ struct NativeTableView: NSViewRepresentable {
 
         if rowsChanged {
             tableView.reloadData()
+            context.coordinator.autoSizeColumns()
+        } else if vendorColumnsChanged {
             context.coordinator.autoSizeColumns()
         } else if selectionChanged {
             let visibleRange = tableView.rows(in: tableView.visibleRect)
@@ -156,6 +163,35 @@ struct NativeTableView: NSViewRepresentable {
         column.isEditable = false
         column.sortDescriptorPrototype = NSSortDescriptor(key: sortKey, ascending: ascending)
         tableView.addTableColumn(column)
+    }
+
+    private func addVendorColumn(to tableView: NSTableView) {
+        addColumn(
+            to: tableView,
+            id: "Vendor",
+            title: String(localized: "table.column.vendor", comment: "MAC vendor column header in network table"),
+            width: 140,
+            sortKey: "vendor",
+            ascending: true
+        )
+    }
+
+    private func updateVendorColumn(in tableView: NSTableView) -> Bool {
+        let vendorIdentifier = NSUserInterfaceItemIdentifier("Vendor")
+        let vendorColumn = tableView.tableColumns.first { $0.identifier == vendorIdentifier }
+
+        if isVendorColumnAvailable, vendorColumn == nil {
+            addVendorColumn(to: tableView)
+            if let vendorIndex = tableView.tableColumns.firstIndex(where: { $0.identifier == vendorIdentifier }),
+               let ssidIndex = tableView.tableColumns.firstIndex(where: { $0.identifier.rawValue == "SSID" }) {
+                tableView.moveColumn(vendorIndex, toColumn: ssidIndex + 1)
+            }
+            return true
+        } else if !isVendorColumnAvailable, let vendorColumn {
+            tableView.removeTableColumn(vendorColumn)
+            return true
+        }
+        return false
     }
 
     class Coordinator: NSObject, NSTableViewDelegate, NSTableViewDataSource {

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -166,6 +166,7 @@ private struct AppRootView: View {
                     mainWindowID: sceneState.id,
                     mainWindowState: sceneState.editionWindowState,
                     scannerViewModel: viewModel,
+                    macVendorDatabaseManager: macVendorDatabaseManager,
                     selectedPage: Binding(
                         get: { sceneState.selectedPage },
                         set: { sceneState.selectedPage = $0 }

--- a/WiFiLens/Tests/WiFiLensTests/MACVendorDatabaseReminderTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/MACVendorDatabaseReminderTests.swift
@@ -40,4 +40,18 @@ struct MACVendorDatabaseReminderTests {
             )
         ).shouldRemindWhenEmpty)
     }
+
+    @Test func onlyInstalledDatabaseMakesVendorColumnAvailable() {
+        let summary = MACVendorDatabaseSummary(
+            source: .manualImport,
+            createdAt: .distantPast,
+            registryCounts: [:],
+            totalRecordCount: 0
+        )
+
+        #expect(!MACVendorDatabaseAvailability.loading.isVendorColumnAvailable)
+        #expect(!MACVendorDatabaseAvailability.notInstalled.isVendorColumnAvailable)
+        #expect(!MACVendorDatabaseAvailability.unavailable(.persistenceFailure).isVendorColumnAvailable)
+        #expect(MACVendorDatabaseAvailability.installed(summary).isVendorColumnAvailable)
+    }
 }

--- a/WiFiLens/Tests/WiFiLensTests/MACVendorResolverTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/MACVendorResolverTests.swift
@@ -106,7 +106,7 @@ struct MACVendorResolverTests {
         #expect(viewModel.combinedTableRows.first?.vendor == "Example Networks")
     }
 
-    @Test func scannerUsesPlaceholderForNonRegisteredAddresses() {
+    @Test func scannerLeavesVendorBlankForNonRegisteredAddresses() {
         let viewModel = ScannerViewModel(vendorResolver: MACVendorResolver(entries: []))
         let unknown = WiFiNetwork(
             ssid: "Unknown",
@@ -117,7 +117,7 @@ struct MACVendorResolverTests {
 
         viewModel.debugApplyNetworksForTesting([unknown], supportedBands: [.band5GHz])
 
-        #expect(viewModel.combinedTableRows.first?.vendor == "—")
+        #expect(viewModel.combinedTableRows.first?.vendor == "")
     }
 
     @Test func scannerRefreshSeamReprojectsExistingRowsWithoutAnotherScan() async {


### PR DESCRIPTION
## Summary
- hide the Vendor column unless the MAC vendor database is installed
- show a blank value when a BSSID has no registered vendor match
- update the Pro submodule to the companion Vendor-column fix

## Dependency
- Requires SHIINASAMA/wifi-lens-pro#5

## Verification
- Skipped before commit by user request.