### PR TITLE
Fix Pages deployment security context

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,11 +1,12 @@
 name: Pages Deploy
 
 on:
-  workflow_run:
-    workflows:
-      - Web CI
-    types:
-      - completed
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/pages-deploy.yml"
+      - "web/**"
   workflow_dispatch:
 
 permissions:
@@ -19,21 +20,12 @@ concurrency:
 
 jobs:
   deploy:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'master'
-      )
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: pnpm/action-setup@v6
         with:


### PR DESCRIPTION
## What changed

- Replace the privileged `workflow_run` trigger with a `push` trigger restricted to `master` and website paths.
- Remove the event-controlled checkout ref.
- Retain manual deployment support.

## Why

CodeQL reported a critical `actions/untrusted-checkout/critical` alert because the privileged Pages workflow checked out `github.event.workflow_run.head_sha` and then installed dependencies and built the site.

## Impact

Pages deployments continue to run for website changes pushed to `master`, while the workflow no longer executes a dynamically selected checkout in a privileged `workflow_run` context.

## Validation

Pre-commit checks were skipped at the developer's request. Before the commit, YAML parsing, dangerous-pattern scanning, `git diff --check`, and the Astro production build had completed successfully.
