### PR TITLE
chore: expose Analysis Workspace preview routes

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -54,6 +54,22 @@ enum EditionComposition {
                 customSkeleton: { TimelineSkeletonView() }
             )
             .accessibilityIdentifier("page-timeline")
+        case .statistics:
+            ProFeaturePlaceholderView(
+                featureName: String(localized: "pro.statistics.title", comment: "Pro Statistics feature title"),
+                featureDescription: String(localized: "pro.statistics.description", comment: "Pro Statistics feature description"),
+                featureIcon: SidebarPage.statistics.icon,
+                customSkeleton: { StatisticsSkeletonView() }
+            )
+            .accessibilityIdentifier("page-statistics")
+        case .insights:
+            ProFeaturePlaceholderView(
+                featureName: String(localized: "pro.insights.title", comment: "Pro Insights feature title"),
+                featureDescription: String(localized: "pro.insights.description", comment: "Pro Insights feature description"),
+                featureIcon: SidebarPage.insights.icon,
+                customSkeleton: { InsightsSkeletonView() }
+            )
+            .accessibilityIdentifier("page-insights")
         default:
             EmptyView()
         }

--- a/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
@@ -429,12 +429,54 @@ struct OverviewView: View {
 
 // MARK: - 3D Earth Globe
 
+/// SCNView whose render loop only starts once its window is on screen.
+/// Starting `isPlaying` for an offscreen window (e.g. the never-ordered-front
+/// NSWindows in DetailPageHorizontalOverflowTests) makes SceneKit render into
+/// a 0x0 drawable — a fatal Metal texture-description validation assertion
+/// that crashes the test host on headless CI.
+private final class GlobeSCNView: SCNView {
+    private var visibilityObserver: NSObjectProtocol?
+
+    /// Idempotent — safe to call from makeNSView's deferred block,
+    /// viewDidMoveToWindow, the visibility notification, and updateNSView.
+    func startPlaybackIfVisible() {
+        guard let window, window.isVisible, !bounds.isEmpty else { return }
+        isPlaying = true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Remove the previous observer (either the one for the old window,
+        // or the one for the window we are detaching from).
+        if let visibilityObserver {
+            NotificationCenter.default.removeObserver(visibilityObserver)
+            self.visibilityObserver = nil
+        }
+        guard let window else { return }
+        // Fires when the window becomes visible (occlusion state changes),
+        // catching the "window shown after the view was created" case.
+        // `queue: .main` + `[weak self]` keeps the callback on the main
+        // actor and lets the view outlive the observer without a deinit
+        // that touches MainActor state from a background thread.
+        visibilityObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            // queue: .main guarantees the callback runs on the main actor.
+            MainActor.assumeIsolated {
+                self?.startPlaybackIfVisible()
+            }
+        }
+    }
+}
+
 private struct EarthGlobeView: NSViewRepresentable {
     let color: Color
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    func makeNSView(context: Context) -> SCNView {
+    func makeNSView(context: Context) -> GlobeSCNView {
         let scene = SCNScene()
 
         // Axial tilt container — Earth rotates at 23.5° from orbital plane
@@ -574,7 +616,7 @@ private struct EarthGlobeView: NSViewRepresentable {
 
         context.coordinator.scene = scene
 
-        let scnView = SCNView()
+        let scnView = GlobeSCNView()
         scnView.backgroundColor = .clear
         scnView.allowsCameraControl = false
         scnView.isJitteringEnabled = true
@@ -583,11 +625,12 @@ private struct EarthGlobeView: NSViewRepresentable {
 
         scnView.scene = scene
         scnView.isPlaying = false
-        DispatchQueue.main.async { scnView.isPlaying = true }
+        DispatchQueue.main.async { scnView.startPlaybackIfVisible() }
         return scnView
     }
 
-    func updateNSView(_ nsView: SCNView, context: Context) {
+    func updateNSView(_ nsView: GlobeSCNView, context: Context) {
+        nsView.startPlaybackIfVisible()
         guard let tilt = nsView.scene?.rootNode.childNode(withName: "tilt", recursively: false) else { return }
         if let innerGlow = tilt.childNode(withName: "innerGlow", recursively: false) {
             innerGlow.geometry?.materials.first?.diffuse.contents = NSColor(color).withAlphaComponent(0.06)

--- a/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
@@ -364,6 +364,146 @@ struct TimelineSkeletonView: View {
     }
 }
 
+struct StatisticsSkeletonView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            summaryCard
+            metricGrid
+            distributionCard
+        }
+    }
+
+    private var summaryCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                line(widthRatio: 0.30, height: 10, opacity: 0.28)
+                line(widthRatio: 0.46, height: 8, opacity: 0.16)
+                line(widthRatio: 0.38, height: 7, opacity: 0.12)
+            }
+        }
+    }
+
+    private var metricGrid: some View {
+        HStack(spacing: 12) {
+            metricCell
+            metricCell
+            metricCell
+        }
+    }
+
+    private var metricCell: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            line(widthRatio: 0.55, height: 7, opacity: 0.14)
+            line(widthRatio: 0.40, height: 12, opacity: 0.30)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardShape)
+    }
+
+    private var distributionCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 10) {
+                line(widthRatio: 0.26, height: 10, opacity: 0.28)
+                line(widthRatio: 0.86, height: 8, opacity: 0.16)
+                line(widthRatio: 0.68, height: 8, opacity: 0.12)
+                line(widthRatio: 0.74, height: 8, opacity: 0.10)
+            }
+        }
+    }
+
+    private func card(@ViewBuilder content: () -> some View) -> some View {
+        content()
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(cardShape)
+    }
+
+    private var cardShape: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.primary.opacity(0.04))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+    }
+
+    private func line(widthRatio: CGFloat, height: CGFloat, opacity: Double) -> some View {
+        GeometryReader { geometry in
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.primary.opacity(opacity))
+                .frame(width: geometry.size.width * widthRatio, height: height)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: height)
+    }
+}
+
+struct InsightsSkeletonView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            statusCard
+            insightCard(iconOpacity: 0.28)
+            insightCard(iconOpacity: 0.20)
+        }
+    }
+
+    private var statusCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            line(widthRatio: 0.34, height: 10, opacity: 0.28)
+            line(widthRatio: 0.60, height: 8, opacity: 0.16)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardShape)
+    }
+
+    private func insightCard(iconOpacity: Double) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(iconOpacity))
+                .frame(width: 36, height: 36)
+
+            VStack(alignment: .leading, spacing: 6) {
+                line(widthRatio: 0.50, height: 9, opacity: 0.26)
+                line(widthRatio: 0.70, height: 7, opacity: 0.14)
+            }
+
+            Spacer(minLength: 8)
+
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.primary.opacity(0.10))
+                .frame(width: 56, height: 22)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardShape)
+    }
+
+    private var cardShape: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.primary.opacity(0.04))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+    }
+
+    private func line(widthRatio: CGFloat, height: CGFloat, opacity: Double) -> some View {
+        GeometryReader { geometry in
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.primary.opacity(opacity))
+                .frame(width: geometry.size.width * widthRatio, height: height)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: height)
+    }
+}
+
 struct RecordingSkeletonView: View {
     var body: some View {
         VStack(spacing: 0) {

--- a/WiFiLens/Sources/WiFiLens/App/SidebarView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SidebarView.swift
@@ -9,6 +9,8 @@ enum SidebarPage: String, CaseIterable {
     case roaming
     case bleScanner
     case timeline
+    case statistics
+    case insights
     case settings
 #if DEBUG
     case spectrumDebugChart
@@ -20,7 +22,7 @@ enum SidebarPage: String, CaseIterable {
 
     var requiresLocationAuthorization: Bool {
         switch self {
-        case .overview, .settings, .bleScanner, .timeline, .networkDiagnostics:
+        case .overview, .settings, .bleScanner, .timeline, .statistics, .insights, .networkDiagnostics:
             false
         case .spectrum, .channels, .interfaces, .roaming:
             true
@@ -37,7 +39,7 @@ enum SidebarPage: String, CaseIterable {
 
     var requiresWiFi: Bool {
         switch self {
-        case .overview, .settings, .bleScanner, .timeline, .networkDiagnostics:
+        case .overview, .settings, .bleScanner, .timeline, .statistics, .insights, .networkDiagnostics:
             false
         case .spectrum, .channels, .interfaces, .roaming:
             true
@@ -62,6 +64,8 @@ enum SidebarPage: String, CaseIterable {
         case .roaming:   String(localized: "nav.roaming_test", comment: "Roaming Test sidebar navigation item")
         case .bleScanner: String(localized: "nav.ble_scanner", comment: "BLE Scanner sidebar navigation item")
         case .timeline: String(localized: "nav.timeline", comment: "Timeline sidebar navigation item")
+        case .statistics: String(localized: "nav.statistics", comment: "Statistics sidebar navigation item")
+        case .insights: String(localized: "nav.insights", comment: "Insights sidebar navigation item")
         case .settings:   String(localized: "common.action.settings", comment: "Settings button or menu item")
 #if DEBUG
         case .spectrumDebugChart: String(localized: "nav.spectrum_debug_chart", comment: "Spectrum Debug Chart sidebar navigation item (dev only)")
@@ -83,6 +87,8 @@ enum SidebarPage: String, CaseIterable {
         case .roaming:   "arrow.triangle.swap"
         case .bleScanner: "personalhotspot"
         case .timeline: "clock.arrow.circlepath"
+        case .statistics: "chart.bar.xaxis"
+        case .insights: "lightbulb"
         case .settings:   "gearshape"
 #if DEBUG
         case .spectrumDebugChart: "antenna.radiowaves.left.and.right"
@@ -98,14 +104,16 @@ enum SidebarPage: String, CaseIterable {
         switch self {
         case .networkDiagnostics:
             .preview
-        case .timeline:
-            Self.timelineBadgeStyle(for: .current)
         default:
             nil
         }
     }
 
     static func timelineBadgeStyle(for config: BuildConfig) -> SidebarBadge.Style {
+        analysisBadgeStyle(for: config)
+    }
+
+    static func analysisBadgeStyle(for config: BuildConfig) -> SidebarBadge.Style {
         switch config {
         case .oss:
             .pro
@@ -113,12 +121,14 @@ enum SidebarPage: String, CaseIterable {
             .preview
         }
     }
+
+    static let analysisPages: [SidebarPage] = [.timeline, .statistics, .insights]
 }
 
 enum SidebarSection {
     case overview
     case tools
-    case insights
+    case analysis
     case debug
     case settings
 
@@ -128,8 +138,8 @@ enum SidebarSection {
             "sidebar.section.overview"
         case .tools:
             "sidebar.section.tools"
-        case .insights:
-            "sidebar.section.insights"
+        case .analysis:
+            "sidebar.section.analysis"
         case .debug:
             "sidebar.section.debug"
         case .settings:
@@ -139,6 +149,17 @@ enum SidebarSection {
 
     var title: String {
         String(localized: String.LocalizationValue(localizationKey), comment: "Sidebar section title")
+    }
+
+    /// Edition badge shown on the group title. The Analysis group carries one
+    /// badge for all of its routes instead of repeating it on every row.
+    var badgeStyle: SidebarBadge.Style? {
+        switch self {
+        case .analysis:
+            SidebarPage.analysisBadgeStyle(for: .current)
+        default:
+            nil
+        }
     }
 }
 
@@ -214,10 +235,12 @@ struct SidebarView: View {
                 }
             }
             Section {
-                sidebarGroupTitle(.insights)
-                sidebarRow(for: .timeline)
-                    .tag(SidebarPage.timeline)
-                    .accessibilityIdentifier("sidebar-\(SidebarPage.timeline.rawValue)")
+                sidebarGroupTitle(.analysis)
+                ForEach(SidebarPage.analysisPages, id: \.self) { page in
+                    sidebarRow(for: page)
+                        .tag(page)
+                        .accessibilityIdentifier("sidebar-\(page.rawValue)")
+                }
             }
 #if DEBUG
             Section {
@@ -279,12 +302,20 @@ struct SidebarView: View {
     }
 
     private func sidebarGroupTitle(_ section: SidebarSection) -> some View {
-        Text(section.title)
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(.secondary)
-            .textCase(nil)
-            .padding(.top, 6)
-            .padding(.bottom, 2)
+        HStack(spacing: 6) {
+            Text(section.title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(nil)
+
+            Spacer(minLength: 4)
+
+            if let badgeStyle = section.badgeStyle {
+                SidebarBadge(style: badgeStyle)
+            }
+        }
+        .padding(.top, 6)
+        .padding(.bottom, 2)
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/Observation/Runtime/WiFiObservationRuntime.swift
+++ b/WiFiLens/Sources/WiFiLens/Observation/Runtime/WiFiObservationRuntime.swift
@@ -1,8 +1,18 @@
 import Foundation
 
+enum WiFiObservationLifecycleEvent: Sendable {
+    case started(at: Date, expectedInterval: Duration)
+    case stopped(at: Date)
+}
+
 @MainActor
 protocol WiFiObservationConsuming: AnyObject {
     func consume(_ observation: WiFiObservation) async throws
+    func consumeLifecycle(_ event: WiFiObservationLifecycleEvent) async throws
+}
+
+extension WiFiObservationConsuming {
+    func consumeLifecycle(_ event: WiFiObservationLifecycleEvent) async throws { _ = event }
 }
 
 struct ObservationConsumerDiagnostics: Equatable, Sendable {
@@ -58,12 +68,14 @@ final class WiFiObservationRuntime {
     private var pendingRawCycle: RawCycleAdmission?
     private var rawCycleReplacementCount: UInt64 = 0
     private var activeScanGeneration: UUID?
+    private var activeLifecycleGeneration: UUID?
     private var outputProjection: (@MainActor (WiFiObservationScanOutput) -> Void)?
     private var requestedOutputProjection: (@MainActor (WiFiObservationScanOutput) -> Void)?
     private var publicationEligibility: (@MainActor () -> Bool)?
     private var requestedPublicationEligibility: (@MainActor () -> Bool)?
     private var latestLifecycleRequestID: UInt64 = 0
     private var lifecycleCommandTail: Task<Void, Never>?
+    private let now: @Sendable () -> Date
 #if DEBUG
     var onActiveScanStoppedForTesting: (@MainActor () -> Void)?
     var onConsumerDrainStartedForTesting: (@MainActor () -> Void)?
@@ -79,12 +91,14 @@ final class WiFiObservationRuntime {
         store: WiFiObservationStore = .shared,
         pipeline: any WiFiObservationPipelining = WiFiObservationPipeline(),
         scanSource: any WiFiScanStreaming = WiFiScanner(),
-        interfaceSource: any NetworkInterfaceSnapshotSourcing = SystemNetworkInterfaceSnapshotSource()
+        interfaceSource: any NetworkInterfaceSnapshotSourcing = SystemNetworkInterfaceSnapshotSource(),
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.store = store
         self.pipeline = pipeline
         self.scanSource = scanSource
         self.interfaceSource = interfaceSource
+        self.now = now
     }
 
     func addConsumer(_ consumer: any WiFiObservationConsuming) {
@@ -167,11 +181,10 @@ final class WiFiObservationRuntime {
         requestedPublicationEligibility = nil
         let command = enqueueLifecycleCommand { [weak self] _ in
             guard let self else { return }
-            await self.stopActiveScan(stopSource: hadRequestedScan)
-#if DEBUG
-            self.onActiveScanStoppedForTesting?()
-#endif
-            await self.drainConsumers()
+            await self.stopActiveScan(
+                stopSource: hadRequestedScan,
+                notifyScanStoppedForTesting: true
+            )
             self.outputProjection = nil
             self.publicationEligibility = nil
         }
@@ -207,8 +220,13 @@ final class WiFiObservationRuntime {
         )
         let generation = UUID()
         activeScanGeneration = generation
+        activeLifecycleGeneration = generation
         outputProjection = onOutput
         publicationEligibility = isPublicationEligible
+        let startedAt = now()
+        for worker in workers.values {
+            await worker.sessionStarted(at: startedAt, expectedInterval: configuration.scanInterval)
+        }
         await scanSource.startScanning(interval: configuration.scanInterval) { [weak self] event in
             await self?.admitRawCycle(RawCycleAdmission(
                 event: event,
@@ -219,6 +237,8 @@ final class WiFiObservationRuntime {
         }
         guard isLatestLifecycleRequest(requestID) else {
             await scanSource.stopScanning()
+            await drainConsumers()
+            await finishLifecycleIfOwned(generation, at: now())
             return
         }
     }
@@ -291,7 +311,10 @@ final class WiFiObservationRuntime {
         guard activeScanGeneration == generation, !Task.isCancelled else { return false }
         guard publicationEligibility?() != false else {
             clearPublicationRequestAfterRejection()
+            activeScanGeneration = nil
             await scanSource.stopScanning()
+            await drainConsumers()
+            await finishLifecycleIfOwned(generation, at: now())
             return false
         }
         store.apply(cycle.observation)
@@ -315,7 +338,11 @@ final class WiFiObservationRuntime {
         publicationEligibility = nil
     }
 
-    private func stopActiveScan(stopSource: Bool) async {
+    private func stopActiveScan(
+        stopSource: Bool,
+        notifyScanStoppedForTesting: Bool = false
+    ) async {
+        let lifecycleGeneration = activeLifecycleGeneration
         let task = rawCycleTask
         rawCycleTask = nil
         pendingRawCycle = nil
@@ -326,6 +353,21 @@ final class WiFiObservationRuntime {
             await scanSource.stopScanning()
         }
         await task?.value
+#if DEBUG
+        if notifyScanStoppedForTesting {
+            onActiveScanStoppedForTesting?()
+        }
+#endif
+        await drainConsumers()
+        if let lifecycleGeneration {
+            await finishLifecycleIfOwned(lifecycleGeneration, at: now())
+        }
+    }
+
+    private func finishLifecycleIfOwned(_ generation: UUID, at date: Date) async {
+        guard activeLifecycleGeneration == generation else { return }
+        activeLifecycleGeneration = nil
+        for worker in workers.values { await worker.sessionStopped(at: date) }
     }
 
     private func ownsScanLifecycle(_ generation: UUID) -> Bool {
@@ -389,6 +431,24 @@ private final class ObservationConsumerWorker {
             let waiters = drainWaiters
             drainWaiters.removeAll()
             waiters.forEach { $0.resume() }
+        }
+    }
+
+    func sessionStarted(at date: Date, expectedInterval: Duration) async {
+        do {
+            try await consumer.consumeLifecycle(.started(at: date, expectedInterval: expectedInterval))
+        } catch {
+            failureCount += 1
+            AppLogger.general.error("Observation consumer lifecycle start failed: \(String(describing: error))")
+        }
+    }
+
+    func sessionStopped(at date: Date) async {
+        do {
+            try await consumer.consumeLifecycle(.stopped(at: date))
+        } catch {
+            failureCount += 1
+            AppLogger.general.error("Observation consumer lifecycle stop failed: \(String(describing: error))")
         }
     }
 

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -1,68 +1,11 @@
 {
   "sourceLanguage": "en",
+  "version": "1.0",
   "strings": {
     " · %@": {
       "shouldTranslate": false
     },
-    "—": {
-      "shouldTranslate": false
-    },
-    "?": {
-      "shouldTranslate": false
-    },
-    "·": {
-      "shouldTranslate": false
-    },
-    "·  %@  ·  Ch %@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "·  %1$@  ·  Ch %2$@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
-          }
-        }
-      },
-      "shouldTranslate": false
-    },
-    "· %@": {
-      "shouldTranslate": false
-    },
     "%@": {
-      "shouldTranslate": false
-    },
-    "%@ — %@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ — %2$@"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ — %2$@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ — %2$@"
-          }
-        }
-      },
       "shouldTranslate": false
     },
     "%@ %@": {
@@ -150,6 +93,29 @@
     "%@ dBm": {
       "shouldTranslate": false
     },
+    "%@ — %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
     "%@/%@": {
       "localizations": {
         "en": {
@@ -164,11 +130,1970 @@
     "%@/100": {
       "shouldTranslate": false
     },
-    "•": {
+    "?": {
       "shouldTranslate": false
     },
-    "⌘Q": {
+    "CH %@  %@ dBm": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CH %1$@  %2$@ dBm"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "CH %1$@  %2$@ dBm"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CH %1$@  %2$@ dBm"
+          }
+        }
+      },
       "shouldTranslate": false
+    },
+    "Ch %@": {
+      "shouldTranslate": false
+    },
+    "PRO": {
+      "shouldTranslate": false
+    },
+    "RSSI %@ dBm": {
+      "shouldTranslate": false
+    },
+    "WiFi Lens": {
+      "shouldTranslate": false
+    },
+    "analysis.insight.repeated_disconnection.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least three recorded disconnections occurred within 30 minutes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innerhalb von 30 Minuten traten mindestens drei aufgezeichnete Verbindungsabbrüche auf."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se registraron al menos tres desconexiones en un intervalo de 30 minutos."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30分以内に、記録された切断が3回以上発生しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 分钟内至少记录到三次断开连接事件。"
+          }
+        }
+      }
+    },
+    "analysis.insight.repeated_disconnection.recommendation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the linked Timeline events and their surrounding observations."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen Sie die verknüpften Timeline-Ereignisse und die umgebenden Beobachtungen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revise los eventos vinculados de Timeline y las observaciones cercanas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクされたTimelineイベントと前後の観測を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看关联的 Timeline 事件及其周边观测。"
+          }
+        }
+      }
+    },
+    "analysis.insight.repeated_disconnection.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated disconnections observed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Trennungen beobachtet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconexiones repetidas observadas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断の繰り返しを観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测到重复断开连接"
+          }
+        }
+      }
+    },
+    "analysis.insight.repeated_gateway_interruption.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least three recorded gateway-latency spikes occurred within 15 minutes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innerhalb von 15 Minuten traten mindestens drei aufgezeichnete Gateway-Latenzspitzen auf."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se registraron al menos tres picos de latencia de la puerta de enlace en un intervalo de 15 minutos."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15分以内に、記録されたゲートウェイ遅延の急増が3回以上発生しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 分钟内至少记录到三次网关延迟突增事件。"
+          }
+        }
+      }
+    },
+    "analysis.insight.repeated_gateway_interruption.recommendation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the linked Timeline events; this observation does not establish gateway failure."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen Sie die verknüpften Timeline-Ereignisse; diese Beobachtung beweist keinen Gateway-Fehler."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revise los eventos vinculados de Timeline; esta observación no demuestra un fallo del gateway."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクされたTimelineイベントを確認してください。この観測はゲートウェイ障害を証明するものではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看关联的 Timeline 事件；此观测不能证明网关故障。"
+          }
+        }
+      }
+    },
+    "analysis.insight.repeated_gateway_interruption.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated gateway-latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Gateway-Latenzbeobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones repetidas de latencia del gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の観測を繰り返し検出"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重复观测到网关延迟"
+          }
+        }
+      }
+    },
+    "analysis.insight.roaming_instability.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least three recorded BSSID changes during connected continuity occurred within 10 minutes."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Innerhalb von 10 Minuten traten bei bestehender Verbindung mindestens drei aufgezeichnete BSSID-Wechsel auf."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se registraron al menos tres cambios de BSSID durante una conexión continua en un intervalo de 10 minutos."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続が継続している間に、記録されたBSSIDの変更が10分以内に3回以上発生しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 分钟内至少记录到三次连接持续期间的 BSSID 变更。"
+          }
+        }
+      }
+    },
+    "analysis.insight.roaming_instability.recommendation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the linked Timeline events; repeated roaming alone does not identify a cause."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen Sie die verknüpften Timeline-Ereignisse; wiederholtes Roaming allein nennt keine Ursache."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revise los eventos vinculados de Timeline; el roaming repetido por sí solo no identifica una causa."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リンクされたTimelineイベントを確認してください。ローミングの繰り返しだけでは原因を特定できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看关联的 Timeline 事件；仅凭重复漫游无法确定原因。"
+          }
+        }
+      }
+    },
+    "analysis.insight.roaming_instability.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated roaming observed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholtes Roaming beobachtet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming repetido observado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローミングの繰り返しを観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测到重复漫游"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_count": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Beobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d observaciones"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d件の観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 条观测"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_kind": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beleg: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidencia: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.failure_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkenntnisse nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights no disponibles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インサイトを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "洞察不可用"
+          }
+        }
+      }
+    },
+    "analysis.insights.findings_available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorded findings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgezeichnete Befunde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hallazgos registrados"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録された検出"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已记录的发现"
+          }
+        }
+      }
+    },
+    "analysis.insights.findings_available_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These findings describe recorded observations and link back to Timeline evidence."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Befunde beschreiben aufgezeichnete Beobachtungen und verweisen auf Timeline-Belege."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos hallazgos describen observaciones registradas y enlazan con evidencia de Timeline."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらの検出は記録された観測を示し、Timelineの証拠にリンクします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这些发现描述已记录的观测，并链接回 Timeline 证据。"
+          }
+        }
+      }
+    },
+    "analysis.insights.insufficient_history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is too short"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf ist zu kurz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial es demasiado corto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴が短すぎます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录太短"
+          }
+        }
+      }
+    },
+    "analysis.insights.insufficient_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The recorded history is limited. Any findings below are based only on clusters in recorded events."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der aufgezeichnete Verlauf ist begrenzt. Die folgenden Befunde basieren ausschließlich auf Häufungen aufgezeichneter Ereignisse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial registrado es limitado. Los hallazgos siguientes se basan únicamente en agrupaciones de eventos registrados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録された履歴が限られています。以下の検出は、記録されたイベントの集中のみを根拠とします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已记录的历史有限。下方发现仅基于已记录事件的集中出现。"
+          }
+        }
+      }
+    },
+    "analysis.insights.load_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local observations could not be evaluated."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Beobachtungen konnten nicht ausgewertet werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron evaluar las observaciones locales."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測を評価できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法评估本地观测。"
+          }
+        }
+      }
+    },
+    "analysis.insights.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evaluating local observations…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Beobachtungen werden ausgewertet …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evaluando observaciones locales…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測を評価中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在评估本地观测…"
+          }
+        }
+      }
+    },
+    "analysis.insights.no_data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No history in this period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Verlauf in diesem Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin historial en este período"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間に履歴なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此时间范围内没有历史记录"
+          }
+        }
+      }
+    },
+    "analysis.insights.no_data_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No persisted events were observed. This is not a statement about network health."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden keine gespeicherten Ereignisse beobachtet. Das ist keine Aussage über die Netzwerkgesundheit."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se observaron eventos persistidos. Esto no es una afirmación sobre la salud de la red."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存されたイベントはありません。ネットワークの健全性を示すものではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有观测到持久化事件。这不是对网络健康度的判断。"
+          }
+        }
+      }
+    },
+    "analysis.insights.no_findings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No rule findings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Regelbefunde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin hallazgos de reglas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "該当する検出なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有规则发现"
+          }
+        }
+      }
+    },
+    "analysis.insights.no_findings_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No enabled rule matched the recorded observations. This does not mean the network is healthy."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine aktivierte Regel passte zu den aufgezeichneten Beobachtungen. Das bedeutet nicht, dass das Netzwerk gesund ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna regla habilitada coincidió con las observaciones registradas. Esto no significa que la red esté sana."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なルールに一致する観測はありませんでした。ネットワークが健全という意味ではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有启用的规则匹配已记录观测。这不表示网络正常。"
+          }
+        }
+      }
+    },
+    "analysis.insights.partial_analysis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partial analysis"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilweise Analyse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análisis parcial"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分的な分析"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分分析"
+          }
+        }
+      }
+    },
+    "analysis.insights.partial_analysis_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage is unavailable or incomplete. Any findings below are based only on clusters in recorded events."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Beobachtungsabdeckung ist nicht verfügbar oder unvollständig. Die folgenden Befunde basieren ausschließlich auf Häufungen aufgezeichneter Ereignisse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura de observación no está disponible o está incompleta. Los hallazgos siguientes se basan únicamente en agrupaciones de eventos registrados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測範囲を確認できないか、不完全です。以下の検出は、記録されたイベントの集中のみを根拠とします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测覆盖范围无法确认或不完整。下方发现仅基于已记录事件的集中出现。"
+          }
+        }
+      }
+    },
+    "analysis.insights.period": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间范围"
+          }
+        }
+      }
+    },
+    "analysis.insights.shell_description": {
+      "comment": "Static Insights page shell description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkenntnisse werden hier angezeigt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights will appear here."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los insights aparecerán aquí."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インサイトはここに表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "洞察将在此显示。"
+          }
+        }
+      }
+    },
+    "analysis.insights.view_timeline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View in Timeline"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Timeline anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver en Timeline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timelineで表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Timeline 中查看"
+          }
+        }
+      }
+    },
+    "analysis.readiness.coverage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungsabdeckung nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura de observación no disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測範囲を確認できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确认观测覆盖范围"
+          }
+        }
+      }
+    },
+    "analysis.readiness.coverage_unavailable_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change events do not record continuous observation coverage. Counts describe recorded events only."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungsereignisse erfassen keine kontinuierliche Beobachtungsabdeckung. Die Zählungen beschreiben nur aufgezeichnete Ereignisse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los eventos de cambio no registran una cobertura de observación continua. Los recuentos solo describen eventos registrados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変化イベントから連続した観測範囲は確認できません。件数は記録されたイベントのみを示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "变化事件不记录连续的观测覆盖范围。计数仅描述已记录的事件。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.incomplete_coverage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage is incomplete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung ist unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura es incompleta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測範囲が不完全"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖范围不完整"
+          }
+        }
+      }
+    },
+    "analysis.readiness.incomplete_coverage_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gaps in observation limit what can be concluded."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungslücken begrenzen mögliche Schlussfolgerungen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las brechas de observación limitan las conclusiones posibles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測の空白により判断できる範囲が限られます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测间隔限制了可得出的结论。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.no_data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No history in this period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Verlauf in diesem Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin historial en este período"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間に履歴なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此时间范围内没有历史记录"
+          }
+        }
+      }
+    },
+    "analysis.readiness.no_data_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No persisted events were observed. This does not mean zero network activity."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden keine gespeicherten Ereignisse beobachtet. Das bedeutet nicht, dass keine Netzwerkaktivität stattfand."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se observaron eventos persistidos. Esto no significa que haya cero actividad de red."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存されたイベントはありません。ネットワーク活動がゼロという意味ではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有观测到持久化事件。这不表示网络活动为零。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.short_history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is short"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf ist kurz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial es corto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴が短い"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录太短"
+          }
+        }
+      }
+    },
+    "analysis.readiness.short_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The observed history is too short for complete analysis."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der beobachtete Verlauf ist für eine vollständige Analyse zu kurz."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial observado es demasiado corto para un análisis completo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全な分析には観測履歴が短すぎます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测历史太短，无法进行完整分析。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.sufficient_evidence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sufficient observed evidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausreichende Beobachtungsdaten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidencia observada suficiente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "十分な観測証拠"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有足够的观测证据"
+          }
+        }
+      }
+    },
+    "analysis.readiness.sufficient_evidence_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistics describe recorded observations only; they do not assess network health."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken beschreiben nur aufgezeichnete Beobachtungen und bewerten nicht die Netzwerkgesundheit."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las estadísticas describen solo observaciones registradas; no evalúan la salud de la red."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計は記録された観測のみを示し、ネットワークの健全性は評価しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计仅描述已记录的观测，不评估网络健康度。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.connections": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connections"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexiones"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        }
+      }
+    },
+    "analysis.statistics.coverage_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed from %@ to %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtet von %@ bis %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observado de %@ a %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ から %@ まで観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测范围：%@ 至 %@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.disconnections": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnections"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trennungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconexiones"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接"
+          }
+        }
+      }
+    },
+    "analysis.statistics.distribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event distribution"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisverteilung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribución de eventos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント分布"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件分布"
+          }
+        }
+      }
+    },
+    "analysis.statistics.event_range_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First recorded event: %@. Last recorded event: %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstes aufgezeichnetes Ereignis: %@. Letztes aufgezeichnetes Ereignis: %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primer evento registrado: %@. Último evento registrado: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最初に記録されたイベント：%@。最後に記録されたイベント：%@。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首条已记录事件：%@。末条已记录事件：%@。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.failure_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistics unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas no disponibles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計を利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计不可用"
+          }
+        }
+      }
+    },
+    "analysis.statistics.gateway_interruptions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Latenzbeobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones de latencia del gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关延迟观测"
+          }
+        }
+      }
+    },
+    "analysis.statistics.load_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local history could not be loaded."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der lokale Verlauf konnte nicht geladen werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo cargar el historial local."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴を読み込めませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法加载本地历史记录。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading local history…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokaler Verlauf wird geladen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando historial local…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴を読み込み中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载本地历史记录…"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_result_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a period to inspect local Timeline history."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen Zeitraum, um den lokalen Timeline-Verlauf zu prüfen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione un período para revisar el historial local de Timeline."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間を選択してローカルのTimeline履歴を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择时间范围以查看本地 Timeline 历史记录。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_result_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No analysis result"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Analyseergebnis"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin resultado de análisis"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析結果なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有分析结果"
+          }
+        }
+      }
+    },
+    "analysis.statistics.period": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间范围"
+          }
+        }
+      }
+    },
+    "analysis.statistics.period.seven_days": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 Days"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 Tage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 días"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7日間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7天"
+          }
+        }
+      }
+    },
+    "analysis.statistics.period.thirty_days": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 Days"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 Tage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 días"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30日間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30天"
+          }
+        }
+      }
+    },
+    "analysis.statistics.period.today": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heute"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今天"
+          }
+        }
+      }
+    },
+    "analysis.statistics.roaming": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローミング"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "漫游"
+          }
+        }
+      }
+    },
+    "analysis.statistics.shell_description": {
+      "comment": "Static Statistics page shell description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken werden hier angezeigt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistics will appear here."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las estadísticas aparecerán aquí."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計情報はここに表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计信息将在此显示。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.total_events": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse gesamt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos totales"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント合計"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件总数"
+          }
+        }
+      }
     },
     "ble.accessibility.trend_chart_fmt": {
       "extractionState": "manual",
@@ -1248,32 +3173,6 @@
           }
         }
       }
-    },
-    "Ch %@": {
-      "shouldTranslate": false
-    },
-    "CH %@  %@ dBm": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "CH %1$@  %2$@ dBm"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
-          }
-        }
-      },
-      "shouldTranslate": false
     },
     "channels.accessibility.card_label": {
       "comment": "Channel card accessibility label with channel, band, quality, and score",
@@ -4513,6 +6412,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "切换展开"
+          }
+        }
+      }
+    },
+    "common.badge.preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
+        }
+      }
+    },
+    "common.badge.pro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
           }
         }
       }
@@ -9079,6 +11048,41 @@
         }
       }
     },
+    "nav.insights": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkenntnisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インサイト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "洞察"
+          }
+        }
+      }
+    },
     "nav.interfaces": {
       "comment": "Interfaces sidebar navigation item",
       "extractionState": "manual",
@@ -9111,6 +11115,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "接口"
+          }
+        }
+      }
+    },
+    "nav.network_diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Check"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク診断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络自检"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerktest"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico de red"
           }
         }
       }
@@ -9331,6 +11370,41 @@
         }
       }
     },
+    "nav.statistics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistics"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计"
+          }
+        }
+      }
+    },
     "nav.timeline": {
       "comment": "Timeline sidebar navigation item",
       "extractionState": "manual",
@@ -9363,6 +11437,3226 @@
           "stringUnit": {
             "state": "translated",
             "value": "时间线"
+          }
+        }
+      }
+    },
+    "network_diagnostics.action.run": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Diagnostics"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断を開始"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始检测"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar diagnóstico"
+          }
+        }
+      }
+    },
+    "network_diagnostics.action.run_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "もう一度診断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新检测"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut ausführen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar de nuevo"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.connectivity.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Connection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク接続"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkverbindung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexión de red"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.dns.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS Resolution"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS解決"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 解析"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS-Auflösung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolución DNS"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.internet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet Access"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インターネットアクセス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "互联网访问"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internetzugang"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso a Internet"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.ipv6.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6 Access"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6-Zugriff"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso IPv6"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6アクセス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6 访问"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.path.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Network Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムネットワーク経路"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统网络路径"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemnetzwerkpfad"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta de red del sistema"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.proxy.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Proxy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムプロキシ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统代理"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemproxy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy del sistema"
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.attention.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review any result marked for attention below."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下で注意が必要と表示された結果を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请检查下方标记为需要注意的检测结果。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe unten alle Ergebnisse, die Aufmerksamkeit erfordern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisa abajo cualquier resultado que requiera atención."
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.attention.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs Attention"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認が必要です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要注意"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfung erforderlich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere atención"
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.normal.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All checks completed without finding a problem."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての確認が完了し、問題は見つかりませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有检测均已完成，未发现问题。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Prüfungen wurden abgeschlossen, ohne ein Problem zu finden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las comprobaciones terminaron sin encontrar problemas."
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.normal.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Normal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークは正常です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络正常"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk normal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red normal"
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.unavailable.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac does not currently have a working network connection."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacには現在、利用可能なネットワーク接続がありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 Mac 当前没有可用的网络连接。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Mac hat derzeit keine funktionierende Netzwerkverbindung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este Mac no tiene actualmente una conexión de red operativa."
+          }
+        }
+      }
+    },
+    "network_diagnostics.conclusion.unavailable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络不可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red no disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.connectivity.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No network connection is available. Check Wi-Fi or Ethernet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用できるネットワーク接続がありません。Wi-Fi または Ethernet を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未连接到可用网络，请检查 Wi-Fi 或网线。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Netzwerkverbindung verfügbar. Prüfe Wi-Fi oder Ethernet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna conexión de red disponible. Comprueba la conexión Wi-Fi o Ethernet."
+          }
+        }
+      }
+    },
+    "network_diagnostics.connectivity.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The network connection could not be confirmed. Try again later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク接続を確認できませんでした。しばらくしてからもう一度お試しください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂时无法确认网络连接状态，请稍后重试。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Netzwerkverbindung konnte nicht bestätigt werden. Versuche es später erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo confirmar la conexión de red. Inténtalo de nuevo más tarde."
+          }
+        }
+      }
+    },
+    "network_diagnostics.connectivity.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続を利用できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexión disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check this Mac's network connection, DNS resolution, and system proxy settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacのネットワーク接続、DNS解決、システムプロキシ設定を確認します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查此 Mac 的网络连接、DNS 解析和系统代理设置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüft die Netzwerkverbindung, DNS-Auflösung und Systemproxy-Einstellungen dieses Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba la conexión de red, la resolución DNS y los ajustes de proxy del sistema de este Mac."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain names cannot be resolved, so some websites may not open. Check DNS settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン名を解決できないため、一部の Web サイトを開けない可能性があります。DNS 設定を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解析域名，部分网站可能无法打开；请检查 DNS 设置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domänennamen können nicht aufgelöst werden, daher lassen sich manche Websites möglicherweise nicht öffnen. Prüfe die DNS-Einstellungen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pueden resolver los nombres de dominio, por lo que es posible que algunos sitios web no se abran. Comprueba los ajustes de DNS."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.available.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS resolution is available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS の名前解決を利用できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS 解析可用。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die DNS-Auflösung ist verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de DNS está disponible."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.inconsistent.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS resolution is inconsistent across test names."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト名で DNS 解決の結果が一致しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各测试域名的 DNS 解析结果不一致。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die DNS-Auflösung ist bei den Testnamen uneinheitlich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de DNS es inconsistente entre los nombres de prueba."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The DNS check could not be completed. Try again later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS チェックを完了できませんでした。しばらくしてからもう一度お試しください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂时无法完成 DNS 检查，请稍后重试。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die DNS-Prüfung konnte nicht abgeschlossen werden. Versuche es später erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo completar la comprobación de DNS. Inténtalo de nuevo más tarde."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain name resolution is working"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン名の解決は正常です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名解析正常"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Namensauflösung funktioniert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de nombres de dominio funciona"
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.unable_to_determine.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The DNS result could not be determined."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS の結果を判断できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确定 DNS 结果。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das DNS-Ergebnis konnte nicht ermittelt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo determinar el resultado de DNS."
+          }
+        }
+      }
+    },
+    "network_diagnostics.dns.unavailable.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS resolution failed for all test names."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのテスト名で DNS 解決に失敗しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有测试域名的 DNS 解析均失败。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die DNS-Auflösung ist für alle Testnamen fehlgeschlagen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de DNS falló para todos los nombres de prueba."
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.abnormal.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One or more control endpoint responses did not match the expected result."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 つ以上の制御エンドポイントのレスポンスが想定された結果と一致しませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一个或多个控制端点响应与预期结果不符。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestens eine Antwort eines Kontrollendpunkts entsprach nicht dem erwarteten Ergebnis."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una o más respuestas de los puntos de conexión de control no coincidieron con el resultado esperado."
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control endpoint checks need attention"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制御エンドポイントの確認が必要です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制端点检查需要注意"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontrollendpunktprüfungen erfordern Aufmerksamkeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las comprobaciones de los puntos de conexión de control requieren atención"
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.certificate_time_failure.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The HTTPS certificate is not valid for the current system time"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のシステム時刻では HTTPS 証明書が有効ではありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前系统时间不在 HTTPS 证书的有效期内"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das HTTPS-Zertifikat ist für die aktuelle Systemzeit nicht gültig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El certificado HTTPS no es válido para la hora actual del sistema"
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.connectivity_failure.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The direct HTTPS connection could not be established"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接 HTTPS 接続を確立できませんでした"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法建立直接 HTTPS 连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die direkte HTTPS-Verbindung konnte nicht hergestellt werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo establecer la conexión HTTPS directa"
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.indeterminate.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS access succeeded, but the captive-portal control endpoint did not respond in time."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS アクセスは成功しましたが、キャプティブポータルの制御エンドポイントが時間内に応答しませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS 访问成功，但强制门户控制端点未在规定时间内响应。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der HTTPS-Zugriff war erfolgreich, aber der Kontrollendpunkt für Captive Portale hat nicht rechtzeitig geantwortet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El acceso HTTPS se completó correctamente, pero el punto de conexión de control del portal cautivo no respondió a tiempo."
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control endpoint check is inconclusive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制御エンドポイントの確認結果は確定できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制端点检查结果无法确定"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontrollendpunktprüfung ist nicht eindeutig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La comprobación del punto de conexión de control no es concluyente"
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.normal.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The HTTPS request succeeded and the captive-portal control response matched."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS リクエストが成功し、キャプティブポータルの制御レスポンスが一致しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS 请求成功，强制门户控制响应符合预期。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die HTTPS-Anfrage war erfolgreich und die Kontrollantwort für das Captive Portal stimmte überein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La solicitud HTTPS se completó correctamente y la respuesta de control del portal cautivo coincidió."
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS access verified"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS アクセスを確認しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已验证 HTTPS 访问"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS-Zugriff bestätigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso HTTPS verificado"
+          }
+        }
+      }
+    },
+    "network_diagnostics.internet.secure_connection_failure.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The HTTPS connection failed during TLS or certificate validation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TLS または証明書の検証中に HTTPS 接続が失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS 连接在 TLS 或证书验证期间失败"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die HTTPS-Verbindung ist bei der TLS- oder Zertifikatsprüfung fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La conexión HTTPS falló durante la validación TLS o del certificado"
+          }
+        }
+      }
+    },
+    "network_diagnostics.ipv6.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6 HTTPS access could not be verified. IPv4 access may still work."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der IPv6-HTTPS-Zugriff konnte nicht bestätigt werden. Der IPv4-Zugriff kann weiterhin funktionieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo verificar el acceso HTTPS mediante IPv6. Es posible que el acceso IPv4 siga funcionando."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6経由のHTTPSアクセスを確認できませんでした。IPv4アクセスは引き続き利用できる可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法验证通过 IPv6 的 HTTPS 访问。IPv4 访问可能仍然可用。"
+          }
+        }
+      }
+    },
+    "network_diagnostics.ipv6.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6 HTTPS access verified"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6-HTTPS-Zugriff bestätigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso HTTPS mediante IPv6 verificado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6経由のHTTPSアクセスを確認しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已验证通过 IPv6 的 HTTPS 访问"
+          }
+        }
+      }
+    },
+    "network_diagnostics.ipv6.skipped.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No global IPv6 address is available, so the optional IPv6 check was skipped."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine globale IPv6-Adresse ist verfügbar. Daher wurde die optionale IPv6-Prüfung übersprungen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna dirección IPv6 global disponible, por lo que se omitió la comprobación IPv6 opcional."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グローバルIPv6アドレスを利用できないため、オプションのIPv6チェックをスキップしました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的全局 IPv6 地址，因此跳过了可选的 IPv6 检查。"
+          }
+        }
+      }
+    },
+    "network_diagnostics.path.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No system network path is available. Check Wi-Fi or Ethernet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なシステムネットワーク経路がありません。Wi-Fi または Ethernet を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用的系统网络路径。请检查 Wi-Fi 或以太网。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Systemnetzwerkpfad ist verfügbar. Prüfe Wi-Fi oder Ethernet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay una ruta de red del sistema disponible. Comprueba Wi-Fi o Ethernet."
+          }
+        }
+      }
+    },
+    "network_diagnostics.path.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The system network path could not be confirmed. Try again later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムネットワーク経路を確認できませんでした。しばらくしてからもう一度お試しください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂时无法确认系统网络路径，请稍后重试。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Systemnetzwerkpfad konnte nicht bestätigt werden. Versuche es später erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo confirmar la ruta de red del sistema. Inténtalo de nuevo más tarde."
+          }
+        }
+      }
+    },
+    "network_diagnostics.path.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System network path is available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムネットワーク経路を利用できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统网络路径可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Systemnetzwerkpfad ist verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta de red del sistema está disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.path_summary.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed network path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出されたネットワーク経路"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到的网络路径"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkannter Netzwerkpfad"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta de red detectada"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The system proxy cannot be reached and may prevent websites from opening. Check or turn off the proxy settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムプロキシに接続できないため、Web サイトを開けない可能性があります。プロキシ設定を確認するか、オフにしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统代理无法连接，可能导致网页无法访问；请检查或关闭代理设置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Systemproxy ist nicht erreichbar und verhindert möglicherweise das Öffnen von Websites. Prüfe oder deaktiviere die Proxyeinstellungen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede acceder al proxy del sistema, lo que puede impedir que se abran sitios web. Comprueba o desactiva los ajustes del proxy."
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.authentication_required.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A tested proxy route requires authentication"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストしたプロキシルートには認証が必要です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试的代理路由需要身份验证"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine getestete Proxy-Route erfordert eine Authentifizierung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una ruta de proxy probada requiere autenticación"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.automatic.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "automatic proxy configuration was detected and was not evaluated."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動プロキシ構成が検出されましたが、評価されませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到自动代理配置，但未进行评估。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine automatische Proxy-Konfiguration wurde erkannt und nicht ausgewertet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó una configuración automática del proxy, pero no se evaluó."
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.direct_routes.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The tested HTTP and HTTPS routes use direct connections"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストした HTTP および HTTPS ルートは直接接続を使用しています"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试的 HTTP 和 HTTPS 路由使用直接连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die getesteten HTTP- und HTTPS-Routen verwenden Direktverbindungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las rutas HTTP y HTTPS probadas usan conexiones directas"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.disabled.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System proxy not in use"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムプロキシは使用されていません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未使用系统代理"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemproxy wird nicht verwendet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proxy del sistema no está en uso"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.egress_unavailable.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected proxy cannot reach the control endpoint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたプロキシから制御エンドポイントに接続できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选代理无法访问控制端点"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der ausgewählte Proxy kann den Kontrollendpunkt nicht erreichen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proxy seleccionado no puede acceder al punto de conexión de control"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.endpoint_unavailable.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected proxy endpoint is unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたプロキシエンドポイントを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选代理端点不可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der ausgewählte Proxy-Endpunkt ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El punto de conexión del proxy seleccionado no está disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The system proxy could not be fully verified."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムプロキシを完全には確認できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法完整确认系统代理是否可用。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Systemproxy konnte nicht vollständig überprüft werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo verificar por completo el proxy del sistema."
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.mixed_routing.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The tested HTTP and HTTPS routes use different proxy paths"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストした HTTP および HTTPS ルートは異なるプロキシ経路を使用しています"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试的 HTTP 和 HTTPS 路由使用不同的代理路径"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die getesteten HTTP- und HTTPS-Routen verwenden unterschiedliche Proxy-Pfade"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las rutas HTTP y HTTPS probadas usan distintas rutas de proxy"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System proxy available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムプロキシを利用できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统代理可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemproxy verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy del sistema disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.pac_unavailable.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic proxy configuration is unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動プロキシ構成を利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动代理配置不可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die automatische Proxy-Konfiguration ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La configuración automática del proxy no está disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.route_unavailable.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A tested proxy route is unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストしたプロキシルートを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试的代理路由不可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine getestete Proxy-Route ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una ruta de proxy probada no está disponible"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.routes_available.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The tested proxy routes are available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストしたプロキシルートを利用できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试的代理路由可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die getesteten Proxy-Routen sind verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las rutas de proxy probadas están disponibles"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.unable_to_determine.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to determine the tested proxy routes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストしたプロキシルートを判定できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确定测试的代理路由"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die getesteten Proxy-Routen konnten nicht ermittelt werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron determinar las rutas de proxy probadas"
+          }
+        }
+      }
+    },
+    "network_diagnostics.ready.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie die Diagnose, um das Netzwerk dieses Macs zu prüfen. Die Ergebnisse werden hier angezeigt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run diagnostics to check this Mac’s network. Results will appear here."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta el diagnóstico para comprobar la red de este Mac. Los resultados aparecerán aquí."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断を実行して、このMacのネットワークを確認します。結果はここに表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行诊断以检查此 Mac 的网络，结果将显示在这里。"
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open a browser and complete the network sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザを開いてネットワークへのサインインを完了してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开浏览器并完成网络登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne einen Browser und schließe die Netzwerkanmeldung ab."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre un navegador y completa el inicio de sesión de la red."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A captive portal may be intercepting web access."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプティブポータルがウェブアクセスを遮っている可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络门户可能正在拦截网页访问。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Captive Portal fängt möglicherweise den Webzugriff ab."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que un portal cautivo esté interceptando el acceso web."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The network may require sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークでサインインが必要な可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络可能需要登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für dieses Netzwerk ist möglicherweise eine Anmeldung erforderlich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la red requiera iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on automatic date and time, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付と時刻の自動設定を有効にして、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启自动设置日期和时间，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviere Datum und Uhrzeit automatisch und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa la fecha y hora automáticas y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac date or time may be incorrect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macの日付または時刻が正しくない可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 的日期或时间可能不正确。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum oder Uhrzeit des Mac sind möglicherweise falsch."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la fecha o la hora del Mac sean incorrectas."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The secure connection certificate time is invalid."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全な接続の証明書時刻が正しくありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全连接的证书时间无效。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zertifikatszeit der sicheren Verbindung ist ungültig."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La hora del certificado de la conexión segura no es válida."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect to the network or try another DNS configuration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークに再接続するか、別のDNS設定を試してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新连接网络，或尝试其他 DNS 配置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde dich erneut mit dem Netzwerk oder probiere eine andere DNS-Konfiguration."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a conectarte a la red o prueba otra configuración DNS."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current network or DNS configuration may not be responding."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のネットワークまたはDNS設定が応答していない可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前网络或 DNS 配置可能没有响应。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das aktuelle Netzwerk oder die DNS-Konfiguration antwortet möglicherweise nicht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la red actual o la configuración DNS no respondan."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name lookup is unavailable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前解決を利用できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名解析不可用。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Namensauflösung ist nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de nombres no está disponible."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the network settings and run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查网络设置，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisa la configuración de red y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The result points to a network configuration or connectivity issue."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定または接続に問題がある可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结果指向网络配置或连接问题。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Ergebnis weist auf ein Problem mit der Netzwerkkonfiguration oder Verbindung hin."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El resultado apunta a un problema de configuración o conectividad de red."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This network check found a problem."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークチェックで問題が見つかりました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络检查发现了问题。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Netzwerkprüfung hat ein Problem gefunden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La comprobación de red ha encontrado un problema."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the network settings, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查网络设置，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba la configuración de red y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The available evidence is inconclusive, so no single cause can be confirmed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠が不十分なため、原因を1つに特定できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "现有证据不足，无法确认单一原因。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die verfügbaren Hinweise sind nicht eindeutig; eine einzelne Ursache kann nicht bestätigt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las pruebas disponibles no son concluyentes, por lo que no se puede confirmar una única causa."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This check could not be confirmed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このチェックを確認できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确认此项检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Prüfung konnte nicht bestätigt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo confirmar esta comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect the network, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークに再接続して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新连接网络，然后再次运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde dich erneut mit dem Netzwerk und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a conectarte a la red y ejecuta de nuevo la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi, Ethernet, or the selected network service may be disconnected."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi、Ethernet、または選択されたネットワークサービスが切断されている可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi、以太网或选中的网络服务可能已断开。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WLAN, Ethernet oder der ausgewählte Netzwerkdienst ist möglicherweise getrennt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la Wi-Fi, Ethernet o el servicio de red seleccionado estén desconectados."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac does not have a usable network path."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macに利用可能なネットワーク経路がありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 没有可用的网络路径。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Mac hat keinen nutzbaren Netzwerkpfad."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El Mac no tiene una ruta de red utilizable."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the proxy credentials or sign in again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシの認証情報を確認するか、もう一度サインインしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查代理凭据，或重新登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Proxy-Zugangsdaten oder melde dich erneut an."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba las credenciales del proxy o vuelve a iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy credentials may be missing or expired."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシの認証情報が未設定または期限切れの可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理凭据可能未设置或已过期。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Proxy-Zugangsdaten fehlen möglicherweise oder sind abgelaufen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que las credenciales del proxy falten o hayan caducado."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy requested sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシが認証を要求しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理要求登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Proxy verlangt eine Anmeldung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proxy solicita iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start the proxy app, or disable the stale system proxy."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシアプリを起動するか、古いシステムプロキシを無効にしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动代理应用，或禁用失效的系统代理。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte die Proxy-App oder deaktiviere den veralteten Systemproxy."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia la app del proxy o desactiva el proxy del sistema obsoleto."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy app may be stopped, or an old proxy setting may remain enabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシアプリが停止しているか、古いプロキシ設定が有効な可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理应用可能已停止，或旧代理设置仍处于启用状态。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Proxy-App wurde möglicherweise beendet oder eine alte Proxy-Einstellung ist noch aktiv."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la app del proxy esté detenida o que una configuración antigua siga activa."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A configured proxy route could not be reached."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定されたプロキシ経路に接続できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法访问已配置的代理路径。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine konfigurierte Proxyroute war nicht erreichbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo alcanzar una ruta de proxy configurada."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.rerun": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Network Self-Check again after making the change."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更後にネットワークセルフチェックをもう一度実行してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成更改后，再次运行网络自检。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe die Netzwerk-Selbstprüfung nach der Änderung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a ejecutar la autocomprobación de red después de realizar el cambio."
+          }
+        }
+      }
+    },
+    "network_diagnostics.report.column.check": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobación"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查项目"
+          }
+        }
+      }
+    },
+    "network_diagnostics.report.column.result": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ergebnis"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Result"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結果"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结果"
+          }
+        }
+      }
+    },
+    "network_diagnostics.report.column.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状態"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态"
+          }
+        }
+      }
+    },
+    "network_diagnostics.state.checking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测中…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando…"
+          }
+        }
+      }
+    },
+    "network_diagnostics.state.completed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check complete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認完了"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测完成"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfung abgeschlossen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobación completada"
+          }
+        }
+      }
+    },
+    "network_diagnostics.state.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting to run"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行待ち"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待检测"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf Ausführung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En espera"
+          }
+        }
+      }
+    },
+    "network_diagnostics.status.abnormal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abnormal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "異常"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "异常"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehlerhaft"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anómalo"
+          }
+        }
+      }
+    },
+    "network_diagnostics.status.blocked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocked"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブロックされています"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已阻止"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blockiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueado"
+          }
+        }
+      }
+    },
+    "network_diagnostics.status.indeterminate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indeterminate"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "判定不能"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法判断"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht bestimmbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No determinable"
+          }
+        }
+      }
+    },
+    "network_diagnostics.status.normal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正常"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正常"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        }
+      }
+    },
+    "network_diagnostics.status.skipped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップ済み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已跳过"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersprungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitido"
           }
         }
       }
@@ -11311,9 +16605,6 @@
         }
       }
     },
-    "PRO": {
-      "shouldTranslate": false
-    },
     "pro.accessibility.feature_fmt": {
       "extractionState": "manual",
       "localizations": {
@@ -11381,6 +16672,78 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话录制"
+          }
+        }
+      }
+    },
+    "pro.insights.description": {
+      "comment": "Pro Insights feature description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhalten Sie nachvollziehbare Hinweise aus Ihrer Timeline-Historie."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get explainable findings from your Timeline history."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtén conclusiones explicables de tu historial de Timeline."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeline履歴から根拠のあるインサイトを確認できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从时间线历史记录中获取可解释的洞察。"
+          }
+        }
+      }
+    },
+    "pro.insights.title": {
+      "comment": "Pro Insights feature title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkenntnisse"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insights"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インサイト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "洞察"
           }
         }
       }
@@ -11591,6 +16954,78 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话录制"
+          }
+        }
+      }
+    },
+    "pro.statistics.description": {
+      "comment": "Pro Statistics feature description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysieren Sie Ihre lokale Timeline-Historie."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyze your local Timeline history."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiza tu historial local de Timeline."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルのTimeline履歴を分析します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析本地时间线历史记录。"
+          }
+        }
+      }
+    },
+    "pro.statistics.title": {
+      "comment": "Pro Statistics feature title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiken"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "统计"
           }
         }
       }
@@ -13105,9 +18540,6 @@
         }
       }
     },
-    "RSSI %@ dBm": {
-      "shouldTranslate": false
-    },
     "settings.about.app_store": {
       "extractionState": "manual",
       "localizations": {
@@ -13790,31 +19222,31 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Löscht alle aufgezeichneten Timeline-Ereignisse dauerhaft von diesem Mac."
+            "value": "Löscht alle aufgezeichneten Timeline-Ereignisse und die lokale Analyse-Historie dauerhaft von diesem Mac."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Permanently delete all recorded timeline events from this Mac."
+            "value": "Permanently delete all recorded Timeline events and local Analysis history from this Mac."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Elimina permanentemente todos los eventos de la línea de tiempo de este Mac."
+            "value": "Elimina permanentemente todos los eventos de la línea de tiempo y el historial de análisis local de este Mac."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "この Mac に保存されているタイムラインイベントをすべて完全に削除します。"
+            "value": "この Mac に保存されているタイムラインイベントとローカルの分析履歴をすべて完全に削除します。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "永久删除本机上记录的所有时间线事件。"
+            "value": "永久删除本机上记录的所有时间线事件和本地分析历史。"
           }
         }
       }
@@ -14070,6 +19502,3171 @@
           }
         }
       }
+    },
+    "settings.mac_vendor.clear_action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeren…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Clear…"
+    },
+    "settings.mac_vendor.clear_action_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove local vendor data without changing the reminder setting."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知設定を変更せずにローカルのベンダーデータを削除します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除本地厂商数据，但不更改提醒设置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Herstellerdaten entfernen, ohne die Erinnerungseinstellung zu ändern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina los datos locales de fabricantes sin cambiar el ajuste de recordatorio."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Remove local vendor data without changing the reminder setting."
+    },
+    "settings.mac_vendor.clear_confirmation_action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Database"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データベースを消去"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空数据库"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenbank leeren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar base de datos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Clear Database"
+    },
+    "settings.mac_vendor.clear_confirmation_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vendor values will display as an em dash until you install another database."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のデータベースをインストールするまで、ベンダー欄にはダッシュが表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装其他数据库前，厂商值将显示为破折号。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bis zur Installation einer anderen Datenbank werden Herstellerwerte als Gedankenstrich angezeigt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los valores de fabricante se mostrarán como una raya hasta que instales otra base de datos."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Vendor values will display as an em dash until you install another database."
+    },
+    "settings.mac_vendor.clear_confirmation_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear MAC vendor database?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MACベンダーデータベースを消去しますか？"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清空 MAC 厂商数据库？"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC-Herstellerdatenbank leeren?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar la base de datos de fabricantes MAC?"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Clear MAC vendor database?"
+    },
+    "settings.mac_vendor.error.automatic_download_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One or more IEEE registry files could not be downloaded. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1つ以上のIEEEレジストリファイルをダウンロードできませんでした。もう一度お試しください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一个或多个 IEEE 注册表文件无法下载，请重试。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestens eine IEEE-Registrierungsdatei konnte nicht heruntergeladen werden. Versuche es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron descargar uno o varios archivos de registro de IEEE. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "settings.mac_vendor.error.conflicting_assignment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The assignment %@/%lld has conflicting organizations."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "割り当て%@/%lldの組織が競合しています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分配 %@/%lld 对应的组织存在冲突。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zuweisung %@/%lld enthält widersprüchliche Organisationen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La asignación %@/%lld tiene organizaciones en conflicto."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The assignment %@/%lld has conflicting organizations."
+    },
+    "settings.mac_vendor.error.database_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Database Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データベースエラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据库错误"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenbankfehler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de base de datos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Database Error"
+    },
+    "settings.mac_vendor.error.disallowed_redirect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The download redirected to a disallowed address: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードが許可されていないアドレスにリダイレクトされました：%@。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载被重定向到不允许的地址：%@。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Download wurde an eine nicht zulässige Adresse umgeleitet: %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La descarga se redirigió a una dirección no permitida: %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The download redirected to a disallowed address: %@."
+    },
+    "settings.mac_vendor.error.download_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The %@ download failed. Try again or use manual import."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のダウンロードに失敗しました。再試行するか、手動インポートを使用してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 下载失败。请重试或使用手动导入。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der %@-Download ist fehlgeschlagen. Versuchen Sie es erneut oder verwenden Sie den manuellen Import."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La descarga de %@ falló. Inténtalo de nuevo o usa la importación manual."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The %@ download failed. Try again or use manual import."
+    },
+    "settings.mac_vendor.error.download_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードに失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载失败"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de descarga"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download Failed"
+    },
+    "settings.mac_vendor.error.duplicate_registry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More than one %@ file was selected."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ファイルが複数選択されています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择了多个 %@ 文件。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr als eine %@-Datei wurde ausgewählt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se seleccionó más de un archivo %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: More than one %@ file was selected."
+    },
+    "settings.mac_vendor.error.file_read_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ could not be read. Choose the four CSV files again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を読み込めませんでした。4つのCSVファイルを選び直してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取 %@。请重新选择四个 CSV 文件。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nicht gelesen werden. Wählen Sie die vier CSV-Dateien erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer %@. Vuelve a elegir los cuatro archivos CSV."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ could not be read. Choose the four CSV files again."
+    },
+    "settings.mac_vendor.error.file_too_large": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ exceeds the %@ file-size limit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@はファイルサイズ上限（%@）を超えています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 超过了 %@ 的文件大小限制。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ überschreitet die Dateigrößengrenze von %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ supera el límite de tamaño de archivo de %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ exceeds the %@ file-size limit."
+    },
+    "settings.mac_vendor.error.files_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files Could Not Be Read"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを読み込めませんでした"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取文件"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien konnten nicht gelesen werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron leer los archivos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Files Could Not Be Read"
+    },
+    "settings.mac_vendor.error.http_status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For %@, IEEE returned HTTP %lld."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@でIEEEがHTTP %lldを返しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE 为 %@ 返回了 HTTP %lld。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für %@ hat IEEE HTTP %lld zurückgegeben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para %@, IEEE devolvió HTTP %lld."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: For %@, IEEE returned HTTP %lld."
+    },
+    "settings.mac_vendor.error.invalid_assignment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contains an invalid %@ assignment: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に無効な%@割り当てがあります：%@。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 包含无效的 %@ 分配：%@。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enthält eine ungültige %@-Zuweisung: %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contiene una asignación %@ no válida: %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ contains an invalid %@ assignment: %@."
+    },
+    "settings.mac_vendor.error.invalid_encoding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is not valid UTF-8 CSV data."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@は有効なUTF-8 CSVデータではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不是有效的 UTF-8 CSV 数据。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enthält keine gültigen UTF-8-CSV-Daten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ no contiene datos CSV UTF-8 válidos."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ is not valid UTF-8 CSV data."
+    },
+    "settings.mac_vendor.error.invalid_organization": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contains an invalid organization name."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に無効な組織名があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 包含无效的组织名称。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enthält einen ungültigen Organisationsnamen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contiene un nombre de organización no válido."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ contains an invalid organization name."
+    },
+    "settings.mac_vendor.error.malformed_csv": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contains malformed CSV data."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のCSVデータが不正です。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 包含格式错误的 CSV 数据。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enthält fehlerhafte CSV-Daten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contiene datos CSV mal formados."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ contains malformed CSV data."
+    },
+    "settings.mac_vendor.error.missing_columns": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is missing required columns: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に必須列がありません：%@。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 缺少必需列：%@。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ fehlen erforderliche Spalten: %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A %@ le faltan columnas obligatorias: %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ is missing required columns: %@."
+    },
+    "settings.mac_vendor.error.missing_registry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The %@ file is missing."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ファイルがありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 %@ 文件。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die %@-Datei fehlt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el archivo %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The %@ file is missing."
+    },
+    "settings.mac_vendor.error.mixed_registries": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contains more than one registry type."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に複数のレジストリ種別が含まれています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 包含多种注册表类型。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enthält mehrere Registertypen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contiene más de un tipo de registro."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ contains more than one registry type."
+    },
+    "settings.mac_vendor.error.no_prepared_import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validate all four CSV files before importing."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートする前に4つのCSVファイルをすべて検証してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入前请先校验全部四个 CSV 文件。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen Sie vor dem Import alle vier CSV-Dateien."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valida los cuatro archivos CSV antes de importarlos."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Validate all four CSV files before importing."
+    },
+    "settings.mac_vendor.error.persistence_failure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The local database could not be saved, loaded, or removed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルデータベースを保存、読み込み、または削除できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存、加载或移除本地数据库。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die lokale Datenbank konnte nicht gespeichert, geladen oder entfernt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo guardar, cargar o eliminar la base de datos local."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The local database could not be saved, loaded, or removed."
+    },
+    "settings.mac_vendor.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC Vendor Database Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MACベンダーデータベースエラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC 厂商数据库错误"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler der MAC-Herstellerdatenbank"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de la base de datos de fabricantes MAC"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: MAC Vendor Database Error"
+    },
+    "settings.mac_vendor.error.too_few_records": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ requires at least %lld valid records; %lld were found."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@には有効なレコードが%lld件以上必要ですが、%lld件しかありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 至少需要 %lld 条有效记录，但只找到 %lld 条。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ benötigt mindestens %lld gültige Einträge; gefunden wurden %lld."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ requiere al menos %lld registros válidos; se encontraron %lld."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ requires at least %lld valid records; %lld were found."
+    },
+    "settings.mac_vendor.error.total_size_exceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected files exceed the %@ total-size limit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したファイルは合計サイズ上限（%@）を超えています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选文件超过了 %@ 的总大小限制。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die ausgewählten Dateien überschreiten die Gesamtgrößengrenze von %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los archivos seleccionados superan el límite de tamaño total de %@."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The selected files exceed the %@ total-size limit."
+    },
+    "settings.mac_vendor.error.unsupported_schema": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Database format version %lld is not supported. Clear or update the database."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データベース形式バージョン%lldには対応していません。消去または更新してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不支持数据库格式版本 %lld。请清空或更新数据库。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenbankformat Version %lld wird nicht unterstützt. Leeren oder aktualisieren Sie die Datenbank."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versión %lld del formato de base de datos no es compatible. Borra o actualiza la base de datos."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Database format version %lld is not supported. Clear or update the database."
+    },
+    "settings.mac_vendor.error.validation_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files Are Not Valid"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルが無効です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件无效"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien sind ungültig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los archivos no son válidos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Files Are Not Valid"
+    },
+    "settings.mac_vendor.error.wrong_file_count": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select exactly %lld files. You selected %lld."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを%lld個選択してください。現在は%lld個です。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择恰好 %lld 个文件。当前选择了 %lld 个。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie genau %lld Dateien aus. Ausgewählt: %lld."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona exactamente %lld archivos. Has seleccionado %lld."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Select exactly %lld files. You selected %lld."
+    },
+    "settings.mac_vendor.footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The database stays on this Mac and is updated only when you request it."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データベースはこのMacに保存され、要求したときだけ更新されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据库保存在这台 Mac 上，仅在你主动请求时更新。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datenbank bleibt auf diesem Mac und wird nur auf Anforderung aktualisiert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La base de datos permanece en este Mac y solo se actualiza cuando lo solicitas."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: The database stays on this Mac and is updated only when you request it."
+    },
+    "settings.mac_vendor.footer_bundled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vendor names come from a bundled IEEE registry snapshot and are not updated at runtime."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベンダー名は内蔵された IEEE レジストリのスナップショットに基づき、実行時には更新されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "厂商名称来自内置的 IEEE 注册表快照，不会在运行时更新。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herstellernamen stammen aus einem integrierten IEEE-Register-Snapshot und werden zur Laufzeit nicht aktualisiert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los nombres de los fabricantes proceden de una instantánea integrada del registro IEEE y no se actualizan durante la ejecución."
+          }
+        }
+      }
+    },
+    "settings.mac_vendor.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC Vendor Database"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MACベンダーデータベース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC 厂商数据库"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC-Herstellerdatenbank"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base de datos de fabricantes MAC"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: MAC Vendor Database"
+    },
+    "settings.mac_vendor.records_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valid records"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なレコード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有效记录"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültige Einträge"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros válidos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Valid records"
+    },
+    "settings.mac_vendor.remind_when_empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me when the database is empty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データベースが空のときに通知"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据库为空时提醒我"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei leerer Datenbank erinnern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recordarme cuando la base de datos esté vacía"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Remind me when the database is empty"
+    },
+    "settings.mac_vendor.remind_when_empty_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a reminder when no local MAC vendor database is installed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルのMACベンダーデータベースがない場合に通知します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安装本地 MAC 厂商数据库时显示提醒。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt eine Erinnerung an, wenn keine lokale MAC-Herstellerdatenbank installiert ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra un recordatorio cuando no hay una base de datos local de fabricantes MAC instalada."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Show a reminder when no local MAC vendor database is installed."
+    },
+    "settings.mac_vendor.reminder.do_not_ask_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do Not Ask Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後は確認しない"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再询问"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht erneut fragen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No volver a preguntar"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Do Not Ask Again"
+    },
+    "settings.mac_vendor.reminder.later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "後で"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Später"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más tarde"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Later"
+    },
+    "settings.mac_vendor.reminder.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install the public registry database to display registered organizations in the network table."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公開レジストリデータベースをインストールすると、ネットワーク表に登録組織を表示できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装公开注册表数据库后，可在网络表格中显示注册组织。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installieren Sie die öffentliche Registerdatenbank, um registrierte Organisationen in der Netzwerktabelle anzuzeigen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala la base de datos pública de registros para mostrar las organizaciones registradas en la tabla de redes."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Install the public registry database to display registered organizations in the network table."
+    },
+    "settings.mac_vendor.reminder.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Up MAC Vendor Information?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MACベンダー情報を設定しますか？"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置 MAC 厂商信息？"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC-Herstellerinformationen einrichten?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Configurar la información del fabricante MAC?"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Set Up MAC Vendor Information?"
+    },
+    "settings.mac_vendor.source_ieee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloaded from IEEE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEEからダウンロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 IEEE 下载"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von IEEE geladen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargada de IEEE"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Downloaded from IEEE"
+    },
+    "settings.mac_vendor.source_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quelle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Origen"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Source"
+    },
+    "settings.mac_vendor.source_manual": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manually imported"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動でインポート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动导入"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuell importiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importada manualmente"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Manually imported"
+    },
+    "settings.mac_vendor.status_bundled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bundled"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内置"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integriert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluida"
+          }
+        }
+      }
+    },
+    "settings.mac_vendor.status_installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalada"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Installed"
+    },
+    "settings.mac_vendor.status_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状態"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Status"
+    },
+    "settings.mac_vendor.status_loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込み中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Loading…"
+    },
+    "settings.mac_vendor.status_not_installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not installed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未インストール"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安装"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No instalada"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Not installed"
+    },
+    "settings.mac_vendor.status_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不可用"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Unavailable"
+    },
+    "settings.mac_vendor.unavailable_reason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unavailable reason"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用できない理由"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不可用原因"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grund für die Nichtverfügbarkeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo de la indisponibilidad"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Unavailable reason"
+    },
+    "settings.mac_vendor.update.automatic_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download the four public address registries directly from IEEE."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4つの公開アドレスレジストリをIEEEから直接ダウンロードします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接从 IEEE 下载四个公开地址注册表。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die vier öffentlichen Adressregister direkt von IEEE laden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga los cuatro registros públicos de direcciones directamente de IEEE."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download the four public address registries directly from IEEE."
+    },
+    "settings.mac_vendor.update.automatic_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download from IEEE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEEからダウンロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 IEEE 下载"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von IEEE laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar de IEEE"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download from IEEE"
+    },
+    "settings.mac_vendor.update.cancel_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard the prepared import and close this sheet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "準備済みのインポートを破棄して閉じます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "放弃已准备的导入并关闭此面板。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiteten Import verwerfen und dieses Fenster schließen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarta la importación preparada y cierra este panel."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Discard the prepared import and close this sheet."
+    },
+    "settings.mac_vendor.update.cancel_operation_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel the current operation and close this sheet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の処理をキャンセルして閉じます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消当前操作并关闭此面板。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuellen Vorgang abbrechen und dieses Fenster schließen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancela la operación actual y cierra este panel."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Cancel the current operation and close this sheet."
+    },
+    "settings.mac_vendor.update.choose_files": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Four CSV Files…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4つのCSVファイルを選択…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择四个 CSV 文件…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vier CSV-Dateien auswählen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir cuatro archivos CSV…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Choose Four CSV Files…"
+    },
+    "settings.mac_vendor.update.choose_files_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the MA-L, MA-M, MA-S, and IAB CSV files together."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MA-L、MA-M、MA-S、IABのCSVファイルをまとめて選択します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一起选择 MA-L、MA-M、MA-S 和 IAB CSV 文件。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die CSV-Dateien MA-L, MA-M, MA-S und IAB gemeinsam auswählen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige juntos los archivos CSV MA-L, MA-M, MA-S e IAB."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Choose the MA-L, MA-M, MA-S, and IAB CSV files together."
+    },
+    "settings.mac_vendor.update.clearing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clearing…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在清空…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geleert…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrando…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Clearing…"
+    },
+    "settings.mac_vendor.update.download": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download from IEEE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEEからダウンロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 IEEE 下载"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von IEEE laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar de IEEE"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download from IEEE"
+    },
+    "settings.mac_vendor.update.download_size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloads about 5.6 MB."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "約5.6 MBをダウンロードします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载约 5.6 MB。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lädt etwa 5,6 MB."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga unos 5,6 MB."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Downloads about 5.6 MB."
+    },
+    "settings.mac_vendor.update.downloading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geladen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Downloading…"
+    },
+    "settings.mac_vendor.update.import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Import"
+    },
+    "settings.mac_vendor.update.import_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install the validated local registry database."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証済みのローカルレジストリデータベースをインストールします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装已校验的本地注册表数据库。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die geprüfte lokale Registerdatenbank installieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala la base de datos local de registros validada."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Install the validated local registry database."
+    },
+    "settings.mac_vendor.update.installing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installing…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird installiert…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Installing…"
+    },
+    "settings.mac_vendor.update.ip_metadata": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE receives ordinary connection metadata, including your IP address."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEEにはIPアドレスを含む通常の接続メタデータが送信されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE 会收到包括你的 IP 地址在内的常规连接元数据。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE erhält übliche Verbindungsmetadaten einschließlich Ihrer IP-Adresse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE recibe metadatos de conexión habituales, incluida tu dirección IP."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: IEEE receives ordinary connection metadata, including your IP address."
+    },
+    "settings.mac_vendor.update.local_scan_privacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs, SSIDs, and Wi-Fi scan data stay on this Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID、SSID、Wi-FiスキャンデータはこのMacから送信されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID、SSID 和 Wi-Fi 扫描数据始终保留在这台 Mac 上。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs, SSIDs und Wi-Fi-Scandaten bleiben auf diesem Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los BSSID, SSID y datos de escaneo Wi-Fi permanecen en este Mac."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: BSSIDs, SSIDs, and Wi-Fi scan data stay on this Mac."
+    },
+    "settings.mac_vendor.update.manual_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download all four official CSV files, then select them together."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公式CSVファイルを4つすべてダウンロードし、まとめて選択してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载全部四个官方 CSV 文件，然后一起选择。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle vier offiziellen CSV-Dateien laden und anschließend gemeinsam auswählen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga los cuatro archivos CSV oficiales y selecciónalos juntos."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download all four official CSV files, then select them together."
+    },
+    "settings.mac_vendor.update.manual_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import IEEE CSV Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE CSVファイルをインポート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入 IEEE CSV 文件"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE-CSV-Dateien importieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar archivos CSV de IEEE"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Import IEEE CSV Files"
+    },
+    "settings.mac_vendor.update.no_endorsement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registry data identifies the address-block holder and may differ from the device brand. WiFi Lens is not affiliated with or endorsed by IEEE."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レジストリデータはアドレスブロックの登録者を示すもので、デバイスのブランドとは異なる場合があります。WiFi LensはIEEEと提携しておらず、IEEEの承認も受けていません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注册表数据标识地址块注册主体，可能与设备品牌不同。WiFi Lens 与 IEEE 无关联，也未获其认可。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registerdaten nennen den Inhaber des Adressblocks und können von der Gerätemarke abweichen. WiFi Lens ist weder mit IEEE verbunden noch von IEEE empfohlen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los datos del registro identifican al titular del bloque de direcciones y pueden diferir de la marca del dispositivo. WiFi Lens no está afiliado ni respaldado por IEEE."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Registry data identifies the address-block holder and may differ from the device brand. WiFi Lens is not affiliated with or endorsed by IEEE."
+    },
+    "settings.mac_vendor.update.progress_accessibility_value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld of %lld files complete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld / %lldファイル完了"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已完成 %lld/%lld 个文件"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld von %lld Dateien abgeschlossen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld de %lld archivos completados"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %lld of %lld files complete"
+    },
+    "settings.mac_vendor.update.progress_count": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld of %lld files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld / %lldファイル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/%lld 个文件"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld von %lld Dateien"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld de %lld archivos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %lld of %lld files"
+    },
+    "settings.mac_vendor.update.reading_files": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading files…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを読み込み中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在读取文件…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien werden gelesen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo archivos…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Reading files…"
+    },
+    "settings.mac_vendor.update.registry_download_accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download %@ CSV"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ CSVをダウンロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载 %@ CSV"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-CSV laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar CSV de %@"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Download %@ CSV"
+    },
+    "settings.mac_vendor.update.registry_valid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@ valid records"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 有効なレコード%@件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@ 条有效记录"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@ gültige Einträge"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@ registros válidos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ — %@ valid records"
+    },
+    "settings.mac_vendor.update.registry_valid_value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ valid records"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なレコード%@件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 条有效记录"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ gültige Einträge"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ registros válidos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ valid records"
+    },
+    "settings.mac_vendor.update.registry_waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — waiting for a valid file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 有効なファイルを待機中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 正在等待有效文件"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — wartet auf eine gültige Datei"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — esperando un archivo válido"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: %@ — waiting for a valid file"
+    },
+    "settings.mac_vendor.update.registry_waiting_value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for validation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証待ち"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待校验"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf Prüfung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando validación"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Waiting for validation"
+    },
+    "settings.mac_vendor.update.source_automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automática"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Automatic"
+    },
+    "settings.mac_vendor.update.source_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quelle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Origen"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Source"
+    },
+    "settings.mac_vendor.update.source_manual": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Manual"
+    },
+    "settings.mac_vendor.update.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update MAC Vendor Database"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MACベンダーデータベースを更新"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新 MAC 厂商数据库"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC-Herstellerdatenbank aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar base de datos de fabricantes MAC"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Update MAC Vendor Database"
+    },
+    "settings.mac_vendor.update.validating": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validating…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証中…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在校验…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validando…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Validating…"
+    },
+    "settings.mac_vendor.update.validation_header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Validation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルの検証"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件校验"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateiprüfung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validación de archivos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: File Validation"
+    },
+    "settings.mac_vendor.update.validation_ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All four registries are valid (%@ records total)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4つのレジストリはすべて有効です（合計%@件）。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "四个注册表均有效（共 %@ 条记录）。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle vier Register sind gültig (insgesamt %@ Einträge)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los cuatro registros son válidos (%@ registros en total)."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: All four registries are valid (%@ records total)."
+    },
+    "settings.mac_vendor.update.validation_ready_accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All four registry files are valid"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4つのレジストリファイルはすべて有効です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "四个注册表文件均有效"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle vier Registerdateien sind gültig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los cuatro archivos de registro son válidos"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: All four registry files are valid"
+    },
+    "settings.mac_vendor.update_action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar…"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Update…"
+    },
+    "settings.mac_vendor.update_action_hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an IEEE download or a manual CSV import."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEEからのダウンロードまたはCSVの手動インポートを選択します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择从 IEEE 下载或手动导入 CSV。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE-Download oder manuellen CSV-Import auswählen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una descarga de IEEE o una importación CSV manual."
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Choose an IEEE download or a manual CSV import."
+    },
+    "settings.mac_vendor.updated_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新日時"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新时间"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizada"
+          }
+        }
+      },
+      "comment": "MAC vendor database UI text. English: Updated"
     },
     "settings.mcp.claude_config_label": {
       "comment": "Label for Claude Desktop config snippet",
@@ -14827,6 +23424,42 @@
         }
       }
     },
+    "settings.scan.interval_10s": {
+      "comment": "10 second scan interval option",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 Sekunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 seconds"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 segundos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 秒"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 秒"
+          }
+        }
+      }
+    },
     "settings.scan.interval_1s": {
       "comment": "1 second scan interval option",
       "extractionState": "manual",
@@ -14967,42 +23600,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "5 秒"
-          }
-        }
-      }
-    },
-    "settings.scan.interval_10s": {
-      "comment": "10 second scan interval option",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10 Sekunden"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10 seconds"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10 segundos"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10 秒"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10 秒"
           }
         }
       }
@@ -15327,6 +23924,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要Wi‑Fi"
+          }
+        }
+      }
+    },
+    "sidebar.section.analysis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysis"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análisis"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析"
           }
         }
       }
@@ -15905,6 +24537,31 @@
         }
       }
     },
+    "spectrum.panel.band.24ghz": {
+      "comment": "2.4 GHz band label in spectrum panel",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
     "spectrum.panel.band.5ghz": {
       "comment": "5 GHz band label in spectrum panel",
       "extractionState": "manual",
@@ -15950,31 +24607,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "6 GHz"
-          }
-        }
-      },
-      "shouldTranslate": false
-    },
-    "spectrum.panel.band.24ghz": {
-      "comment": "2.4 GHz band label in spectrum panel",
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
           }
         }
       },
@@ -16926,6 +25558,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "SSID"
+          }
+        }
+      }
+    },
+    "table.column.vendor": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hersteller"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vendor"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fabricante"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベンダー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "厂商"
           }
         }
       }
@@ -18056,6 +26723,216 @@
         }
       }
     },
+    "timeline.filter.type.channel_change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel Change"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チャネル切替"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信道变更"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanalwechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio de canal"
+          }
+        }
+      }
+    },
+    "timeline.filter.type.connection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexión"
+          }
+        }
+      }
+    },
+    "timeline.filter.type.disconnection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung getrennt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconexión"
+          }
+        }
+      }
+    },
+    "timeline.filter.type.latency_spike": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latency Spike"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レイテンシスパイク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "延迟尖峰"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latenzspitze"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pico de latencia"
+          }
+        }
+      }
+    },
+    "timeline.filter.type.roaming": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローミング"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "漫游"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roaming"
+          }
+        }
+      }
+    },
+    "timeline.filter.type.signal_drop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal Drop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信号減衰"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信号衰减"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signalverlust"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caída de señal"
+          }
+        }
+      }
+    },
     "timeline.filter.yesterday": {
       "comment": "Timeline filter for yesterday's events",
       "extractionState": "manual",
@@ -18088,6 +26965,181 @@
           "stringUnit": {
             "state": "translated",
             "value": "昨天"
+          }
+        }
+      }
+    },
+    "timeline.filter_panel.date_range": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date Range"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付範囲"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期范围"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datumsbereich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rango de fechas"
+          }
+        }
+      }
+    },
+    "timeline.filter_panel.event_types": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event Types"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントタイプ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件类型"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignistypen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipos de evento"
+          }
+        }
+      }
+    },
+    "timeline.filter_panel.from": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "From"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desde"
+          }
+        }
+      }
+    },
+    "timeline.filter_panel.search_placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search events…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントを検索…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索事件…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse suchen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar eventos…"
+          }
+        }
+      }
+    },
+    "timeline.filter_panel.to": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bis"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hasta"
           }
         }
       }
@@ -18200,8 +27252,41 @@
         }
       }
     },
-    "WiFi Lens": {
-      "shouldTranslate": false
+    "wifi.band.24ghz": {
+      "comment": "2.4 GHz Wi-Fi band name",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.4 GHz"
+          }
+        }
+      }
     },
     "wifi.band.5ghz": {
       "comment": "5 GHz Wi-Fi band name",
@@ -18271,42 +27356,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "6 GHz"
-          }
-        }
-      }
-    },
-    "wifi.band.24ghz": {
-      "comment": "2.4 GHz Wi-Fi band name",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2.4 GHz"
           }
         }
       }
@@ -19067,150 +28116,6 @@
         }
       }
     },
-    "wifi.security.wpa_enterprise": {
-      "comment": "WPA Enterprise security type",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Enterprise"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Enterprise"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Empresarial"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA エンタープライズ"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA 企业"
-          }
-        }
-      }
-    },
-    "wifi.security.wpa_personal": {
-      "comment": "WPA Personal security type",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Persönlich"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Personal"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA Personal"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA パーソナル"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA 个人"
-          }
-        }
-      }
-    },
-    "wifi.security.wpa_wpa2_enterprise": {
-      "comment": "WPA/WPA2 Enterprise mixed mode",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Enterprise"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Enterprise"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Empresarial"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 エンタープライズ"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 企业"
-          }
-        }
-      }
-    },
-    "wifi.security.wpa_wpa2_personal": {
-      "comment": "WPA/WPA2 Personal mixed mode",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Persönlich"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Personal"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 Personal"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 パーソナル"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WPA/WPA2 个人"
-          }
-        }
-      }
-    },
     "wifi.security.wpa2_enterprise": {
       "comment": "WPA2 Enterprise security type",
       "extractionState": "manual",
@@ -19391,6916 +28296,3722 @@
         }
       }
     },
-    "timeline.filter_panel.search_placeholder": {
+    "wifi.security.wpa_enterprise": {
+      "comment": "WPA Enterprise security type",
       "extractionState": "manual",
       "localizations": {
-        "en": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Search events…"
+            "value": "WPA Enterprise"
           }
         },
-        "ja": {
+        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "イベントを検索…"
+            "value": "WPA Enterprise"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "搜索事件…"
+            "value": "WPA Empresarial"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ereignisse suchen…"
+            "value": "WPA エンタープライズ"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buscar eventos…"
+            "value": "WPA 企业"
           }
         }
       }
     },
-    "timeline.filter_panel.date_range": {
+    "wifi.security.wpa_personal": {
+      "comment": "WPA Personal security type",
       "extractionState": "manual",
       "localizations": {
-        "en": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Date Range"
+            "value": "WPA Persönlich"
           }
         },
-        "ja": {
+        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "日付範囲"
+            "value": "WPA Personal"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "日期范围"
+            "value": "WPA Personal"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Datumsbereich"
+            "value": "WPA パーソナル"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rango de fechas"
+            "value": "WPA 个人"
           }
         }
       }
     },
-    "timeline.filter_panel.from": {
+    "wifi.security.wpa_wpa2_enterprise": {
+      "comment": "WPA/WPA2 Enterprise mixed mode",
       "extractionState": "manual",
       "localizations": {
-        "en": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "From"
+            "value": "WPA/WPA2 Enterprise"
           }
         },
-        "ja": {
+        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "開始"
+            "value": "WPA/WPA2 Enterprise"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "从"
+            "value": "WPA/WPA2 Empresarial"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Von"
+            "value": "WPA/WPA2 エンタープライズ"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desde"
+            "value": "WPA/WPA2 企业"
           }
         }
       }
     },
-    "timeline.filter_panel.to": {
+    "wifi.security.wpa_wpa2_personal": {
+      "comment": "WPA/WPA2 Personal mixed mode",
       "extractionState": "manual",
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA/WPA2 Persönlich"
+          }
+        },
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA/WPA2 Personal"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "To"
+            "value": "WPA/WPA2 Personal"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "終了"
+            "value": "WPA/WPA2 パーソナル"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "到"
+            "value": "WPA/WPA2 个人"
           }
-        },
+        }
+      }
+    },
+    "·": {
+      "shouldTranslate": false
+    },
+    "·  %@  ·  Ch %@": {
+      "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bis"
+            "value": "·  %1$@  ·  Ch %2$@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "·  %1$@  ·  Ch %2$@"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hasta"
+            "value": "·  %1$@  ·  Ch %2$@"
           }
         }
-      }
+      },
+      "shouldTranslate": false
+    },
+    "· %@": {
+      "shouldTranslate": false
+    },
+    "—": {
+      "shouldTranslate": false
+    },
+    "•": {
+      "shouldTranslate": false
+    },
+    "⌘Q": {
+      "shouldTranslate": false
     },
-    "timeline.filter_panel.event_types": {
+    "analysis.statistics.scope_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Event Types"
+            "value": "Scope"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "イベントタイプ"
+            "value": "Bereich"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "事件类型"
+            "value": "Ámbito"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ereignistypen"
+            "value": "範囲"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tipos de evento"
+            "value": "范围"
           }
         }
       }
     },
-    "timeline.filter.type.roaming": {
+    "analysis.statistics.network_all": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Roaming"
+            "value": "All networks"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ローミング"
+            "value": "Alle Netzwerke"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "漫游"
+            "value": "Todas las redes"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Roaming"
+            "value": "すべてのネットワーク"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Roaming"
+            "value": "全部网络"
           }
         }
       }
     },
-    "timeline.filter.type.signal_drop": {
+    "analysis.statistics.network_logical_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Signal Drop"
+            "value": "Network: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "信号減衰"
+            "value": "Netzwerk: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "信号衰减"
+            "value": "Red: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Signalverlust"
+            "value": "ネットワーク：%@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Caída de señal"
+            "value": "网络：%@"
           }
         }
       }
     },
-    "timeline.filter.type.channel_change": {
+    "analysis.statistics.network_access_point_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Channel Change"
+            "value": "AP: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "チャネル切替"
+            "value": "AP: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "信道变更"
+            "value": "AP: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kanalwechsel"
+            "value": "AP：%@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cambio de canal"
+            "value": "AP：%@"
           }
         }
       }
     },
-    "timeline.filter.type.latency_spike": {
+    "analysis.statistics.network_multiple": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Latency Spike"
+            "value": "Selected networks"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "レイテンシスパイク"
+            "value": "Ausgewählte Netzwerke"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "延迟尖峰"
+            "value": "Redes seleccionadas"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Latenzspitze"
+            "value": "選択したネットワーク"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pico de latencia"
+            "value": "选中的网络"
           }
         }
       }
     },
-    "timeline.filter.type.disconnection": {
+    "analysis.statistics.network_unattributed": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disconnection"
+            "value": "Unattributed events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "切断"
+            "value": "Nicht zugeordnete Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "断开连接"
+            "value": "Eventos sin atribución"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verbindung getrennt"
+            "value": "帰属なしのイベント"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desconexión"
+            "value": "未归属事件"
           }
         }
       }
     },
-    "timeline.filter.type.connection": {
+    "analysis.statistics.period_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connection"
+            "value": "Period: %@ – %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "接続"
+            "value": "Zeitraum: %@ – %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "连接"
+            "value": "Período: %@ – %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verbindung"
+            "value": "期間：%@ – %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conexión"
+            "value": "周期：%@ – %@"
           }
         }
       }
     },
-    "nav.network_diagnostics": {
+    "analysis.statistics.coverage_percent_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Network Check"
+            "value": "Coverage: %lld%%"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク診断"
+            "value": "Abdeckung: %lld%%"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络自检"
+            "value": "Cobertura: %lld%%"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Netzwerktest"
+            "value": "カバレッジ：%lld%%"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnóstico de red"
+            "value": "覆盖：%lld%%"
           }
         }
       }
     },
-    "network_diagnostics.description": {
+    "analysis.statistics.session_count_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Check this Mac's network connection, DNS resolution, and system proxy settings."
+            "value": "Sessions: %lld"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "このMacのネットワーク接続、DNS解決、システムプロキシ設定を確認します。"
+            "value": "Sessions: %lld"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查此 Mac 的网络连接、DNS 解析和系统代理设置。"
+            "value": "Sesiones: %lld"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüft die Netzwerkverbindung, DNS-Auflösung und Systemproxy-Einstellungen dieses Mac."
+            "value": "セッション数：%lld"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprueba la conexión de red, la resolución DNS y los ajustes de proxy del sistema de este Mac."
+            "value": "会话数：%lld"
           }
         }
       }
     },
-    "network_diagnostics.action.run": {
+    "analysis.statistics.connection_changes": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Run Diagnostics"
+            "value": "Connection changes"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "診断を開始"
+            "value": "Verbindungswechsel"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "开始检测"
+            "value": "Cambios de conexión"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diagnose starten"
+            "value": "接続変更"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ejecutar diagnóstico"
+            "value": "连接变化"
           }
         }
       }
     },
-    "network_diagnostics.action.run_again": {
+    "analysis.statistics.gateway_latency_observations": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Run Again"
+            "value": "Gateway latency observations"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "もう一度診断"
+            "value": "Gateway-Latenzbeobachtungen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新检测"
+            "value": "Observaciones de latencia del gateway"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erneut ausführen"
+            "value": "ゲートウェイ遅延の観測"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ejecutar de nuevo"
+            "value": "网关延迟观测"
           }
         }
       }
     },
-    "network_diagnostics.state.waiting": {
+    "analysis.statistics.ap_switching": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Waiting to run"
+            "value": "AP switching"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "実行待ち"
+            "value": "AP-Wechsel"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "等待检测"
+            "value": "Cambios de AP"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wartet auf Ausführung"
+            "value": "AP 切り替え"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "En espera"
+            "value": "AP 切换"
           }
         }
       }
     },
-    "network_diagnostics.state.checking": {
+    "analysis.statistics.severity_distribution": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Checking…"
+            "value": "Severity distribution"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "確認中…"
+            "value": "Schweregrad-Verteilung"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测中…"
+            "value": "Distribución por gravedad"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wird geprüft…"
+            "value": "重要度の分布"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprobando…"
+            "value": "严重度分布"
           }
         }
       }
     },
-    "network_diagnostics.state.completed": {
+    "analysis.statistics.severity_info": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Check complete"
+            "value": "Info"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "確認完了"
+            "value": "Info"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测完成"
+            "value": "Info"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüfung abgeschlossen"
+            "value": "情報"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprobación completada"
+            "value": "信息"
           }
         }
       }
     },
-    "network_diagnostics.status.normal": {
+    "analysis.statistics.severity_warning": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Normal"
+            "value": "Warnings"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "正常"
+            "value": "Warnungen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "正常"
+            "value": "Advertencias"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Normal"
+            "value": "警告"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Normal"
+            "value": "警告"
           }
         }
       }
     },
-    "network_diagnostics.status.abnormal": {
+    "analysis.statistics.severity_critical": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abnormal"
+            "value": "Critical"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "異常"
+            "value": "Kritisch"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "异常"
+            "value": "Crítico"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fehlerhaft"
+            "value": "重大"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Anómalo"
+            "value": "严重"
           }
         }
       }
     },
-    "network_diagnostics.status.indeterminate": {
+    "analysis.statistics.most_concentrated_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Indeterminate"
+            "value": "Most concentrated interval: %@ · %lld events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "判定不能"
+            "value": "Konzentriertestes Intervall: %@ · %lld Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法判断"
+            "value": "Intervalo más concentrado: %@ · %lld eventos"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nicht bestimmbar"
+            "value": "最も集中している期間：%@（%lld 件）"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No determinable"
+            "value": "最集中区间：%@（%lld 个事件）"
           }
         }
       }
     },
-    "network_diagnostics.check.connectivity.title": {
+    "analysis.statistics.latest_notable_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Network Connection"
+            "value": "Latest notable event: %@ · %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク接続"
+            "value": "Letztes bemerkenswertes Ereignis: %@ · %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络连接"
+            "value": "Último evento notable: %@ · %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Netzwerkverbindung"
+            "value": "最近の注目イベント：%@ · %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conexión de red"
+            "value": "最近的重要事件：%@ · %@"
           }
         }
       }
     },
-    "network_diagnostics.check.dns.title": {
+    "analysis.statistics.comparison_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS Resolution"
+            "value": "Compared with previous period"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS解決"
+            "value": "Vergleich mit dem vorherigen Zeitraum"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS 解析"
+            "value": "Comparación con el período anterior"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS-Auflösung"
+            "value": "前の期間との比較"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Resolución DNS"
+            "value": "与上一周期比较"
           }
         }
       }
     },
-    "network_diagnostics.check.proxy.title": {
+    "analysis.statistics.comparison_total_change": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "System Proxy"
+            "value": "Event total change: %lld"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムプロキシ"
+            "value": "Änderung der Ereignisanzahl: %lld"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "系统代理"
+            "value": "Cambio total de eventos: %lld"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Systemproxy"
+            "value": "イベント合計の変化：%lld"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proxy del sistema"
+            "value": "事件总数变化：%lld"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.normal.title": {
+    "analysis.statistics.comparison_percent_change": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Network Normal"
+            "value": "Relative change: %.1f%%"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークは正常です"
+            "value": "Relative Änderung: %.1f%%"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络正常"
+            "value": "Cambio relativo: %.1f%%"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Netzwerk normal"
+            "value": "相対変化：%.1f%%"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Red normal"
+            "value": "相对变化：%.1f%%"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.normal.message": {
+    "analysis.insights.metadata_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "All checks completed without finding a problem."
+            "value": "Category %@ · %@ · %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "すべての確認が完了し、問題は見つかりませんでした。"
+            "value": "Kategorie %@ · %@ · %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "所有检测均已完成，未发现问题。"
+            "value": "Categoría %@ · %@ · %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alle Prüfungen wurden abgeschlossen, ohne ein Problem zu finden."
+            "value": "カテゴリ %@ · %@ · %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas las comprobaciones terminaron sin encontrar problemas."
+            "value": "类别 %@ · %@ · %@"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.attention.title": {
+    "analysis.insights.evidence_count_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Needs Attention"
+            "value": "Evidence: %d events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "確認が必要です"
+            "value": "Belege: %d Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "需要注意"
+            "value": "Evidencia: %d eventos"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Überprüfung erforderlich"
+            "value": "エビデンス: %d 件"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Requiere atención"
+            "value": "证据：%d 个事件"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.attention.message": {
+    "analysis.insights.evidence_range_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Review any result marked for attention below."
+            "value": "%@ – %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "下で注意が必要と表示された結果を確認してください。"
+            "value": "%@ – %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "请检查下方标记为需要注意的检测结果。"
+            "value": "%@ – %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüfe unten alle Ergebnisse, die Aufmerksamkeit erfordern."
+            "value": "%@ – %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Revisa abajo cualquier resultado que requiera atención."
+            "value": "%@ – %@"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.unavailable.title": {
+    "analysis.insights.evidence_duration_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Network Unavailable"
+            "value": "Cluster duration: %d min"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークを利用できません"
+            "value": "Clusterdauer: %d Min."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络不可用"
+            "value": "Duración del clúster: %d min"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Netzwerk nicht verfügbar"
+            "value": "クラスターの継続時間: %d 分"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Red no disponible"
+            "value": "聚类持续时长：%d 分钟"
           }
         }
       }
     },
-    "network_diagnostics.conclusion.unavailable.message": {
+    "analysis.insights.category.connectivity": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This Mac does not currently have a working network connection."
+            "value": "Connectivity"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このMacには現在、利用可能なネットワーク接続がありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此 Mac 当前没有可用的网络连接。"
-          }
-        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dieser Mac hat derzeit keine funktionierende Netzwerkverbindung."
+            "value": "Konnektivität"
           }
         },
         "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este Mac no tiene actualmente una conexión de red operativa."
-          }
-        }
-      }
-    },
-    "network_diagnostics.connectivity.normal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connection available"
+            "value": "Conectividad"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "接続を利用できます"
+            "value": "接続性"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接可用"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindung verfügbar"
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conexión disponible"
+            "value": "连接性"
           }
         }
       }
     },
-    "network_diagnostics.connectivity.abnormal.summary": {
+    "analysis.insights.category.performance": {
       "extractionState": "manual",
       "localizations": {
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No network connection is available. Check Wi-Fi or Ethernet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用できるネットワーク接続がありません。Wi-Fi または Ethernet を確認してください。"
-          }
-        },
-        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "未连接到可用网络，请检查 Wi-Fi 或网线。"
+            "value": "Performance"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keine Netzwerkverbindung verfügbar. Prüfe Wi-Fi oder Ethernet."
+            "value": "Leistung"
           }
         },
         "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay ninguna conexión de red disponible. Comprueba la conexión Wi-Fi o Ethernet."
-          }
-        }
-      }
-    },
-    "network_diagnostics.connectivity.indeterminate.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The network connection could not be confirmed. Try again later."
+            "value": "Rendimiento"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク接続を確認できませんでした。しばらくしてからもう一度お試しください。"
+            "value": "パフォーマンス"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂时无法确认网络连接状态，请稍后重试。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Netzwerkverbindung konnte nicht bestätigt werden. Versuche es später erneut."
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo confirmar la conexión de red. Inténtalo de nuevo más tarde."
+            "value": "性能"
           }
         }
       }
     },
-    "network_diagnostics.dns.normal.summary": {
+    "analysis.insights.category.stability": {
       "extractionState": "manual",
       "localizations": {
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Domain name resolution is working"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドメイン名の解決は正常です"
-          }
-        },
-        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "域名解析正常"
+            "value": "Stability"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Namensauflösung funktioniert"
+            "value": "Stabilität"
           }
         },
         "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La resolución de nombres de dominio funciona"
-          }
-        }
-      }
-    },
-    "network_diagnostics.dns.abnormal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Domain names cannot be resolved, so some websites may not open. Check DNS settings."
+            "value": "Estabilidad"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ドメイン名を解決できないため、一部の Web サイトを開けない可能性があります。DNS 設定を確認してください。"
+            "value": "安定性"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法解析域名，部分网站可能无法打开；请检查 DNS 设置。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Domänennamen können nicht aufgelöst werden, daher lassen sich manche Websites möglicherweise nicht öffnen. Prüfe die DNS-Einstellungen."
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pueden resolver los nombres de dominio, por lo que es posible que algunos sitios web no se abran. Comprueba los ajustes de DNS."
+            "value": "稳定性"
           }
         }
       }
     },
-    "network_diagnostics.dns.indeterminate.summary": {
+    "analysis.insights.severity.informational": {
       "extractionState": "manual",
       "localizations": {
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The DNS check could not be completed. Try again later."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "DNS チェックを完了できませんでした。しばらくしてからもう一度お試しください。"
-          }
-        },
-        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "暂时无法完成 DNS 检查，请稍后重试。"
+            "value": "Informational"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die DNS-Prüfung konnte nicht abgeschlossen werden. Versuche es später erneut."
+            "value": "Information"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo completar la comprobación de DNS. Inténtalo de nuevo más tarde."
+            "value": "Informativo"
           }
-        }
-      }
-    },
-    "network_diagnostics.proxy.disabled.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System proxy not in use"
-          }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムプロキシは使用されていません"
+            "value": "情報"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未使用系统代理"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Systemproxy wird nicht verwendet"
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El proxy del sistema no está en uso"
+            "value": "信息"
           }
         }
       }
     },
-    "network_diagnostics.proxy.normal.summary": {
+    "analysis.insights.severity.warning": {
       "extractionState": "manual",
       "localizations": {
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System proxy available"
-          }
-        },
-        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムプロキシを利用できます"
+            "value": "Warning"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统代理可用"
-          }
-        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Systemproxy verfügbar"
+            "value": "Warnung"
           }
         },
         "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proxy del sistema disponible"
-          }
-        }
-      }
-    },
-    "network_diagnostics.proxy.abnormal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The system proxy cannot be reached and may prevent websites from opening. Check or turn off the proxy settings."
+            "value": "Advertencia"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムプロキシに接続できないため、Web サイトを開けない可能性があります。プロキシ設定を確認するか、オフにしてください。"
+            "value": "警告"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统代理无法连接，可能导致网页无法访问；请检查或关闭代理设置。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Systemproxy ist nicht erreichbar und verhindert möglicherweise das Öffnen von Websites. Prüfe oder deaktiviere die Proxyeinstellungen."
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se puede acceder al proxy del sistema, lo que puede impedir que se abran sitios web. Comprueba o desactiva los ajustes del proxy."
+            "value": "警告"
           }
         }
       }
     },
-    "network_diagnostics.proxy.indeterminate.summary": {
+    "analysis.insights.confidence.high": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The system proxy could not be fully verified."
+            "value": "High confidence"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システムプロキシを完全には確認できませんでした。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法完整确认系统代理是否可用。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Systemproxy konnte nicht vollständig überprüft werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo verificar por completo el proxy del sistema."
-          }
-        }
-      }
-    },
-    "network_diagnostics.ready.message": {
-      "extractionState": "manual",
-      "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Starten Sie die Diagnose, um das Netzwerk dieses Macs zu prüfen. Die Ergebnisse werden hier angezeigt."
+            "value": "Hohe Zuversicht"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Run diagnostics to check this Mac’s network. Results will appear here."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ejecuta el diagnóstico para comprobar la red de este Mac. Los resultados aparecerán aquí."
+            "value": "Confianza alta"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "診断を実行して、このMacのネットワークを確認します。結果はここに表示されます。"
+            "value": "信頼度: 高"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "运行诊断以检查此 Mac 的网络，结果将显示在这里。"
+            "value": "高置信度"
           }
         }
       }
     },
-    "network_diagnostics.report.column.check": {
+    "analysis.insights.confidence.medium": {
       "extractionState": "manual",
       "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prüfung"
-          }
-        },
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comprobación"
-          }
-        },
-        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "チェック"
+            "value": "Medium confidence"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "检查项目"
-          }
-        }
-      }
-    },
-    "network_diagnostics.report.column.status": {
-      "extractionState": "manual",
-      "localizations": {
         "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
-          }
-        },
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Status"
+            "value": "Mittlere Zuversicht"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estado"
+            "value": "Confianza media"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "状態"
+            "value": "信頼度: 中"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "状态"
+            "value": "中等置信度"
           }
         }
       }
     },
-    "network_diagnostics.report.column.result": {
+    "analysis.insights.confidence.low": {
       "extractionState": "manual",
       "localizations": {
-        "de": {
+        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ergebnis"
+            "value": "Low confidence"
           }
         },
-        "en": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Result"
+            "value": "Niedrige Zuversicht"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Resultado"
+            "value": "Confianza baja"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "結果"
+            "value": "信頼度: 低"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "结果"
+            "value": "低置信度"
           }
         }
       }
     },
-    "common.badge.pro": {
+    "analysis.insight.limitation.coverage_unavailable": {
       "extractionState": "manual",
       "localizations": {
         "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pro"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pro"
-          }
-        },
-        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pro"
+            "value": "Coverage unavailable"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pro"
+            "value": "Abdeckung nicht verfügbar"
           }
         },
         "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pro"
-          }
-        }
-      }
-    },
-    "common.badge.preview": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Preview"
+            "value": "Cobertura no disponible"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "プレビュー"
+            "value": "カバレッジを利用できません"
           }
         },
         "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "预览"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorschau"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vista previa"
-          }
-        }
-      }
-    },
-    "table.column.vendor": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hersteller"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vendor"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fabricante"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ベンダー"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "厂商"
-          }
-        }
-      }
-    },
-    "settings.mac_vendor.header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC Vendor Database"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MACベンダーデータベース"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC 厂商数据库"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC-Herstellerdatenbank"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Base de datos de fabricantes MAC"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: MAC Vendor Database"
-    },
-    "settings.mac_vendor.footer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The database stays on this Mac and is updated only when you request it."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データベースはこのMacに保存され、要求したときだけ更新されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "数据库保存在这台 Mac 上，仅在你主动请求时更新。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Datenbank bleibt auf diesem Mac und wird nur auf Anforderung aktualisiert."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La base de datos permanece en este Mac y solo se actualiza cuando lo solicitas."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The database stays on this Mac and is updated only when you request it."
-    },
-    "settings.mac_vendor.status_label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "状態"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "状态"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Status"
-    },
-    "settings.mac_vendor.status_loading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "読み込み中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird geladen…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cargando…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Loading…"
-    },
-    "settings.mac_vendor.status_not_installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not installed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未インストール"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未安装"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nicht installiert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No instalada"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Not installed"
-    },
-    "settings.mac_vendor.status_installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール済み"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已安装"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installiert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalada"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Installed"
-    },
-    "settings.mac_vendor.status_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unavailable"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不可用"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No disponible"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Unavailable"
-    },
-    "settings.mac_vendor.unavailable_reason": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unavailable reason"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用できない理由"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不可用原因"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grund für die Nichtverfügbarkeit"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Motivo de la indisponibilidad"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Unavailable reason"
-    },
-    "settings.mac_vendor.source_label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソース"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "来源"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quelle"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origen"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Source"
-    },
-    "settings.mac_vendor.source_ieee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloaded from IEEE"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEEからダウンロード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从 IEEE 下载"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Von IEEE geladen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargada de IEEE"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Downloaded from IEEE"
-    },
-    "settings.mac_vendor.source_manual": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manually imported"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "手動でインポート"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "手动导入"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manuell importiert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importada manualmente"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Manually imported"
-    },
-    "settings.mac_vendor.updated_label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updated"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新日時"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新时间"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktualisiert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizada"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Updated"
-    },
-    "settings.mac_vendor.records_label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid records"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なレコード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有效记录"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gültige Einträge"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registros válidos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Valid records"
-    },
-    "settings.mac_vendor.remind_when_empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remind me when the database is empty"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データベースが空のときに通知"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "数据库为空时提醒我"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bei leerer Datenbank erinnern"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recordarme cuando la base de datos esté vacía"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Remind me when the database is empty"
-    },
-    "settings.mac_vendor.remind_when_empty_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show a reminder when no local MAC vendor database is installed."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルのMACベンダーデータベースがない場合に通知します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未安装本地 MAC 厂商数据库时显示提醒。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zeigt eine Erinnerung an, wenn keine lokale MAC-Herstellerdatenbank installiert ist."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Muestra un recordatorio cuando no hay una base de datos local de fabricantes MAC instalada."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Show a reminder when no local MAC vendor database is installed."
-    },
-    "settings.mac_vendor.update_action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktualisieren…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Update…"
-    },
-    "settings.mac_vendor.update_action_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose an IEEE download or a manual CSV import."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEEからのダウンロードまたはCSVの手動インポートを選択します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择从 IEEE 下载或手动导入 CSV。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE-Download oder manuellen CSV-Import auswählen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elige una descarga de IEEE o una importación CSV manual."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Choose an IEEE download or a manual CSV import."
-    },
-    "settings.mac_vendor.clear_action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "消去…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清空…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leeren…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Clear…"
-    },
-    "settings.mac_vendor.clear_action_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove local vendor data without changing the reminder setting."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知設定を変更せずにローカルのベンダーデータを削除します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移除本地厂商数据，但不更改提醒设置。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokale Herstellerdaten entfernen, ohne die Erinnerungseinstellung zu ändern."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elimina los datos locales de fabricantes sin cambiar el ajuste de recordatorio."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Remove local vendor data without changing the reminder setting."
-    },
-    "settings.mac_vendor.clear_confirmation_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear MAC vendor database?"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MACベンダーデータベースを消去しますか？"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清空 MAC 厂商数据库？"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC-Herstellerdatenbank leeren?"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Borrar la base de datos de fabricantes MAC?"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Clear MAC vendor database?"
-    },
-    "settings.mac_vendor.clear_confirmation_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vendor values will display as an em dash until you install another database."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "別のデータベースをインストールするまで、ベンダー欄にはダッシュが表示されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安装其他数据库前，厂商值将显示为破折号。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bis zur Installation einer anderen Datenbank werden Herstellerwerte als Gedankenstrich angezeigt."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los valores de fabricante se mostrarán como una raya hasta que instales otra base de datos."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Vendor values will display as an em dash until you install another database."
-    },
-    "settings.mac_vendor.clear_confirmation_action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear Database"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データベースを消去"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清空数据库"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datenbank leeren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar base de datos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Clear Database"
-    },
-    "settings.mac_vendor.update.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update MAC Vendor Database"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MACベンダーデータベースを更新"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新 MAC 厂商数据库"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC-Herstellerdatenbank aktualisieren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actualizar base de datos de fabricantes MAC"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Update MAC Vendor Database"
-    },
-    "settings.mac_vendor.update.source_label": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソース"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "来源"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quelle"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origen"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Source"
-    },
-    "settings.mac_vendor.update.source_automatic": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatic"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自动"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatisch"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automática"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Automatic"
-    },
-    "settings.mac_vendor.update.source_manual": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manual"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "手動"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "手动"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manuell"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manual"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Manual"
-    },
-    "settings.mac_vendor.update.automatic_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download from IEEE"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEEからダウンロード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从 IEEE 下载"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Von IEEE laden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar de IEEE"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download from IEEE"
-    },
-    "settings.mac_vendor.update.automatic_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download the four public address registries directly from IEEE."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4つの公開アドレスレジストリをIEEEから直接ダウンロードします。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直接从 IEEE 下载四个公开地址注册表。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die vier öffentlichen Adressregister direkt von IEEE laden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descarga los cuatro registros públicos de direcciones directamente de IEEE."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download the four public address registries directly from IEEE."
-    },
-    "settings.mac_vendor.update.download_size": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloads about 5.6 MB."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "約5.6 MBをダウンロードします。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载约 5.6 MB。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lädt etwa 5,6 MB."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descarga unos 5,6 MB."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Downloads about 5.6 MB."
-    },
-    "settings.mac_vendor.update.local_scan_privacy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs, SSIDs, and Wi-Fi scan data stay on this Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID、SSID、Wi-FiスキャンデータはこのMacから送信されません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID、SSID 和 Wi-Fi 扫描数据始终保留在这台 Mac 上。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs, SSIDs und Wi-Fi-Scandaten bleiben auf diesem Mac."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los BSSID, SSID y datos de escaneo Wi-Fi permanecen en este Mac."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: BSSIDs, SSIDs, and Wi-Fi scan data stay on this Mac."
-    },
-    "settings.mac_vendor.update.ip_metadata": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE receives ordinary connection metadata, including your IP address."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEEにはIPアドレスを含む通常の接続メタデータが送信されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE 会收到包括你的 IP 地址在内的常规连接元数据。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE erhält übliche Verbindungsmetadaten einschließlich Ihrer IP-Adresse."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE recibe metadatos de conexión habituales, incluida tu dirección IP."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: IEEE receives ordinary connection metadata, including your IP address."
-    },
-    "settings.mac_vendor.update.no_endorsement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registry data identifies the address-block holder and may differ from the device brand. WiFi Lens is not affiliated with or endorsed by IEEE."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レジストリデータはアドレスブロックの登録者を示すもので、デバイスのブランドとは異なる場合があります。WiFi LensはIEEEと提携しておらず、IEEEの承認も受けていません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "注册表数据标识地址块注册主体，可能与设备品牌不同。WiFi Lens 与 IEEE 无关联，也未获其认可。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registerdaten nennen den Inhaber des Adressblocks und können von der Gerätemarke abweichen. WiFi Lens ist weder mit IEEE verbunden noch von IEEE empfohlen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los datos del registro identifican al titular del bloque de direcciones y pueden diferir de la marca del dispositivo. WiFi Lens no está afiliado ni respaldado por IEEE."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Registry data identifies the address-block holder and may differ from the device brand. WiFi Lens is not affiliated with or endorsed by IEEE."
-    },
-    "settings.mac_vendor.update.download": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download from IEEE"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEEからダウンロード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "从 IEEE 下载"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Von IEEE laden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar de IEEE"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download from IEEE"
-    },
-    "settings.mac_vendor.update.manual_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import IEEE CSV Files"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE CSVファイルをインポート"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导入 IEEE CSV 文件"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE-CSV-Dateien importieren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importar archivos CSV de IEEE"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Import IEEE CSV Files"
-    },
-    "settings.mac_vendor.update.manual_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download all four official CSV files, then select them together."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公式CSVファイルを4つすべてダウンロードし、まとめて選択してください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载全部四个官方 CSV 文件，然后一起选择。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle vier offiziellen CSV-Dateien laden und anschließend gemeinsam auswählen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descarga los cuatro archivos CSV oficiales y selecciónalos juntos."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download all four official CSV files, then select them together."
-    },
-    "settings.mac_vendor.update.registry_download_accessibility": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download %@ CSV"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ CSVをダウンロード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载 %@ CSV"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@-CSV laden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargar CSV de %@"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download %@ CSV"
-    },
-    "settings.mac_vendor.update.choose_files": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose Four CSV Files…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4つのCSVファイルを選択…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择四个 CSV 文件…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vier CSV-Dateien auswählen…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elegir cuatro archivos CSV…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Choose Four CSV Files…"
-    },
-    "settings.mac_vendor.update.choose_files_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose the MA-L, MA-M, MA-S, and IAB CSV files together."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MA-L、MA-M、MA-S、IABのCSVファイルをまとめて選択します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一起选择 MA-L、MA-M、MA-S 和 IAB CSV 文件。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die CSV-Dateien MA-L, MA-M, MA-S und IAB gemeinsam auswählen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elige juntos los archivos CSV MA-L, MA-M, MA-S e IAB."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Choose the MA-L, MA-M, MA-S, and IAB CSV files together."
-    },
-    "settings.mac_vendor.update.validation_header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File Validation"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルの検証"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文件校验"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dateiprüfung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validación de archivos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: File Validation"
-    },
-    "settings.mac_vendor.update.registry_waiting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — waiting for a valid file"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — 有効なファイルを待機中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — 正在等待有效文件"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — wartet auf eine gültige Datei"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — esperando un archivo válido"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ — waiting for a valid file"
-    },
-    "settings.mac_vendor.update.registry_waiting_value": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for validation"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検証待ち"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "等待校验"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wartet auf Prüfung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperando validación"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Waiting for validation"
-    },
-    "settings.mac_vendor.update.registry_valid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — %@ valid records"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — 有効なレコード%@件"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — %@ 条有效记录"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — %@ gültige Einträge"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ — %@ registros válidos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ — %@ valid records"
-    },
-    "settings.mac_vendor.update.registry_valid_value": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ valid records"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なレコード%@件"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 条有效记录"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ gültige Einträge"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ registros válidos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ valid records"
-    },
-    "settings.mac_vendor.update.validation_ready": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All four registries are valid (%@ records total)."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4つのレジストリはすべて有効です（合計%@件）。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "四个注册表均有效（共 %@ 条记录）。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle vier Register sind gültig (insgesamt %@ Einträge)."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los cuatro registros son válidos (%@ registros en total)."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: All four registries are valid (%@ records total)."
-    },
-    "settings.mac_vendor.update.validation_ready_accessibility": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All four registry files are valid"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4つのレジストリファイルはすべて有効です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "四个注册表文件均有效"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle vier Registerdateien sind gültig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los cuatro archivos de registro son válidos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: All four registry files are valid"
-    },
-    "settings.mac_vendor.update.import": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポート"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导入"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importieren"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importar"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Import"
-    },
-    "settings.mac_vendor.update.import_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install the validated local registry database."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検証済みのローカルレジストリデータベースをインストールします。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安装已校验的本地注册表数据库。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die geprüfte lokale Registerdatenbank installieren."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instala la base de datos local de registros validada."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Install the validated local registry database."
-    },
-    "settings.mac_vendor.update.downloading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロード中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在下载…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird geladen…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descargando…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Downloading…"
-    },
-    "settings.mac_vendor.update.progress_count": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld of %lld files"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld / %lldファイル"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld/%lld 个文件"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld von %lld Dateien"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld de %lld archivos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %lld of %lld files"
-    },
-    "settings.mac_vendor.update.progress_accessibility_value": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld of %lld files complete"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld / %lldファイル完了"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已完成 %lld/%lld 个文件"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld von %lld Dateien abgeschlossen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld de %lld archivos completados"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %lld of %lld files complete"
-    },
-    "settings.mac_vendor.update.reading_files": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading files…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルを読み込み中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在读取文件…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dateien werden gelesen…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leyendo archivos…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Reading files…"
-    },
-    "settings.mac_vendor.update.validating": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検証中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在校验…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird geprüft…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validando…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Validating…"
-    },
-    "settings.mac_vendor.update.installing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installing…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストール中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在安装…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird installiert…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instalando…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Installing…"
-    },
-    "settings.mac_vendor.update.clearing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clearing…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "消去中…"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在清空…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wird geleert…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrando…"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Clearing…"
-    },
-    "settings.mac_vendor.update.cancel_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discard the prepared import and close this sheet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "準備済みのインポートを破棄して閉じます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "放弃已准备的导入并关闭此面板。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorbereiteten Import verwerfen und dieses Fenster schließen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descarta la importación preparada y cierra este panel."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Discard the prepared import and close this sheet."
-    },
-    "settings.mac_vendor.update.cancel_operation_hint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel the current operation and close this sheet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在の処理をキャンセルして閉じます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取消当前操作并关闭此面板。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktuellen Vorgang abbrechen und dieses Fenster schließen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancela la operación actual y cierra este panel."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Cancel the current operation and close this sheet."
-    },
-    "settings.mac_vendor.error.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC Vendor Database Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MACベンダーデータベースエラー"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MAC 厂商数据库错误"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler der MAC-Herstellerdatenbank"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de la base de datos de fabricantes MAC"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: MAC Vendor Database Error"
-    },
-    "settings.mac_vendor.error.download_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download Failed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロードに失敗しました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载失败"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download fehlgeschlagen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de descarga"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Download Failed"
-    },
-    "settings.mac_vendor.error.files_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files Could Not Be Read"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルを読み込めませんでした"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取文件"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dateien konnten nicht gelesen werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudieron leer los archivos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Files Could Not Be Read"
-    },
-    "settings.mac_vendor.error.validation_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files Are Not Valid"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルが無効です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文件无效"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dateien sind ungültig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los archivos no son válidos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Files Are Not Valid"
-    },
-    "settings.mac_vendor.error.database_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データベースエラー"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "数据库错误"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datenbankfehler"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error de base de datos"
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Database Error"
-    },
-    "settings.mac_vendor.error.wrong_file_count": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select exactly %lld files. You selected %lld."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルを%lld個選択してください。現在は%lld個です。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "请选择恰好 %lld 个文件。当前选择了 %lld 个。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wählen Sie genau %lld Dateien aus. Ausgewählt: %lld."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecciona exactamente %lld archivos. Has seleccionado %lld."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Select exactly %lld files. You selected %lld."
-    },
-    "settings.mac_vendor.error.file_too_large": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ exceeds the %@ file-size limit."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@はファイルサイズ上限（%@）を超えています。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 超过了 %@ 的文件大小限制。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ überschreitet die Dateigrößengrenze von %@."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ supera el límite de tamaño de archivo de %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ exceeds the %@ file-size limit."
-    },
-    "settings.mac_vendor.error.total_size_exceeded": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The selected files exceed the %@ total-size limit."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したファイルは合計サイズ上限（%@）を超えています。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选文件超过了 %@ 的总大小限制。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die ausgewählten Dateien überschreiten die Gesamtgrößengrenze von %@."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los archivos seleccionados superan el límite de tamaño total de %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The selected files exceed the %@ total-size limit."
-    },
-    "settings.mac_vendor.error.invalid_encoding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is not valid UTF-8 CSV data."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@は有効なUTF-8 CSVデータではありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 不是有效的 UTF-8 CSV 数据。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ enthält keine gültigen UTF-8-CSV-Daten."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ no contiene datos CSV UTF-8 válidos."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ is not valid UTF-8 CSV data."
-    },
-    "settings.mac_vendor.error.malformed_csv": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contains malformed CSV data."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@のCSVデータが不正です。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 包含格式错误的 CSV 数据。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ enthält fehlerhafte CSV-Daten."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contiene datos CSV mal formados."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ contains malformed CSV data."
-    },
-    "settings.mac_vendor.error.missing_columns": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ is missing required columns: %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@に必須列がありません：%@。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 缺少必需列：%@。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ fehlen erforderliche Spalten: %@."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A %@ le faltan columnas obligatorias: %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ is missing required columns: %@."
-    },
-    "settings.mac_vendor.error.mixed_registries": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contains more than one registry type."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@に複数のレジストリ種別が含まれています。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 包含多种注册表类型。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ enthält mehrere Registertypen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contiene más de un tipo de registro."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ contains more than one registry type."
-    },
-    "settings.mac_vendor.error.duplicate_registry": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More than one %@ file was selected."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ファイルが複数選択されています。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择了多个 %@ 文件。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mehr als eine %@-Datei wurde ausgewählt."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se seleccionó más de un archivo %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: More than one %@ file was selected."
-    },
-    "settings.mac_vendor.error.missing_registry": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The %@ file is missing."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ファイルがありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 %@ 文件。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die %@-Datei fehlt."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el archivo %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The %@ file is missing."
-    },
-    "settings.mac_vendor.error.invalid_assignment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contains an invalid %@ assignment: %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@に無効な%@割り当てがあります：%@。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 包含无效的 %@ 分配：%@。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ enthält eine ungültige %@-Zuweisung: %@."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contiene una asignación %@ no válida: %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ contains an invalid %@ assignment: %@."
-    },
-    "settings.mac_vendor.error.invalid_organization": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contains an invalid organization name."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@に無効な組織名があります。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 包含无效的组织名称。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ enthält einen ungültigen Organisationsnamen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ contiene un nombre de organización no válido."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ contains an invalid organization name."
-    },
-    "settings.mac_vendor.error.too_few_records": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ requires at least %lld valid records; %lld were found."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@には有効なレコードが%lld件以上必要ですが、%lld件しかありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 至少需要 %lld 条有效记录，但只找到 %lld 条。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ benötigt mindestens %lld gültige Einträge; gefunden wurden %lld."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ requiere al menos %lld registros válidos; se encontraron %lld."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ requires at least %lld valid records; %lld were found."
-    },
-    "settings.mac_vendor.error.conflicting_assignment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The assignment %@/%lld has conflicting organizations."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "割り当て%@/%lldの組織が競合しています。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分配 %@/%lld 对应的组织存在冲突。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Zuweisung %@/%lld enthält widersprüchliche Organisationen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La asignación %@/%lld tiene organizaciones en conflicto."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The assignment %@/%lld has conflicting organizations."
-    },
-    "settings.mac_vendor.error.http_status": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For %@, IEEE returned HTTP %lld."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@でIEEEがHTTP %lldを返しました。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IEEE 为 %@ 返回了 HTTP %lld。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Für %@ hat IEEE HTTP %lld zurückgegeben."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Para %@, IEEE devolvió HTTP %lld."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: For %@, IEEE returned HTTP %lld."
-    },
-    "settings.mac_vendor.error.disallowed_redirect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The download redirected to a disallowed address: %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダウンロードが許可されていないアドレスにリダイレクトされました：%@。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下载被重定向到不允许的地址：%@。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Download wurde an eine nicht zulässige Adresse umgeleitet: %@."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La descarga se redirigió a una dirección no permitida: %@."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The download redirected to a disallowed address: %@."
-    },
-    "settings.mac_vendor.error.download_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The %@ download failed. Try again or use manual import."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@のダウンロードに失敗しました。再試行するか、手動インポートを使用してください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 下载失败。请重试或使用手动导入。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der %@-Download ist fehlgeschlagen. Versuchen Sie es erneut oder verwenden Sie den manuellen Import."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La descarga de %@ falló. Inténtalo de nuevo o usa la importación manual."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The %@ download failed. Try again or use manual import."
-    },
-    "settings.mac_vendor.error.file_read_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ could not be read. Choose the four CSV files again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@を読み込めませんでした。4つのCSVファイルを選び直してください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取 %@。请重新选择四个 CSV 文件。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ konnte nicht gelesen werden. Wählen Sie die vier CSV-Dateien erneut aus."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer %@. Vuelve a elegir los cuatro archivos CSV."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: %@ could not be read. Choose the four CSV files again."
-    },
-    "settings.mac_vendor.error.unsupported_schema": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database format version %lld is not supported. Clear or update the database."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "データベース形式バージョン%lldには対応していません。消去または更新してください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不支持数据库格式版本 %lld。请清空或更新数据库。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datenbankformat Version %lld wird nicht unterstützt. Leeren oder aktualisieren Sie die Datenbank."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La versión %lld del formato de base de datos no es compatible. Borra o actualiza la base de datos."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: Database format version %lld is not supported. Clear or update the database."
-    },
-    "settings.mac_vendor.error.persistence_failure": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The local database could not be saved, loaded, or removed."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルデータベースを保存、読み込み、または削除できませんでした。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法保存、加载或移除本地数据库。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die lokale Datenbank konnte nicht gespeichert, geladen oder entfernt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo guardar, cargar o eliminar la base de datos local."
-          }
-        }
-      },
-      "comment": "MAC vendor database UI text. English: The local database could not be saved, loaded, or removed."
-    },
-    "settings.mac_vendor.error.no_prepared_import": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validate all four CSV files before importing."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートする前に4つのCSVファイルをすべて検証してください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "导入前请先校验全部四个 CSV 文件。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prüfen Sie vor dem Import alle vier CSV-Dateien."
-          }
-        },
-        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Valida los cuatro archivos CSV antes de importarlos."
+            "value": "覆盖率不可用"
           }
         }
-      },
-      "comment": "MAC vendor database UI text. English: Validate all four CSV files before importing."
+      }
     },
-    "settings.mac_vendor.reminder.title": {
+    "analysis.insight.limitation.incomplete_coverage": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Set Up MAC Vendor Information?"
+            "value": "Coverage incomplete"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "MACベンダー情報を設定しますか？"
+            "value": "Abdeckung unvollständig"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "设置 MAC 厂商信息？"
+            "value": "Cobertura incompleta"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "MAC-Herstellerinformationen einrichten?"
+            "value": "カバレッジが不完全です"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "¿Configurar la información del fabricante MAC?"
+            "value": "覆盖率不完整"
           }
         }
-      },
-      "comment": "MAC vendor database UI text. English: Set Up MAC Vendor Information?"
+      }
     },
-    "settings.mac_vendor.reminder.message": {
+    "analysis.insight.limitation.session_boundary": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install the public registry database to display registered organizations in the network table."
+            "value": "Evidence crosses a session boundary"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "公開レジストリデータベースをインストールすると、ネットワーク表に登録組織を表示できます。"
+            "value": "Belege überschreiten eine Sitzungsgrenze"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "安装公开注册表数据库后，可在网络表格中显示注册组织。"
+            "value": "La evidencia cruza un límite de sesión"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Installieren Sie die öffentliche Registerdatenbank, um registrierte Organisationen in der Netzwerktabelle anzuzeigen."
+            "value": "エビデンスがセッション境界をまたいでいます"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Instala la base de datos pública de registros para mostrar las organizaciones registradas en la tabla de redes."
+            "value": "证据跨越会话边界"
           }
         }
-      },
-      "comment": "MAC vendor database UI text. English: Install the public registry database to display registered organizations in the network table."
+      }
     },
-    "settings.mac_vendor.reminder.later": {
+    "analysis.insight.limitation.missing_ssid": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Later"
+            "value": "SSID missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "後で"
+            "value": "SSID fehlt"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "稍后"
+            "value": "Falta el SSID"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Später"
+            "value": "SSID がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Más tarde"
+            "value": "缺少 SSID"
           }
         }
-      },
-      "comment": "MAC vendor database UI text. English: Later"
+      }
     },
-    "settings.mac_vendor.reminder.do_not_ask_again": {
+    "analysis.insight.limitation.missing_bssid": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Do Not Ask Again"
+            "value": "BSSID missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "今後は確認しない"
+            "value": "BSSID fehlt"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "不再询问"
+            "value": "Falta el BSSID"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nicht erneut fragen"
+            "value": "BSSID がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No volver a preguntar"
+            "value": "缺少 BSSID"
           }
         }
-      },
-      "comment": "MAC vendor database UI text. English: Do Not Ask Again"
+      }
     },
-    "settings.mac_vendor.error.automatic_download_failed": {
+    "analysis.insight.limitation.missing_gateway_identity": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "One or more IEEE registry files could not be downloaded. Try again."
+            "value": "Gateway identity missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "1つ以上のIEEEレジストリファイルをダウンロードできませんでした。もう一度お試しください。"
+            "value": "Gateway-Identität fehlt"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "一个或多个 IEEE 注册表文件无法下载，请重试。"
+            "value": "Falta la identidad de la puerta de enlace"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mindestens eine IEEE-Registrierungsdatei konnte nicht heruntergeladen werden. Versuche es erneut."
+            "value": "ゲートウェイ ID がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudieron descargar uno o varios archivos de registro de IEEE. Inténtalo de nuevo."
+            "value": "缺少网关标识"
           }
         }
       }
     },
-    "network_diagnostics.status.blocked": {
+    "analysis.insight.limitation.ambiguous_normal_behavior": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Blocked"
+            "value": "Normal behavior cannot be ruled out"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ブロックされています"
+            "value": "Normales Verhalten kann nicht ausgeschlossen werden"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "已阻止"
+            "value": "No se puede descartar un comportamiento normal"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Blockiert"
+            "value": "正常な動作を除外できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bloqueado"
+            "value": "无法排除正常行为"
           }
         }
       }
     },
-    "network_diagnostics.status.skipped": {
+    "analysis.insight.limitation.cross_network_evidence": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skipped"
+            "value": "Evidence spans networks"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "スキップ済み"
+            "value": "Belege erstrecken sich über mehrere Netzwerke"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "已跳过"
+            "value": "La evidencia abarca varias redes"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Übersprungen"
+            "value": "エビデンスが複数ネットワークにわたります"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Omitido"
+            "value": "证据跨多个网络"
           }
         }
       }
     },
-    "network_diagnostics.check.path.title": {
+    "analysis.insight.limitation.threshold_not_met": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "System Network Path"
+            "value": "Threshold not met"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムネットワーク経路"
+            "value": "Schwelle nicht erreicht"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "系统网络路径"
+            "value": "Umbral no alcanzado"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Systemnetzwerkpfad"
+            "value": "しきい値に達していません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ruta de red del sistema"
+            "value": "未达到阈值"
           }
         }
       }
     },
-    "network_diagnostics.check.internet.title": {
+    "analysis.statistics.network": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Internet Access"
+            "value": "Network"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "インターネットアクセス"
+            "value": "Netzwerk"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "互联网访问"
+            "value": "Red"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Internetzugang"
+            "value": "ネットワーク"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acceso a Internet"
+            "value": "网络"
           }
         }
       }
     },
-    "network_diagnostics.path.normal.summary": {
+    "analysis.statistics.no_history_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "System network path is available"
+            "value": "No local history"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムネットワーク経路を利用できます"
+            "value": "Keine lokale Historie"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "系统网络路径可用"
+            "value": "Sin historial local"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Systemnetzwerkpfad ist verfügbar"
+            "value": "ローカル履歴がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La ruta de red del sistema está disponible"
+            "value": "没有本地历史记录"
           }
         }
       }
     },
-    "network_diagnostics.path.abnormal.summary": {
+    "analysis.statistics.no_history_message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No system network path is available. Check Wi-Fi or Ethernet."
+            "value": "WiFi Lens has not recorded Timeline history for this period. This is not a statement about network health."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "利用可能なシステムネットワーク経路がありません。Wi-Fi または Ethernet を確認してください。"
+            "value": "WiFi Lens hat für diesen Zeitraum keine Timeline-Historie aufgezeichnet. Das ist keine Aussage über die Netzwerkgesundheit."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的系统网络路径。请检查 Wi-Fi 或以太网。"
+            "value": "WiFi Lens no registró historial de línea de tiempo para este período. Esto no es una afirmación sobre la salud de la red."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kein Systemnetzwerkpfad ist verfügbar. Prüfe Wi-Fi oder Ethernet."
+            "value": "この期間のタイムライン履歴は WiFi Lens に記録されていません。これはネットワークの健全性を示すものではありません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No hay una ruta de red del sistema disponible. Comprueba Wi-Fi o Ethernet."
+            "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
           }
         }
       }
     },
-    "network_diagnostics.path.indeterminate.summary": {
+    "analysis.statistics.observation_state_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The system network path could not be confirmed. Try again later."
+            "value": "Observation state"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "システムネットワーク経路を確認できませんでした。しばらくしてからもう一度お試しください。"
+            "value": "Beobachtungsstatus"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "暂时无法确认系统网络路径，请稍后重试。"
+            "value": "Estado de observación"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Systemnetzwerkpfad konnte nicht bestätigt werden. Versuche es später erneut."
+            "value": "観測状態"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo confirmar la ruta de red del sistema. Inténtalo de nuevo más tarde."
+            "value": "观测状态"
           }
         }
       }
     },
-    "network_diagnostics.internet.normal.summary": {
+    "analysis.statistics.observation_state_message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS access verified"
+            "value": "WiFi Lens records local Timeline observations while the app is observing. New history appears as observations continue."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS アクセスを確認しました"
+            "value": "WiFi Lens zeichnet lokale Timeline-Beobachtungen auf, während die App beobachtet. Neue Historie erscheint, während die Beobachtungen fortgesetzt werden."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "已验证 HTTPS 访问"
+            "value": "WiFi Lens registra observaciones locales de la línea de tiempo mientras la app está observando. El historial nuevo aparece a medida que continúan las observaciones."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS-Zugriff bestätigt"
+            "value": "アプリが観測している間、WiFi Lens はローカルのタイムライン観測を記録します。観測が続くにつれて新しい履歴が表示されます。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acceso HTTPS verificado"
+            "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
           }
         }
       }
     },
-    "network_diagnostics.internet.normal.detail": {
+    "analysis.statistics.local_history_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The HTTPS request succeeded and the captive-portal control response matched."
+            "value": "Local history"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS リクエストが成功し、キャプティブポータルの制御レスポンスが一致しました。"
+            "value": "Lokale Historie"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS 请求成功，强制门户控制响应符合预期。"
+            "value": "Historial local"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die HTTPS-Anfrage war erfolgreich und die Kontrollantwort für das Captive Portal stimmte überein."
+            "value": "ローカル履歴"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La solicitud HTTPS se completó correctamente y la respuesta de control del portal cautivo coincidió."
+            "value": "本地历史记录"
           }
         }
       }
     },
-    "network_diagnostics.internet.abnormal.summary": {
+    "analysis.statistics.local_history_message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Control endpoint checks need attention"
+            "value": "History is stored locally on this Mac. You can clear it in Settings → Data."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "制御エンドポイントの確認が必要です"
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert. Sie können sie unter Einstellungen → Daten löschen."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "控制端点检查需要注意"
+            "value": "El historial se almacena localmente en este Mac. Puedes borrarlo en Ajustes → Datos."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kontrollendpunktprüfungen erfordern Aufmerksamkeit"
+            "value": "履歴はこの Mac にローカル保存されます。設定 → データで消去できます。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las comprobaciones de los puntos de conexión de control requieren atención"
+            "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
           }
         }
       }
     },
-    "network_diagnostics.internet.abnormal.detail": {
+    "analysis.statistics.no_matching_events_title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "One or more control endpoint responses did not match the expected result."
+            "value": "No matching events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "1 つ以上の制御エンドポイントのレスポンスが想定された結果と一致しませんでした。"
+            "value": "Keine passenden Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "一个或多个控制端点响应与预期结果不符。"
+            "value": "Sin eventos coincidentes"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mindestens eine Antwort eines Kontrollendpunkts entsprach nicht dem erwarteten Ergebnis."
+            "value": "一致するイベントがありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una o más respuestas de los puntos de conexión de control no coincidieron con el resultado esperado."
+            "value": "没有匹配的事件"
           }
         }
       }
     },
-    "network_diagnostics.internet.indeterminate.summary": {
+    "analysis.statistics.no_matching_events_message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Control endpoint check is inconclusive"
+            "value": "WiFi Lens observed this time range, but no events match the current network and filter."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "制御エンドポイントの確認結果は確定できません"
+            "value": "WiFi Lens hat diesen Zeitraum beobachtet, aber keine Ereignisse passen zum aktuellen Netzwerk und Filter."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "控制端点检查结果无法确定"
+            "value": "WiFi Lens observó este rango de tiempo, pero ningún evento coincide con la red y el filtro actuales."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kontrollendpunktprüfung ist nicht eindeutig"
+            "value": "WiFi Lens はこの期間を観測しましたが、現在のネットワークとフィルターに一致するイベントはありません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La comprobación del punto de conexión de control no es concluyente"
+            "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
           }
         }
       }
     },
-    "network_diagnostics.internet.indeterminate.detail": {
+    "analysis.readiness.observing": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS access succeeded, but the captive-portal control endpoint did not respond in time."
+            "value": "Recording local observations is active"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS アクセスは成功しましたが、キャプティブポータルの制御エンドポイントが時間内に応答しませんでした。"
+            "value": "Lokale Beobachtungen werden aktiv aufgezeichnet"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS 访问成功，但强制门户控制端点未在规定时间内响应。"
+            "value": "La grabación de observaciones locales está activa"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der HTTPS-Zugriff war erfolgreich, aber der Kontrollendpunkt für Captive Portale hat nicht rechtzeitig geantwortet."
+            "value": "ローカル観測の記録中"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El acceso HTTPS se completó correctamente, pero el punto de conexión de control del portal cautivo no respondió a tiempo."
+            "value": "正在记录本地观测"
           }
         }
       }
     },
-    "network_diagnostics.dns.available.summary": {
+    "analysis.readiness.observation_range_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS resolution is available."
+            "value": "Observed %@ – %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS の名前解決を利用できます。"
+            "value": "Beobachtet %@ – %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS 解析可用。"
+            "value": "Observado %@ – %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die DNS-Auflösung ist verfügbar."
+            "value": "観測 %@ – %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La resolución de DNS está disponible."
+            "value": "观测 %@ – %@"
           }
         }
       }
     },
-    "network_diagnostics.dns.inconsistent.summary": {
+    "analysis.readiness.observed_duration_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS resolution is inconsistent across test names."
+            "value": "Observed duration: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テスト名で DNS 解決の結果が一致しません。"
+            "value": "Beobachtungsdauer: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "各测试域名的 DNS 解析结果不一致。"
+            "value": "Duración observada: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die DNS-Auflösung ist bei den Testnamen uneinheitlich."
+            "value": "観測時間: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La resolución de DNS es inconsistente entre los nombres de prueba."
+            "value": "观测时长：%@"
           }
         }
       }
     },
-    "network_diagnostics.dns.unavailable.summary": {
+    "analysis.readiness.coverage_gap_count_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS resolution failed for all test names."
+            "value": "Coverage gaps: %lld"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "すべてのテスト名で DNS 解決に失敗しました。"
+            "value": "Abdeckungslücken: %lld"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "所有测试域名的 DNS 解析均失败。"
+            "value": "Brechas de cobertura: %lld"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die DNS-Auflösung ist für alle Testnamen fehlgeschlagen."
+            "value": "範囲の欠落: %lld"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La resolución de DNS falló para todos los nombres de prueba."
+            "value": "覆盖缺口：%lld"
           }
         }
       }
     },
-    "network_diagnostics.dns.unable_to_determine.summary": {
+    "analysis.readiness.local_storage": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The DNS result could not be determined."
+            "value": "History is stored locally on this Mac."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "DNS の結果を判断できませんでした。"
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法确定 DNS 结果。"
+            "value": "El historial se almacena localmente en este Mac."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Das DNS-Ergebnis konnte nicht ermittelt werden."
+            "value": "履歴はこの Mac にローカル保存されます。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo determinar el resultado de DNS."
+            "value": "历史记录存储在本机本地。"
           }
         }
       }
     },
-    "network_diagnostics.proxy.automatic.detail": {
+    "analysis.readiness.storage_unavailable": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "automatic proxy configuration was detected and was not evaluated."
+            "value": "Local history storage is unavailable."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "自動プロキシ構成が検出されましたが、評価されませんでした。"
+            "value": "Der lokale Historienspeicher ist nicht verfügbar."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测到自动代理配置，但未进行评估。"
+            "value": "El almacenamiento de historial local no está disponible."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eine automatische Proxy-Konfiguration wurde erkannt und nicht ausgewertet."
+            "value": "ローカル履歴ストレージを利用できません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se detectó una configuración automática del proxy, pero no se evaluó."
+            "value": "本地历史记录存储不可用。"
           }
         }
       }
     },
-    "network_diagnostics.proxy.pac_unavailable.summary": {
+    "analysis.readiness.rules_eligible": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Automatic proxy configuration is unavailable"
+            "value": "All rules can run for the selected scope."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "自動プロキシ構成を利用できません"
+            "value": "Alle Regeln können für den ausgewählten Bereich ausgeführt werden."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动代理配置不可用"
+            "value": "Todas las reglas pueden ejecutarse para el ámbito seleccionado."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die automatische Proxy-Konfiguration ist nicht verfügbar"
+            "value": "選択したスコープではすべてのルールを実行できます。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La configuración automática del proxy no está disponible"
+            "value": "所选作用域可以运行所有规则。"
           }
         }
       }
     },
-    "network_diagnostics.proxy.authentication_required.summary": {
+    "analysis.readiness.rules_blocked_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A tested proxy route requires authentication"
+            "value": "Rules unavailable: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストしたプロキシルートには認証が必要です"
+            "value": "Regeln nicht verfügbar: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "测试的代理路由需要身份验证"
+            "value": "Reglas no disponibles: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eine getestete Proxy-Route erfordert eine Authentifizierung"
+            "value": "実行できないルール: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una ruta de proxy probada requiere autenticación"
+            "value": "无法运行的规则：%@"
           }
         }
       }
     },
-    "network_diagnostics.proxy.endpoint_unavailable.summary": {
+    "analysis.rule.category.repeated_disconnection": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The selected proxy endpoint is unavailable"
+            "value": "Repeated disconnection"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "選択されたプロキシエンドポイントを利用できません"
+            "value": "Wiederholte Trennung"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "所选代理端点不可用"
+            "value": "Desconexión repetida"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der ausgewählte Proxy-Endpunkt ist nicht verfügbar"
+            "value": "切断の繰り返し"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El punto de conexión del proxy seleccionado no está disponible"
+            "value": "重复断开"
           }
         }
       }
     },
-    "network_diagnostics.proxy.egress_unavailable.summary": {
+    "analysis.rule.category.gateway_interruption": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The selected proxy cannot reach the control endpoint"
+            "value": "Repeated gateway-latency observations"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "選択されたプロキシから制御エンドポイントに接続できません"
+            "value": "Wiederholte Gateway-Latenz-Beobachtungen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "所选代理无法访问控制端点"
+            "value": "Observaciones repetidas de latencia de gateway"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der ausgewählte Proxy kann den Kontrollendpunkt nicht erreichen"
+            "value": "ゲートウェイ遅延の繰り返し"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El proxy seleccionado no puede acceder al punto de conexión de control"
+            "value": "重复的网关延迟观测"
           }
         }
       }
     },
-    "network_diagnostics.check.ipv6.title": {
+    "analysis.rule.category.roaming_instability": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6 Access"
+            "value": "AP switching"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6-Zugriff"
+            "value": "AP-Wechsel"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acceso IPv6"
+            "value": "Cambios de AP"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6アクセス"
+            "value": "AP 切り替え"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6 访问"
+            "value": "AP 切换"
           }
         }
       }
     },
-    "network_diagnostics.ipv6.normal.summary": {
+    "analysis.readiness.duration_minutes_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6 HTTPS access verified"
+            "value": "%lld min"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6-HTTPS-Zugriff bestätigt"
+            "value": "%lld Min."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acceso HTTPS mediante IPv6 verificado"
+            "value": "%lld min"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6経由のHTTPSアクセスを確認しました"
+            "value": "%lld 分"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已验证通过 IPv6 的 HTTPS 访问"
+            "value": "%lld 分钟"
           }
         }
       }
     },
-    "network_diagnostics.ipv6.indeterminate.summary": {
+    "analysis.readiness.duration_hours_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6 HTTPS access could not be verified. IPv4 access may still work."
+            "value": "%lld h %lld min"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der IPv6-HTTPS-Zugriff konnte nicht bestätigt werden. Der IPv4-Zugriff kann weiterhin funktionieren."
+            "value": "%lld Std. %lld Min."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo verificar el acceso HTTPS mediante IPv6. Es posible que el acceso IPv4 siga funcionando."
+            "value": "%lld h %lld min"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "IPv6経由のHTTPSアクセスを確認できませんでした。IPv4アクセスは引き続き利用できる可能性があります。"
+            "value": "%lld 時間 %lld 分"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法验证通过 IPv6 的 HTTPS 访问。IPv4 访问可能仍然可用。"
+            "value": "%lld 小时 %lld 分钟"
           }
         }
       }
     },
-    "network_diagnostics.ipv6.skipped.summary": {
+    "analysis.insights.network": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No global IPv6 address is available, so the optional IPv6 check was skipped."
+            "value": "Network"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keine globale IPv6-Adresse ist verfügbar. Daher wurde die optionale IPv6-Prüfung übersprungen."
+            "value": "Netzwerk"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No hay ninguna dirección IPv6 global disponible, por lo que se omitió la comprobación IPv6 opcional."
+            "value": "Red"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "グローバルIPv6アドレスを利用できないため、オプションのIPv6チェックをスキップしました。"
+            "value": "ネットワーク"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有可用的全局 IPv6 地址，因此跳过了可选的 IPv6 检查。"
+            "value": "网络"
           }
         }
       }
     },
-    "network_diagnostics.proxy.direct_routes.summary": {
+    "analysis.insights.network_logical_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The tested HTTP and HTTPS routes use direct connections"
+            "value": "Network: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストした HTTP および HTTPS ルートは直接接続を使用しています"
+            "value": "Netzwerk: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "测试的 HTTP 和 HTTPS 路由使用直接连接"
+            "value": "Red: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die getesteten HTTP- und HTTPS-Routen verwenden Direktverbindungen"
+            "value": "ネットワーク: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las rutas HTTP y HTTPS probadas usan conexiones directas"
+            "value": "网络：%@"
           }
         }
       }
     },
-    "network_diagnostics.proxy.mixed_routing.summary": {
+    "analysis.insights.network_access_point_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The tested HTTP and HTTPS routes use different proxy paths"
+            "value": "AP: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストした HTTP および HTTPS ルートは異なるプロキシ経路を使用しています"
+            "value": "AP: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "测试的 HTTP 和 HTTPS 路由使用不同的代理路径"
+            "value": "AP: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die getesteten HTTP- und HTTPS-Routen verwenden unterschiedliche Proxy-Pfade"
+            "value": "AP: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las rutas HTTP y HTTPS probadas usan distintas rutas de proxy"
+            "value": "AP：%@"
           }
         }
       }
     },
-    "network_diagnostics.proxy.routes_available.summary": {
+    "analysis.insights.network_unattributed": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The tested proxy routes are available"
+            "value": "Network: unattributed"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストしたプロキシルートを利用できます"
+            "value": "Netzwerk: nicht zugeordnet"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "测试的代理路由可用"
+            "value": "Red: no atribuida"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die getesteten Proxy-Routen sind verfügbar"
+            "value": "ネットワーク: 未分類"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las rutas de proxy probadas están disponibles"
+            "value": "网络：无法归属"
           }
         }
       }
     },
-    "network_diagnostics.proxy.route_unavailable.summary": {
+    "analysis.insights.gateway_identity_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A tested proxy route is unavailable"
+            "value": "Gateway: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストしたプロキシルートを利用できません"
+            "value": "Gateway: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "测试的代理路由不可用"
+            "value": "Gateway: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eine getestete Proxy-Route ist nicht verfügbar"
+            "value": "ゲートウェイ: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una ruta de proxy probada no está disponible"
+            "value": "网关：%@"
           }
         }
       }
     },
-    "network_diagnostics.proxy.unable_to_determine.summary": {
+    "analysis.insights.bssid_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Unable to determine the tested proxy routes"
+            "value": "BSSIDs: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "テストしたプロキシルートを判定できません"
+            "value": "BSSIDs: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法确定测试的代理路由"
+            "value": "BSSIDs: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die getesteten Proxy-Routen konnten nicht ermittelt werden"
+            "value": "BSSID: %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudieron determinar las rutas de proxy probadas"
+            "value": "BSSID：%@"
           }
         }
       }
     },
-    "network_diagnostics.internet.connectivity_failure.summary": {
+    "analysis.insights.trust_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The direct HTTPS connection could not be established"
+            "value": "%@ · %@ · %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "直接 HTTPS 接続を確立できませんでした"
+            "value": "%@ · %@ · %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法建立直接 HTTPS 连接"
+            "value": "%@ · %@ · %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die direkte HTTPS-Verbindung konnte nicht hergestellt werden"
+            "value": "%@ · %@ · %@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo establecer la conexión HTTPS directa"
+            "value": "%@ · %@ · %@"
           }
         }
       }
     },
-    "network_diagnostics.internet.secure_connection_failure.summary": {
+    "analysis.insights.applicability.applicable": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The HTTPS connection failed during TLS or certificate validation"
+            "value": "Applicable"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "TLS または証明書の検証中に HTTPS 接続が失敗しました"
+            "value": "Anwendbar"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTPS 连接在 TLS 或证书验证期间失败"
+            "value": "Aplicable"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die HTTPS-Verbindung ist bei der TLS- oder Zertifikatsprüfung fehlgeschlagen"
+            "value": "適用"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La conexión HTTPS falló durante la validación TLS o del certificado"
+            "value": "适用"
           }
         }
       }
     },
-    "network_diagnostics.internet.certificate_time_failure.summary": {
+    "analysis.insights.applicability.limited": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The HTTPS certificate is not valid for the current system time"
+            "value": "Limited applicability"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在のシステム時刻では HTTPS 証明書が有効ではありません"
+            "value": "Eingeschränkt anwendbar"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "当前系统时间不在 HTTPS 证书的有效期内"
+            "value": "Aplicabilidad limitada"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Das HTTPS-Zertifikat ist für die aktuelle Systemzeit nicht gültig"
+            "value": "適用は限定的"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El certificado HTTPS no es válido para la hora actual del sistema"
+            "value": "适用性有限"
           }
         }
       }
     },
-    "network_diagnostics.path_summary.title": {
+    "timeline.evidence.query_failure.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Observed network path"
+            "value": "Evidence query failed"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "検出されたネットワーク経路"
+            "value": "Abfrage der Belege fehlgeschlagen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测到的网络路径"
+            "value": "Error al consultar las evidencias"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Erkannter Netzwerkpfad"
+            "value": "証拠のクエリに失敗しました"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ruta de red detectada"
+            "value": "证据查询失败"
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_authentication.detection": {
+    "timeline.evidence.query_failure.message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The proxy requested sign-in."
+            "value": "The supporting Timeline history could not be read, so no events are shown instead of incomplete evidence."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "プロキシが認証を要求しました。"
+            "value": "Die unterstützende Timeline-Historie konnte nicht gelesen werden. Es werden keine Ereignisse angezeigt, statt unvollständiger Belege."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理要求登录。"
+            "value": "No se pudo leer el historial de la línea de tiempo de respaldo, por lo que no se muestran eventos en lugar de evidencias incompletas."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Proxy verlangt eine Anmeldung."
+            "value": "根拠となるタイムライン履歴を読み取れなかったため、不完全な証拠の代わりにイベントを表示しません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El proxy solicita iniciar sesión."
+            "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_authentication.cause": {
+    "timeline.evidence.storage_failure.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The proxy credentials may be missing or expired."
+            "value": "History storage unavailable"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "プロキシの認証情報が未設定または期限切れの可能性があります。"
+            "value": "Historienspeicher nicht verfügbar"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理凭据可能未设置或已过期。"
+            "value": "Almacenamiento de historial no disponible"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Proxy-Zugangsdaten fehlen möglicherweise oder sind abgelaufen."
+            "value": "履歴ストレージを利用できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que las credenciales del proxy falten o hayan caducado."
+            "value": "历史记录存储不可用"
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_authentication.action": {
+    "timeline.evidence.storage_failure.message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Check the proxy credentials or sign in again."
+            "value": "Local Timeline history could not be read, so the supporting events cannot be verified."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "プロキシの認証情報を確認するか、もう一度サインインしてください。"
+            "value": "Die lokale Timeline-Historie konnte nicht gelesen werden, daher können die Belegereignisse nicht überprüft werden."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查代理凭据，或重新登录。"
+            "value": "No se pudo leer el historial local de la línea de tiempo, por lo que no se pueden verificar los eventos de respaldo."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüfe die Proxy-Zugangsdaten oder melde dich erneut an."
+            "value": "ローカルのタイムライン履歴を読み取れないため、根拠となるイベントを確認できません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprueba las credenciales del proxy o vuelve a iniciar sesión."
+            "value": "无法读取本地时间线历史，因此无法验证支持事件。"
           }
         }
       }
     },
-    "network_diagnostics.remediation.captive_portal.detection": {
+    "timeline.evidence.not_found.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The network may require sign-in."
+            "value": "Supporting events not found"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークでサインインが必要な可能性があります。"
+            "value": "Belegereignisse nicht gefunden"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络可能需要登录。"
+            "value": "No se encontraron eventos de respaldo"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Für dieses Netzwerk ist möglicherweise eine Anmeldung erforderlich."
+            "value": "根拠となるイベントが見つかりません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que la red requiera iniciar sesión."
+            "value": "未找到支持事件"
           }
         }
       }
     },
-    "network_diagnostics.remediation.captive_portal.cause": {
+    "timeline.evidence.not_found.message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A captive portal may be intercepting web access."
+            "value": "None of the supporting events for this insight exist in the selected period and network."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "キャプティブポータルがウェブアクセスを遮っている可能性があります。"
+            "value": "Keines der Belegereignisse für diese Erkenntnis existiert im ausgewählten Zeitraum und Netzwerk."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络门户可能正在拦截网页访问。"
+            "value": "Ninguno de los eventos de respaldo de esta conclusión existe en el período y la red seleccionados."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ein Captive Portal fängt möglicherweise den Webzugriff ab."
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークには存在しません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que un portal cautivo esté interceptando el acceso web."
+            "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
           }
         }
       }
     },
-    "network_diagnostics.remediation.captive_portal.action": {
+    "timeline.evidence.no_matching.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Open a browser and complete the network sign-in."
+            "value": "No matching events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ブラウザを開いてネットワークへのサインインを完了してください。"
+            "value": "Keine passenden Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "打开浏览器并完成网络登录。"
+            "value": "No hay eventos coincidentes"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Öffne einen Browser und schließe die Netzwerkanmeldung ab."
+            "value": "一致するイベントがありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abre un navegador y completa el inicio de sesión de la red."
+            "value": "没有匹配的事件"
           }
         }
       }
     },
-    "network_diagnostics.remediation.certificate_time.detection": {
+    "timeline.evidence.no_matching.message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The secure connection certificate time is invalid."
+            "value": "WiFi Lens was observing during this period, but no events match the selected network and event type."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "安全な接続の証明書時刻が正しくありません。"
+            "value": "WiFi Lens hat in diesem Zeitraum beobachtet, aber keine Ereignisse entsprechen dem ausgewählten Netzwerk und Ereignistyp."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "安全连接的证书时间无效。"
+            "value": "WiFi Lens estaba observando durante este período, pero ningún evento coincide con la red y el tipo de evento seleccionados."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Zertifikatszeit der sicheren Verbindung ist ungültig."
+            "value": "この期間に WiFi Lens は観測していましたが、選択したネットワークとイベントタイプに一致するイベントはありません。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La hora del certificado de la conexión segura no es válida."
+            "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
           }
         }
       }
     },
-    "network_diagnostics.remediation.certificate_time.cause": {
+    "analysis.readiness.rule_unavailable_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The Mac date or time may be incorrect."
+            "value": "Cannot evaluate now: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Macの日付または時刻が正しくない可能性があります。"
+            "value": "Aktuell nicht bewertbar: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mac 的日期或时间可能不正确。"
+            "value": "No se puede evaluar ahora: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Datum oder Uhrzeit des Mac sind möglicherweise falsch."
+            "value": "現在は評価できません：%@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que la fecha o la hora del Mac sean incorrectas."
+            "value": "当前无法评估：%@"
           }
         }
       }
     },
-    "network_diagnostics.remediation.certificate_time.action": {
+    "analysis.readiness.rule_limited_format": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Turn on automatic date and time, then run the check again."
+            "value": "Limited analysis: %@"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "日付と時刻の自動設定を有効にして、もう一度チェックしてください。"
+            "value": "Eingeschränkte Analyse: %@"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "开启自动设置日期和时间，然后重新运行检查。"
+            "value": "Análisis limitado: %@"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktiviere Datum und Uhrzeit automatisch und führe die Prüfung erneut aus."
+            "value": "限定分析：%@"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activa la fecha y hora automáticas y vuelve a ejecutar la comprobación."
+            "value": "有限分析：%@"
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_unavailable.detection": {
+    "analysis.readiness.rule_limited_basis": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A configured proxy route could not be reached."
+            "value": "Judgment is based only on recorded events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "設定されたプロキシ経路に接続できませんでした。"
+            "value": "Die Bewertung basiert nur auf aufgezeichneten Ereignissen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法访问已配置的代理路径。"
+            "value": "El juicio se basa solo en los eventos registrados"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eine konfigurierte Proxyroute war nicht erreichbar."
+            "value": "記録されたイベントのみに基づく判断です"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo alcanzar una ruta de proxy configurada."
+            "value": "仅根据已经记录的事件进行判断"
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_unavailable.cause": {
+    "analysis.readiness.rule_reason_prefix": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The proxy app may be stopped, or an old proxy setting may remain enabled."
+            "value": "Reason: "
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "プロキシアプリが停止しているか、古いプロキシ設定が有効な可能性があります。"
+            "value": "Grund: "
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理应用可能已停止，或旧代理设置仍处于启用状态。"
+            "value": "Motivo: "
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Proxy-App wurde möglicherweise beendet oder eine alte Proxy-Einstellung ist noch aktiv."
+            "value": "理由："
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que la app del proxy esté detenida o que una configuración antigua siga activa."
+            "value": "原因："
           }
         }
       }
     },
-    "network_diagnostics.remediation.proxy_unavailable.action": {
+    "analysis.readiness.rule_reason.not_single_network": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start the proxy app, or disable the stale system proxy."
+            "value": "The current analysis scope is not a single network"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "プロキシアプリを起動するか、古いシステムプロキシを無効にしてください。"
+            "value": "Der aktuelle Analysebereich ist kein einzelnes Netzwerk"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动代理应用，或禁用失效的系统代理。"
+            "value": "El ámbito de análisis actual no es una única red"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Starte die Proxy-App oder deaktiviere den veralteten Systemproxy."
+            "value": "現在の分析スコープは単一ネットワークではありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicia la app del proxy o desactiva el proxy del sistema obsoleto."
+            "value": "当前分析范围不是单一网络"
           }
         }
       }
     },
-    "network_diagnostics.remediation.dns_unavailable.detection": {
+    "analysis.readiness.rule_reason.unattributed_scope": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Name lookup is unavailable."
+            "value": "Events cannot be attributed to a specific network"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "名前解決を利用できません。"
+            "value": "Ereignisse können keinem bestimmten Netzwerk zugeordnet werden"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "域名解析不可用。"
+            "value": "Los eventos no pueden atribuirse a una red específica"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Namensauflösung ist nicht verfügbar."
+            "value": "イベントを特定のネットワークに帰属できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La resolución de nombres no está disponible."
+            "value": "事件无法归属到具体网络"
           }
         }
       }
     },
-    "network_diagnostics.remediation.dns_unavailable.cause": {
+    "analysis.readiness.rule_reason.missing_ssid_attribution": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The current network or DNS configuration may not be responding."
+            "value": "The required network name information is missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在のネットワークまたはDNS設定が応答していない可能性があります。"
+            "value": "Die erforderlichen Netzwerknamen-Informationen fehlen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "当前网络或 DNS 配置可能没有响应。"
+            "value": "Falta la información del nombre de red necesaria"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Das aktuelle Netzwerk oder die DNS-Konfiguration antwortet möglicherweise nicht."
+            "value": "必要なネットワーク名の情報がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que la red actual o la configuración DNS no respondan."
+            "value": "缺少必要的网络名称信息"
           }
         }
       }
     },
-    "network_diagnostics.remediation.dns_unavailable.action": {
+    "analysis.readiness.rule_reason.missing_event_capability": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reconnect to the network or try another DNS configuration."
+            "value": "The current data lacks the event type this rule needs"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークに再接続するか、別のDNS設定を試してください。"
+            "value": "Den aktuellen Daten fehlt der Ereignistyp, den diese Regel benötigt"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新连接网络，或尝试其他 DNS 配置。"
+            "value": "Los datos actuales no incluyen el tipo de evento que requiere esta regla"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verbinde dich erneut mit dem Netzwerk oder probiere eine andere DNS-Konfiguration."
+            "value": "現在のデータには、このルールが必要とするイベントタイプがありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuelve a conectarte a la red o prueba otra configuración DNS."
+            "value": "当前数据缺少该规则需要的事件类型"
           }
         }
       }
     },
-    "network_diagnostics.remediation.path_unavailable.detection": {
+    "analysis.readiness.rule_reason.missing_router_identity": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The Mac does not have a usable network path."
+            "value": "The gateway identity cannot be confirmed"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Macに利用可能なネットワーク経路がありません。"
+            "value": "Die Gateway-Identität kann nicht bestätigt werden"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mac 没有可用的网络路径。"
+            "value": "No se puede confirmar la identidad de la puerta de enlace"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Mac hat keinen nutzbaren Netzwerkpfad."
+            "value": "ゲートウェイの識別情報を確認できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El Mac no tiene una ruta de red utilizable."
+            "value": "无法确认网关身份"
           }
         }
       }
     },
-    "network_diagnostics.remediation.path_unavailable.cause": {
+    "analysis.readiness.rule_reason.coverage_unavailable": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wi-Fi, Ethernet, or the selected network service may be disconnected."
+            "value": "Observation coverage is unavailable"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wi-Fi、Ethernet、または選択されたネットワークサービスが切断されている可能性があります。"
+            "value": "Die Beobachtungsabdeckung ist nicht verfügbar"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wi-Fi、以太网或选中的网络服务可能已断开。"
+            "value": "La cobertura de observación no está disponible"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "WLAN, Ethernet oder der ausgewählte Netzwerkdienst ist möglicherweise getrennt."
+            "value": "観測カバレッジを利用できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Es posible que la Wi-Fi, Ethernet o el servicio de red seleccionado estén desconectados."
+            "value": "观测覆盖不可用"
           }
         }
       }
     },
-    "network_diagnostics.remediation.path_unavailable.action": {
+    "analysis.readiness.rule_reason.coverage_incomplete": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reconnect the network, then run the check again."
+            "value": "Observation coverage is incomplete"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークに再接続して、もう一度チェックしてください。"
+            "value": "Die Beobachtungsabdeckung ist unvollständig"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新连接网络，然后再次运行检查。"
+            "value": "La cobertura de observación está incompleta"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verbinde dich erneut mit dem Netzwerk und führe die Prüfung erneut aus."
+            "value": "観測カバレッジが不完全です"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuelve a conectarte a la red y ejecuta de nuevo la comprobación."
+            "value": "观测覆盖不完整"
           }
         }
       }
     },
-    "network_diagnostics.remediation.indeterminate.detection": {
+    "analysis.readiness.rule_reason.history_too_short": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This check could not be confirmed."
+            "value": "The recorded history is too short"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "このチェックを確認できませんでした。"
+            "value": "Die aufgezeichnete Historie ist zu kurz"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法确认此项检查。"
+            "value": "El historial registrado es demasiado corto"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diese Prüfung konnte nicht bestätigt werden."
+            "value": "記録された履歴が短すぎます"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo confirmar esta comprobación."
+            "value": "历史记录太短"
           }
         }
       }
     },
-    "network_diagnostics.remediation.indeterminate.cause": {
+    "analysis.readiness.rule_reason.missing_bssid_metadata": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The available evidence is inconclusive, so no single cause can be confirmed."
+            "value": "Access point information is missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "証拠が不十分なため、原因を1つに特定できません。"
+            "value": "AP-Informationen fehlen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "现有证据不足，无法确认单一原因。"
+            "value": "Falta información del AP"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die verfügbaren Hinweise sind nicht eindeutig; eine einzelne Ursache kann nicht bestätigt werden."
+            "value": "AP 情報がありません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las pruebas disponibles no son concluyentes, por lo que no se puede confirmar una única causa."
+            "value": "缺少 AP 信息"
           }
         }
       }
     },
-    "network_diagnostics.remediation.indeterminate.action": {
+    "analysis.readiness.rule_reason.all_networks_overview": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Check the network settings, then run the check again."
+            "value": "The overview scope can only provide informational conclusions"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+            "value": "Der Überblicksbereich kann nur informative Schlussfolgerungen liefern"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查网络设置，然后重新运行检查。"
+            "value": "El ámbito de resumen solo puede proporcionar conclusiones informativas"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+            "value": "概要スコープは情報提供のみの結論しか出せません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprueba la configuración de red y vuelve a ejecutar la comprobación."
+            "value": "概览范围只能提供信息性结论"
           }
         }
       }
     },
-    "network_diagnostics.remediation.generic.detection": {
+    "analysis.readiness.rule_reason.storage_unavailable": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This network check found a problem."
+            "value": "The storage layer is unavailable"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワークチェックで問題が見つかりました。"
+            "value": "Die Speicherebene ist nicht verfügbar"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络检查发现了问题。"
+            "value": "La capa de almacenamiento no está disponible"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Netzwerkprüfung hat ein Problem gefunden."
+            "value": "ストレージ層を利用できません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "La comprobación de red ha encontrado un problema."
+            "value": "存储层不可用"
           }
         }
       }
     },
-    "network_diagnostics.remediation.generic.cause": {
+    "analysis.readiness.not_observing": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The result points to a network configuration or connectivity issue."
+            "value": "Recording local observations is inactive"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク設定または接続に問題がある可能性があります。"
+            "value": "Die Aufzeichnung lokaler Beobachtungen ist inaktiv"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "结果指向网络配置或连接问题。"
+            "value": "La grabación de observaciones locales está inactiva"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Das Ergebnis weist auf ein Problem mit der Netzwerkkonfiguration oder Verbindung hin."
+            "value": "ローカル観測の記録は停止中"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "El resultado apunta a un problema de configuración o conectividad de red."
+            "value": "未在记录本地观测"
           }
         }
       }
     },
-    "network_diagnostics.remediation.generic.action": {
+    "timeline.evidence.partial.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Review the network settings and run the check again."
+            "value": "Some supporting events are missing"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+            "value": "Einige Belegereignisse fehlen"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查网络设置，然后重新运行检查。"
+            "value": "Faltan algunos eventos de respaldo"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+            "value": "一部の根拠イベントが見つかりません"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Revisa la configuración de red y vuelve a ejecutar la comprobación."
+            "value": "部分支持事件缺失"
           }
         }
       }
     },
-    "network_diagnostics.remediation.rerun": {
+    "timeline.evidence.partial.message": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Run Network Self-Check again after making the change."
+            "value": "Only %lld of %lld supporting events for this insight exist in the selected period and network."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "変更後にネットワークセルフチェックをもう一度実行してください。"
+            "value": "Nur %lld von %lld Belegereignissen für diese Erkenntnis existieren im ausgewählten Zeitraum und Netzwerk."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "完成更改后，再次运行网络自检。"
+            "value": "Solo %lld de %lld eventos de respaldo de esta conclusión existen en el período y la red seleccionados."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Führe die Netzwerk-Selbstprüfung nach der Änderung erneut aus."
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークに %2$lld 件中 %1$lld 件のみ存在します。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuelve a ejecutar la autocomprobación de red después de realizar el cambio."
+            "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
           }
         }
       }
     },
-    "settings.mac_vendor.status_bundled": {
+    "timeline.evidence.context.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bundled"
+            "value": "Surrounding events"
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "内蔵"
+            "value": "Umgebende Ereignisse"
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "内置"
+            "value": "Eventos circundantes"
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Integriert"
+            "value": "周辺のイベント"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Incluida"
+            "value": "周边事件"
           }
         }
       }
     },
-    "settings.mac_vendor.footer_bundled": {
+    "timeline.evidence.context.subtitle": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vendor names come from a bundled IEEE registry snapshot and are not updated at runtime."
+            "value": "Events before and after the selected evidence, shown for context."
           }
         },
-        "ja": {
+        "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "ベンダー名は内蔵された IEEE レジストリのスナップショットに基づき、実行時には更新されません。"
+            "value": "Ereignisse vor und nach den ausgewählten Belegen, zur Einordnung."
           }
         },
-        "zh-Hans": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "厂商名称来自内置的 IEEE 注册表快照，不会在运行时更新。"
+            "value": "Eventos anteriores y posteriores a las pruebas seleccionadas, como contexto."
           }
         },
-        "de": {
+        "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Herstellernamen stammen aus einem integrierten IEEE-Register-Snapshot und werden zur Laufzeit nicht aktualisiert."
+            "value": "選択した根拠の前後にあるイベントを、前後関係として表示します。"
           }
         },
-        "es": {
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Los nombres de los fabricantes proceden de una instantánea integrada del registro IEEE y no se actualizan durante la ejecución."
+            "value": "所选证据前后的事件，供参考上下文。"
           }
         }
       }
     }
-  },
-  "version": "1.0"
+  }
 }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -315,19 +315,33 @@ private struct AppRootView: View {
             installMainWindowOpenAction {
                 openWindow(id: WiFiLensApp.mainWindowSceneID)
             }
-            EditionComposition.startLifecycle(observationRuntime: viewModel.observationRuntime)
-            await viewModel.start()
-            roamingViewModel.handleWiFiPowerStateChange(viewModel.wifiPowerState)
+            // Under `xcodebuild test` the app process hosts the unit test
+            // bundle, so the real scanner must not start: CoreWLAN and
+            // NetworkInfoService are synchronous XPC calls that can stall the
+            // test process. Unit tests inject their own stores and fakes.
+            if !ProcessInfo.processInfo.isRunningUnderTestHost {
+                EditionComposition.startLifecycle(observationRuntime: viewModel.observationRuntime)
+                await viewModel.start()
+                roamingViewModel.handleWiFiPowerStateChange(viewModel.wifiPowerState)
+            }
             updateMCPServer()
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
+            if newPhase == .active, !ProcessInfo.processInfo.isRunningUnderTestHost {
                 Task { await viewModel.handleSceneDidBecomeActive() }
             }
         }
     }
 }
 
+private extension ProcessInfo {
+    /// True while the app process hosts a unit test bundle. `xcodebuild test`
+    /// sets this environment variable for the injected test host, so app
+    /// startup must not begin real scanning or observation in that process.
+    var isRunningUnderTestHost: Bool {
+        environment["XCTestConfigurationFilePath"] != nil
+    }
+}
 
 private struct WindowAccessor: NSViewRepresentable {
     let defaultSize: CGSize

--- a/WiFiLens/Tests/WiFiLensTests/App/MenuBarWindowBehaviorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/App/MenuBarWindowBehaviorTests.swift
@@ -105,18 +105,40 @@ struct MenuBarWindowBehaviorTests {
         #expect(!SidebarPage.timeline.requiresWiFi)
     }
 
+    @Test("Analysis routes have stable identities and order")
+    func analysisRoutesHaveStableIdentitiesAndOrder() {
+        #expect(SidebarPage.statistics.rawValue == "statistics")
+        #expect(SidebarPage.insights.rawValue == "insights")
+        #expect(SidebarPage.analysisPages == [.timeline, .statistics, .insights])
+        #expect(SidebarPage.timeline.rawValue == "timeline")
+        #expect(!SidebarPage.statistics.requiresLocationAuthorization)
+        #expect(!SidebarPage.statistics.requiresWiFi)
+        #expect(!SidebarPage.insights.requiresLocationAuthorization)
+        #expect(!SidebarPage.insights.requiresWiFi)
+    }
+
     @Test("Timeline badge reflects edition semantics")
     func timelineBadgeReflectsEdition() {
         #expect(SidebarPage.timelineBadgeStyle(for: .oss) == .pro)
         #expect(SidebarPage.timelineBadgeStyle(for: .pro) == .preview)
-        #expect(SidebarPage.timeline.badgeStyle == SidebarPage.timelineBadgeStyle(for: .current))
+        #expect(SidebarPage.timeline.badgeStyle == nil)
+    }
+
+    @Test("Analysis group badge reflects Timeline preview semantics")
+    func analysisBadgesReflectTimelinePreviewSemantics() {
+        for page in [SidebarPage.timeline, .statistics, .insights] {
+            #expect(page.badgeStyle == nil)
+        }
+        #expect(SidebarSection.analysis.badgeStyle == SidebarPage.analysisBadgeStyle(for: .current))
+        #expect(SidebarPage.analysisBadgeStyle(for: .oss) == .pro)
+        #expect(SidebarPage.analysisBadgeStyle(for: .pro) == .preview)
     }
 
     @Test("sidebar section titles use localized keys")
     func sidebarSectionTitlesUseLocalizedKeys() {
         #expect(SidebarSection.overview.localizationKey == "sidebar.section.overview")
         #expect(SidebarSection.tools.localizationKey == "sidebar.section.tools")
-        #expect(SidebarSection.insights.localizationKey == "sidebar.section.insights")
+        #expect(SidebarSection.analysis.localizationKey == "sidebar.section.analysis")
         #expect(SidebarSection.debug.localizationKey == "sidebar.section.debug")
         #expect(SidebarSection.settings.localizationKey == "sidebar.section.settings")
     }

--- a/WiFiLens/Tests/WiFiLensTests/Observation/RuntimeTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Observation/RuntimeTests.swift
@@ -129,6 +129,129 @@ struct RuntimeTests {
         #expect(store.currentStatus == status)
     }
 
+    @Test("scan generation delivers lifecycle start before work and stop exactly once")
+    func observationLifecycleOrder() async {
+        let source = ScriptedScanSource()
+        let consumer = LifecycleRecordingConsumer()
+        let dates = LockedDateSequence([10, 20, 30])
+        let runtime = WiFiObservationRuntime(
+            store: WiFiObservationStore(), scanSource: source,
+            now: { dates.next() }
+        )
+        runtime.addConsumer(consumer)
+
+        await runtime.startScanning(configuration: .init(scanInterval: .seconds(4))) { _ in }
+        #expect(consumer.events == [.started(date: Date(timeIntervalSince1970: 10), interval: .seconds(4))])
+        await runtime.stopScanning()
+        await runtime.stopScanning()
+
+        #expect(consumer.events == [
+            .started(date: Date(timeIntervalSince1970: 10), interval: .seconds(4)),
+            .stopped(date: Date(timeIntervalSince1970: 20)),
+        ])
+    }
+
+    @Test("restart closes the old generation before starting the new interval")
+    func observationLifecycleRestartOrdering() async {
+        let source = ScriptedScanSource()
+        let consumer = LifecycleRecordingConsumer()
+        let dates = LockedDateSequence([10, 20, 30, 40])
+        let runtime = WiFiObservationRuntime(
+            store: WiFiObservationStore(), scanSource: source,
+            now: { dates.next() }
+        )
+        runtime.addConsumer(consumer)
+
+        await runtime.startScanning(configuration: .init(scanInterval: .seconds(4))) { _ in }
+        await runtime.restartScanning(configuration: .init(scanInterval: .seconds(9)))
+        await runtime.stopScanning()
+
+        #expect(consumer.events == [
+            .started(date: Date(timeIntervalSince1970: 10), interval: .seconds(4)),
+            .stopped(date: Date(timeIntervalSince1970: 20)),
+            .started(date: Date(timeIntervalSince1970: 30), interval: .seconds(9)),
+            .stopped(date: Date(timeIntervalSince1970: 40)),
+        ])
+    }
+
+    @Test("publication rejection closes the active observation generation")
+    func publicationRejectionStopsObservationLifecycle() async {
+        let source = ScriptedScanSource()
+        let consumer = LifecycleRecordingConsumer()
+        let dates = LockedDateSequence([10, 20])
+        let runtime = WiFiObservationRuntime(
+            store: WiFiObservationStore(), scanSource: source,
+            interfaceSource: ImmediateInterfaceSnapshotSource(),
+            now: { dates.next() }
+        )
+        runtime.addConsumer(consumer)
+        await runtime.startScanning(configuration: .testDefault, isPublicationEligible: { false }) { _ in }
+        await source.yield(.networks([]))
+        await runtime.drainRawCyclesForTesting()
+
+        #expect(consumer.events == [
+            .started(date: Date(timeIntervalSince1970: 10), interval: .seconds(3)),
+            .stopped(date: Date(timeIntervalSince1970: 20)),
+        ])
+    }
+
+    @Test("all consumers receive one shared lifecycle timestamp")
+    func observationLifecycleTimestampIsShared() async {
+        let source = ScriptedScanSource()
+        let first = LifecycleRecordingConsumer()
+        let second = LifecycleRecordingConsumer()
+        let dates = LockedDateSequence([10, 11, 20])
+        let runtime = WiFiObservationRuntime(
+            store: WiFiObservationStore(), scanSource: source,
+            now: { dates.next() }
+        )
+        runtime.addConsumer(first)
+        runtime.addConsumer(second)
+        await runtime.startScanning(configuration: .testDefault) { _ in }
+
+        #expect(first.events.first == second.events.first)
+        #expect(first.events.first == .started(date: Date(timeIntervalSince1970: 10), interval: .seconds(3)))
+        await runtime.stopScanning()
+    }
+
+    @Test("synchronous scan emission cannot overtake lifecycle start")
+    func synchronousEmissionFollowsLifecycleStart() async {
+        let source = ScriptedScanSource()
+        await source.setSynchronousStartEvent(.networks([]))
+        let consumer = LifecycleRecordingConsumer()
+        let runtime = WiFiObservationRuntime(
+            store: WiFiObservationStore(), scanSource: source,
+            interfaceSource: ImmediateInterfaceSnapshotSource(),
+            now: { Date(timeIntervalSince1970: 10) }
+        )
+        runtime.addConsumer(consumer)
+        await runtime.startScanning(configuration: .testDefault) { _ in }
+        await runtime.drainRawCyclesForTesting()
+
+        #expect(consumer.events.prefix(2) == [
+            .started(date: Date(timeIntervalSince1970: 10), interval: .seconds(3)),
+            .observation,
+        ])
+        await runtime.stopScanning()
+    }
+
+    @Test("start superseded during capability lookup emits no lifecycle")
+    func supersededCapabilityLookupHasNoLifecycle() async {
+        let source = ScriptedScanSource()
+        await source.suspendNextCapabilityLookup()
+        let consumer = LifecycleRecordingConsumer()
+        let runtime = WiFiObservationRuntime(store: WiFiObservationStore(), scanSource: source)
+        runtime.addConsumer(consumer)
+        let start = Task { @MainActor in await runtime.startScanning(configuration: .testDefault) { _ in } }
+        await source.waitUntilCapabilityLookupEntered()
+        let stop = Task { @MainActor in await runtime.stopScanning() }
+        await source.releaseCapabilityLookup()
+        await start.value
+        await stop.value
+
+        #expect(consumer.events.isEmpty)
+    }
+
     @Test("runtime exposes scan cadence energy diagnostics")
     func scanCadenceDiagnosticsAreQueryable() async {
         let source = ScriptedScanSource()
@@ -1310,6 +1433,7 @@ private actor ScriptedScanSource: WiFiScanStreaming {
     private var hasCompletedStop = false
     private var stopCompletedContinuation: CheckedContinuation<Void, Never>?
     private var cadenceSkippedSlotCount: UInt64 = 0
+    private var synchronousStartEvent: WiFiScanEvent?
 
     func startScanning(
         interval: Duration,
@@ -1317,6 +1441,9 @@ private actor ScriptedScanSource: WiFiScanStreaming {
     ) async {
         requestedIntervals.append(interval)
         handlers[UUID()] = onEvent
+        if let synchronousStartEvent {
+            await onEvent(synchronousStartEvent)
+        }
     }
 
     func stopScanning() async {
@@ -1374,6 +1501,10 @@ private actor ScriptedScanSource: WiFiScanStreaming {
 
     func setCadenceSkippedSlotCount(_ count: UInt64) {
         cadenceSkippedSlotCount = count
+    }
+
+    func setSynchronousStartEvent(_ event: WiFiScanEvent) {
+        synchronousStartEvent = event
     }
 
     func yield(_ event: WiFiScanEvent) async {
@@ -1792,6 +1923,44 @@ private final class CapturingObservationConsumer: WiFiObservationConsuming {
 
     func consume(_ observation: WiFiObservation) async throws {
         observations.append(observation)
+    }
+}
+
+private enum RecordedObservationLifecycleEvent: Equatable {
+    case started(date: Date, interval: Duration)
+    case observation
+    case stopped(date: Date)
+}
+
+@MainActor
+private final class LifecycleRecordingConsumer: WiFiObservationConsuming {
+    private(set) var events: [RecordedObservationLifecycleEvent] = []
+
+    func consume(_ observation: WiFiObservation) async throws {
+        _ = observation
+        events.append(.observation)
+    }
+
+    func consumeLifecycle(_ event: WiFiObservationLifecycleEvent) async throws {
+        switch event {
+        case .started(let date, let expectedInterval):
+            events.append(.started(date: date, interval: expectedInterval))
+        case .stopped(let date):
+            events.append(.stopped(date: date))
+        }
+    }
+}
+
+private final class LockedDateSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Date]
+
+    init(_ seconds: [TimeInterval]) {
+        values = seconds.map(Date.init(timeIntervalSince1970:))
+    }
+
+    func next() -> Date {
+        lock.withLock { values.isEmpty ? Date(timeIntervalSince1970: -1) : values.removeFirst() }
     }
 }
 

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -291,8 +291,29 @@
 		EC20000000000000000000008 /* ProSettingsComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000007 /* ProSettingsComposition.swift */; };
 		EC2000000000000000000000A /* ProMenuBarComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000009 /* ProMenuBarComposition.swift */; };
 		EC2000000000000000000000C /* ProSpectrumCompositionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000000D /* ProSpectrumCompositionView.swift */; };
+		EC20000000000000000000010 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000000F /* StatisticsView.swift */; };
+		EC20000000000000000000012 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000011 /* InsightsView.swift */; };
+		EC20000000000000000000014 /* AnalysisDataReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000013 /* AnalysisDataReadiness.swift */; };
+		EC20000000000000000000016 /* TimelineStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000017 /* TimelineStatistics.swift */; };
+		EC20000000000000000000018 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000019 /* StatisticsViewModel.swift */; };
+		EC2000000000000000000001A /* Insight.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001B /* Insight.swift */; };
+		EC2000000000000000000001C /* InsightRuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001D /* InsightRuleEngine.swift */; };
+		EC2000000000000000000001E /* InitialInsightRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001F /* InitialInsightRules.swift */; };
+		EC20000000000000000000020 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000021 /* InsightsViewModel.swift */; };
 		EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000001 /* EditionCompositionTests.swift */; };
 		E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */; };
+		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
+		EA1000000000000000000004 /* AnalysisScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000003 /* AnalysisScope.swift */; };
+		EB2000000000000000000002 /* AnalysisSchemaV3MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2000000000000000000001 /* AnalysisSchemaV3MigrationTests.swift */; };
+		EB2000000000000000000004 /* released-v1.5.0-schema-v2.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = EB2000000000000000000003 /* released-v1.5.0-schema-v2.sqlite */; };
+		EB3000000000000000000002 /* AnalysisObservationCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3000000000000000000001 /* AnalysisObservationCoverageTests.swift */; };
+		EF1000000000000000000002 /* InsightModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1000000000000000000001 /* InsightModelTests.swift */; };
+		EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2000000000000000000001 /* InsightRuleValidationTests.swift */; };
+		ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000001 /* AnalysisSnapshotTests.swift */; };
+		ED2000000000000000000002 /* AnalysisNetworkScopeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */; };
+		ED3000000000000000000002 /* AnalysisWorkspaceScenarioValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */; };
+		EB4000000000000000000002 /* AnalysisObservationCoverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4000000000000000000001 /* AnalysisObservationCoverage.swift */; };
+		ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000003 /* AnalysisSnapshot.swift */; };
 		E20000000000000000000002 /* WiFiObservationEventJournal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000000000000000000001 /* WiFiObservationEventJournal.swift */; };
 		FB92F9212FBE208500BCEC67 /* DebugChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB92F91F2FBE208500BCEC67 /* DebugChartView.swift */; };
 		FB92F9232FBE208500BCEC67 /* DebugContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB92F9222FBE208500BCEC67 /* DebugContainerView.swift */; };
@@ -604,8 +625,29 @@
 		EC20000000000000000000007 /* ProSettingsComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSettingsComposition.swift; sourceTree = "<group>"; };
 		EC20000000000000000000009 /* ProMenuBarComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProMenuBarComposition.swift; sourceTree = "<group>"; };
 		EC2000000000000000000000D /* ProSpectrumCompositionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProSpectrumCompositionView.swift; sourceTree = "<group>"; };
+		EC2000000000000000000000F /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
+		EC20000000000000000000011 /* InsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
+		EC20000000000000000000013 /* AnalysisDataReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisDataReadiness.swift; sourceTree = "<group>"; };
+		EC20000000000000000000017 /* TimelineStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStatistics.swift; sourceTree = "<group>"; };
+		EC20000000000000000000019 /* StatisticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModel.swift; sourceTree = "<group>"; };
+		EC2000000000000000000001B /* Insight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Insight.swift; sourceTree = "<group>"; };
+		EC2000000000000000000001D /* InsightRuleEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRuleEngine.swift; sourceTree = "<group>"; };
+		EC2000000000000000000001F /* InitialInsightRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialInsightRules.swift; sourceTree = "<group>"; };
+		EC20000000000000000000021 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
 		EC20000000000000000000001 /* EditionCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionTests.swift; sourceTree = "<group>"; };
 		E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiObservationEventSQLiteStoreTests.swift; sourceTree = "<group>"; };
+		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
+		EA1000000000000000000003 /* AnalysisScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScope.swift; sourceTree = "<group>"; };
+		EB2000000000000000000001 /* AnalysisSchemaV3MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSchemaV3MigrationTests.swift; sourceTree = "<group>"; };
+		EB2000000000000000000003 /* released-v1.5.0-schema-v2.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = "released-v1.5.0-schema-v2.sqlite"; sourceTree = "<group>"; };
+		EB3000000000000000000001 /* AnalysisObservationCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisObservationCoverageTests.swift; sourceTree = "<group>"; };
+		EF1000000000000000000001 /* InsightModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightModelTests.swift; sourceTree = "<group>"; };
+		EF2000000000000000000001 /* InsightRuleValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRuleValidationTests.swift; sourceTree = "<group>"; };
+		ED1000000000000000000001 /* AnalysisSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshotTests.swift; sourceTree = "<group>"; };
+		ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisNetworkScopeIntegrationTests.swift; sourceTree = "<group>"; };
+		ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisWorkspaceScenarioValidationTests.swift; sourceTree = "<group>"; };
+		EB4000000000000000000001 /* AnalysisObservationCoverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisObservationCoverage.swift; sourceTree = "<group>"; };
+		ED1000000000000000000003 /* AnalysisSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshot.swift; sourceTree = "<group>"; };
 		E20000000000000000000001 /* WiFiObservationEventJournal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiObservationEventJournal.swift; sourceTree = "<group>"; };
 		FB92F91F2FBE208500BCEC67 /* DebugChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugChartView.swift; sourceTree = "<group>"; };
 		FB92F9222FBE208500BCEC67 /* DebugContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugContainerView.swift; sourceTree = "<group>"; };
@@ -1060,6 +1102,15 @@
 		FB8FCB1B2FF6C4E300BB2929 /* WiFiLensProTests */ = {
 			isa = PBXGroup;
 			children = (
+				EA1000000000000000000001 /* AnalysisScopeTests.swift */,
+				EB2000000000000000000001 /* AnalysisSchemaV3MigrationTests.swift */,
+				EB3000000000000000000001 /* AnalysisObservationCoverageTests.swift */,
+				ED1000000000000000000001 /* AnalysisSnapshotTests.swift */,
+				ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */,
+				ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */,
+				EF1000000000000000000001 /* InsightModelTests.swift */,
+				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
+				EB2000000000000000000005 /* Fixtures */,
 				EC20000000000000000000001 /* EditionCompositionTests.swift */,
 				E10000000000000000000001 /* EventJournalTests.swift */,
 				E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */,
@@ -1072,6 +1123,14 @@
 			name = WiFiLensProTests;
 			path = ../Pro/Tests/WiFiLensProTests;
 			sourceTree = SOURCE_ROOT;
+		};
+		EB2000000000000000000005 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				EB2000000000000000000003 /* released-v1.5.0-schema-v2.sqlite */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
 		};
 		FBA000060000000000000006 /* WiFiLensUITests */ = {
 			isa = PBXGroup;
@@ -1139,6 +1198,7 @@
 			isa = PBXGroup;
 			children = (
 				EC2000000000000000000000B /* App */,
+				EC20000000000000000000015 /* Analysis */,
 				FBD0A4762FE5C06000000023 /* Events */,
 				A71200010000000000000001 /* Presentation */,
 				FBD0A4842FE5C06000000031 /* Timeline */,
@@ -1159,8 +1219,27 @@
 				EC20000000000000000000007 /* ProSettingsComposition.swift */,
 				EC20000000000000000000009 /* ProMenuBarComposition.swift */,
 				EC2000000000000000000000D /* ProSpectrumCompositionView.swift */,
+				EC2000000000000000000000F /* StatisticsView.swift */,
+				EC20000000000000000000019 /* StatisticsViewModel.swift */,
+				EC20000000000000000000011 /* InsightsView.swift */,
+				EC20000000000000000000021 /* InsightsViewModel.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		EC20000000000000000000015 /* Analysis */ = {
+			isa = PBXGroup;
+			children = (
+				EA1000000000000000000003 /* AnalysisScope.swift */,
+				EB4000000000000000000001 /* AnalysisObservationCoverage.swift */,
+				EC20000000000000000000013 /* AnalysisDataReadiness.swift */,
+				EC20000000000000000000017 /* TimelineStatistics.swift */,
+				ED1000000000000000000003 /* AnalysisSnapshot.swift */,
+				EC2000000000000000000001B /* Insight.swift */,
+				EC2000000000000000000001D /* InsightRuleEngine.swift */,
+				EC2000000000000000000001F /* InitialInsightRules.swift */,
+			);
+			path = Analysis;
 			sourceTree = "<group>";
 		};
 		FBD0A4562FE5C06000000003 /* MenuBar */ = {
@@ -1592,6 +1671,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB2000000000000000000004 /* released-v1.5.0-schema-v2.sqlite in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1840,6 +1920,18 @@
 				EC20000000000000000000008 /* ProSettingsComposition.swift in Sources */,
 				EC2000000000000000000000A /* ProMenuBarComposition.swift in Sources */,
 				EC2000000000000000000000C /* ProSpectrumCompositionView.swift in Sources */,
+				EC20000000000000000000010 /* StatisticsView.swift in Sources */,
+				EC20000000000000000000012 /* InsightsView.swift in Sources */,
+				EA1000000000000000000004 /* AnalysisScope.swift in Sources */,
+				EB4000000000000000000002 /* AnalysisObservationCoverage.swift in Sources */,
+				EC20000000000000000000014 /* AnalysisDataReadiness.swift in Sources */,
+				EC20000000000000000000016 /* TimelineStatistics.swift in Sources */,
+				ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */,
+				EC20000000000000000000018 /* StatisticsViewModel.swift in Sources */,
+				EC2000000000000000000001A /* Insight.swift in Sources */,
+				EC2000000000000000000001C /* InsightRuleEngine.swift in Sources */,
+				EC2000000000000000000001E /* InitialInsightRules.swift in Sources */,
+				EC20000000000000000000020 /* InsightsViewModel.swift in Sources */,
 				FB1E32482FC7316C009D1BDC /* BluetoothPermissionManager.swift in Sources */,
 				FB1E32492FC7316C009D1BDC /* BLEChannel.swift in Sources */,
 				FB1E324A2FC7316C009D1BDC /* BLEAdvertisementEvent.swift in Sources */,
@@ -1979,6 +2071,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */,
+				EB2000000000000000000002 /* AnalysisSchemaV3MigrationTests.swift in Sources */,
+				EB3000000000000000000002 /* AnalysisObservationCoverageTests.swift in Sources */,
+				ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */,
+				ED2000000000000000000002 /* AnalysisNetworkScopeIntegrationTests.swift in Sources */,
+				ED3000000000000000000002 /* AnalysisWorkspaceScenarioValidationTests.swift in Sources */,
+				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
+				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,
 				E10000000000000000000002 /* EventJournalTests.swift in Sources */,
 				E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */,


### PR DESCRIPTION
## Summary

- Expose stable Statistics and Insights Analysis routes in the shared Sidebar and Edition Composition contract.
- Mark Timeline, Statistics, and Insights as Preview in Pro while OSS retains the Pro placeholder surface.
- Update shared localization for evidence-based readiness and rule-threshold wording.
- Point the main repository at the corresponding Pro Analysis Workspace commit.

## Related Pro PR

The implementation lives in [Pro PR #15](https://github.com/SHIINASAMA/wifi-lens-pro/pull/15) and must be landed before or together with this pointer update.

## Verification

- Focused Pro Analysis, Journal, SQLite, and rule tests: 51 passed.
- `WiFiLensProTests`: 205 tests in 14 suites passed.
- WiFi Lens Pro Debug build passed.
- WiFi Lens OSS Debug build passed.
- Localization completeness, knowledge-boundary, integrity, and diff checks passed.

These checks cover the current source content. No additional pre-commit rerun was performed after the user declined it.

## Issue tracking

Refs SHIINASAMA/wifi-lens-pro#8, SHIINASAMA/wifi-lens-pro#9, SHIINASAMA/wifi-lens-pro#10, SHIINASAMA/wifi-lens-pro#11, SHIINASAMA/wifi-lens-pro#12, and SHIINASAMA/wifi-lens-pro#13. Neither PR automatically closes these Preview issues.

Pro issue #7 remains a coordination gate and requires explicit user confirmation before closure. Pro issue #14 remains deferred and outside this implementation chain.
