### PR TITLE
Network self-check: record gateway evidence

### DIFF
--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
@@ -1,6 +1,16 @@
 import Foundation
 import Network
 
+protocol NetworkInterfaceInfoSourcing: Sendable {
+    func currentInterface() async -> NetworkInterfaceInfo?
+}
+
+struct SystemNetworkInterfaceInfoSource: NetworkInterfaceInfoSourcing {
+    func currentInterface() async -> NetworkInterfaceInfo? {
+        NetworkInfoService.fetch()
+    }
+}
+
 enum NetworkPathState: Equatable, Sendable {
     case satisfied
     case unsatisfied
@@ -51,18 +61,27 @@ struct SystemNetworkPathChecker: NetworkPathChecking {
 struct NetworkConnectivityCheck: DiagnosticCheck {
     let id = NetworkDiagnosticCheckID.path
     private let pathSource: any NetworkPathChecking
+    private let interfaceSource: any NetworkInterfaceInfoSourcing
+    private let gatewayLatency: any GatewayLatencyProviding
     private let timeout: Duration
 
     init(
         pathSource: any NetworkPathChecking = SystemNetworkPathChecker(),
+        interfaceSource: any NetworkInterfaceInfoSourcing = SystemNetworkInterfaceInfoSource(),
+        gatewayLatency: any GatewayLatencyProviding = GatewayLatencyProvider(),
         timeout: Duration = .seconds(3)
     ) {
         self.pathSource = pathSource
+        self.interfaceSource = interfaceSource
+        self.gatewayLatency = gatewayLatency
         self.timeout = timeout
     }
 
     func run() async -> NetworkDiagnosticResult {
         let state = await pathSource.currentState(timeout: timeout)
+        let interface = await interfaceSource.currentInterface()
+        let gateway = await gatewayLatency.measure(routerIP: interface?.router)
+        let evidence = pathEvidence(interface: interface, gateway: gateway)
         return switch state {
         case .satisfied:
             NetworkDiagnosticResult(
@@ -75,20 +94,53 @@ struct NetworkConnectivityCheck: DiagnosticCheck {
                 detail: String(
                     localized: "network_diagnostics.path.normal.summary",
                     comment: "Network self-check system path success detail"
-                )
+                ),
+                evidence: evidence
             )
         case .unsatisfied:
             NetworkDiagnosticResult(
                 id: id,
                 status: .abnormal,
-                summary: String(localized: "network_diagnostics.path.abnormal.summary", comment: "Network self-check system path failure summary")
+                summary: String(localized: "network_diagnostics.path.abnormal.summary", comment: "Network self-check system path failure summary"),
+                evidence: evidence
             )
         case .requiresConnection, nil:
             NetworkDiagnosticResult(
                 id: id,
                 status: .indeterminate,
-                summary: String(localized: "network_diagnostics.path.indeterminate.summary", comment: "Network self-check system path indeterminate summary")
+                summary: String(localized: "network_diagnostics.path.indeterminate.summary", comment: "Network self-check system path indeterminate summary"),
+                evidence: evidence
             )
         }
+    }
+
+    private func pathEvidence(
+        interface: NetworkInterfaceInfo?,
+        gateway: GatewayLatencyResult
+    ) -> [NetworkDiagnosticEvidence] {
+        var evidence: [NetworkDiagnosticEvidence] = []
+        if let interface {
+            evidence.append(.init(code: "path.interface", value: interface.interfaceName))
+            if let address = interface.ipv4Addresses.first {
+                evidence.append(.init(code: "path.local-ip", value: address))
+            }
+            if let subnet = interface.subnetMasks.first {
+                evidence.append(.init(code: "path.subnet-mask", value: subnet))
+            }
+            if let router = interface.router {
+                evidence.append(.init(code: "path.router", value: router))
+            }
+            if let dns = interface.dnsServers.first {
+                evidence.append(.init(code: "path.dns-server", value: dns))
+            }
+        }
+        if let latency = gateway.latencyMs {
+            evidence.append(.init(code: "path.gateway-latency-ms", value: String(latency)))
+        } else if let router = gateway.routerIP, gateway.error != nil {
+            evidence.append(.init(code: "path.gateway-unreachable", value: router))
+        } else if gateway.error != nil {
+            evidence.append(.init(code: "path.gateway-unavailable", value: nil))
+        }
+        return evidence
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -534,6 +534,42 @@ struct NetworkDiagnosticsTests {
         ))
     }
 
+    @Test("path check records local interface and gateway evidence separately")
+    func pathCheckRecordsGatewayEvidence() async {
+        let result = await NetworkConnectivityCheck(
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
+            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
+                timestamp: Date(),
+                routerIP: "192.0.2.1",
+                latencyMs: 2.5
+            ))
+        ).run()
+
+        #expect(result.status == .normal)
+        #expect(result.evidence.contains(.init(code: "path.interface", value: "en0")))
+        #expect(result.evidence.contains(.init(code: "path.local-ip", value: "192.0.2.10")))
+        #expect(result.evidence.contains(.init(code: "path.subnet-mask", value: "255.255.255.0")))
+        #expect(result.evidence.contains(.init(code: "path.router", value: "192.0.2.1")))
+        #expect(result.evidence.contains(.init(code: "path.gateway-latency-ms", value: "2.5")))
+    }
+
+    @Test("gateway nonresponse is advisory and does not fail the local path")
+    func gatewayFailureIsAdvisory() async {
+        let result = await NetworkConnectivityCheck(
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
+            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
+                timestamp: Date(),
+                routerIP: "192.0.2.1",
+                error: .gatewayPingFailed("192.0.2.1")
+            ))
+        ).run()
+
+        #expect(result.status == .normal)
+        #expect(result.evidence.contains(.init(code: "path.gateway-unreachable", value: "192.0.2.1")))
+    }
+
     @Test("Microsoft captive-portal probe rejects a rewritten response")
     func captivePortalProbeRejectsRewrittenResponse() async {
         let check = HTTPSControlEndpointCheck(
@@ -3195,4 +3231,39 @@ private final class SequencedFingerprintSettingsReader: NetworkFingerprintSettin
     func staticProxySettingsHash() -> UInt64 {
         proxyHash
     }
+}
+
+private struct StubNetworkInterfaceSource: NetworkInterfaceInfoSourcing {
+    let interface: NetworkInterfaceInfo?
+
+    func currentInterface() async -> NetworkInterfaceInfo? {
+        interface
+    }
+}
+
+private struct StubGatewayLatencyProvider: GatewayLatencyProviding {
+    let result: GatewayLatencyResult
+
+    func measure(routerIP: String?) async -> GatewayLatencyResult {
+        result
+    }
+}
+
+private func makeNetworkInterface(router: String?) -> NetworkInterfaceInfo {
+    NetworkInterfaceInfo(
+        interfaceName: "en0",
+        hardwareMAC: "00:11:22:33:44:55",
+        ipv4Addresses: ["192.0.2.10"],
+        subnetMasks: ["255.255.255.0"],
+        router: router,
+        dnsServers: ["192.0.2.53"],
+        ssid: "Test Network",
+        bssid: nil,
+        channel: nil,
+        band: nil,
+        rssi: nil,
+        txRate: nil,
+        phyMode: nil,
+        security: "WPA2"
+    )
 }


### PR DESCRIPTION
Closes #38

## Summary
- Add injectable network-interface and gateway providers to the self-check.
- Record interface, local IP, subnet, router, DNS, gateway latency, and gateway failure evidence.
- Keep gateway failures advisory while deriving path status from NWPath.

## Verification
- OSS Debug build: passed
- NetworkDiagnosticsTests: 105 passed
- Pro Debug build: blocked by the empty Pro submodule in this worktree; no Pro source was changed.