### PR TITLE
Network self-check: add actionable diagnostics guidance

### DIFF
--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
@@ -46,6 +46,39 @@ struct SystemNetworkPathChecker: NetworkPathChecking {
             return first
         }
     }
+
+    func diagnosticEvidence(timeout: Duration) async -> [NetworkDiagnosticEvidence] {
+        let monitor = NWPathMonitor()
+        let stream = AsyncStream<NWPath> { continuation in
+            monitor.pathUpdateHandler = { path in
+                continuation.yield(path)
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in monitor.cancel() }
+            monitor.start(queue: DispatchQueue(label: "io.github.kaoru.wifi-lens.network-diagnostics.path-evidence"))
+        }
+        defer { monitor.cancel() }
+        for await path in stream {
+            let activeInterface = path.availableInterfaces
+                .filter { path.usesInterfaceType($0.type) }
+                .sorted { $0.name < $1.name }
+                .first
+            guard let activeInterface else { return [] }
+            var evidence = [
+                NetworkDiagnosticEvidence(code: "path.interface-type", value: activeInterface.type.pathEvidenceName),
+                NetworkDiagnosticEvidence(code: "path.interface-name", value: activeInterface.name),
+            ]
+            if ["utun", "ipsec", "ppp"].contains(where: { activeInterface.name.hasPrefix($0) }) {
+                evidence.append(.init(code: "path.routed-tunnel", value: activeInterface.name))
+            }
+            return evidence
+        }
+        return []
+    }
+}
+
+extension NetworkPathChecking {
+    func diagnosticEvidence(timeout: Duration) async -> [NetworkDiagnosticEvidence] { [] }
 }
 
 struct NetworkConnectivityCheck: DiagnosticCheck {
@@ -63,6 +96,7 @@ struct NetworkConnectivityCheck: DiagnosticCheck {
 
     func run() async -> NetworkDiagnosticResult {
         let state = await pathSource.currentState(timeout: timeout)
+        let evidence = await pathSource.diagnosticEvidence(timeout: timeout)
         return switch state {
         case .satisfied:
             NetworkDiagnosticResult(
@@ -75,20 +109,36 @@ struct NetworkConnectivityCheck: DiagnosticCheck {
                 detail: String(
                     localized: "network_diagnostics.path.normal.summary",
                     comment: "Network self-check system path success detail"
-                )
+                ),
+                evidence: evidence
             )
         case .unsatisfied:
             NetworkDiagnosticResult(
                 id: id,
                 status: .abnormal,
-                summary: String(localized: "network_diagnostics.path.abnormal.summary", comment: "Network self-check system path failure summary")
+                summary: String(localized: "network_diagnostics.path.abnormal.summary", comment: "Network self-check system path failure summary"),
+                evidence: evidence
             )
         case .requiresConnection, nil:
             NetworkDiagnosticResult(
                 id: id,
                 status: .indeterminate,
-                summary: String(localized: "network_diagnostics.path.indeterminate.summary", comment: "Network self-check system path indeterminate summary")
+                summary: String(localized: "network_diagnostics.path.indeterminate.summary", comment: "Network self-check system path indeterminate summary"),
+                evidence: evidence
             )
+        }
+    }
+}
+
+private extension NWInterface.InterfaceType {
+    var pathEvidenceName: String {
+        switch self {
+        case .wifi: "wifi"
+        case .wiredEthernet: "wiredEthernet"
+        case .cellular: "cellular"
+        case .loopback: "loopback"
+        case .other: "other"
+        @unknown default: "other"
         }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
@@ -44,6 +44,122 @@ struct NetworkDiagnosticEvidence: Equatable, Sendable {
     let value: String?
 }
 
+struct NetworkDiagnosticRemediation: Equatable, Sendable {
+    let detectionKey: String
+    let causeKey: String
+    let actionKey: String
+    let rerunKey: String
+
+    static func forResult(_ result: NetworkDiagnosticResult) -> Self {
+        let codes = Set(result.evidence.map(\.code))
+        let base: (String, String, String) = if codes.contains("proxy.authentication-required") {
+            (
+                "network_diagnostics.remediation.proxy_authentication.detection",
+                "network_diagnostics.remediation.proxy_authentication.cause",
+                "network_diagnostics.remediation.proxy_authentication.action"
+            )
+        } else if codes.contains("captive-portal.suspected") || codes.contains("captive-portal.redirect") {
+            (
+                "network_diagnostics.remediation.captive_portal.detection",
+                "network_diagnostics.remediation.captive_portal.cause",
+                "network_diagnostics.remediation.captive_portal.action"
+            )
+        } else if codes.contains("https.certificate-time-error") {
+            (
+                "network_diagnostics.remediation.certificate_time.detection",
+                "network_diagnostics.remediation.certificate_time.cause",
+                "network_diagnostics.remediation.certificate_time.action"
+            )
+        } else if codes.contains("proxy.endpoint-unavailable") || codes.contains("proxy.egress-unavailable") {
+            (
+                "network_diagnostics.remediation.proxy_unavailable.detection",
+                "network_diagnostics.remediation.proxy_unavailable.cause",
+                "network_diagnostics.remediation.proxy_unavailable.action"
+            )
+        } else if result.id == .dns && result.status == .abnormal {
+            (
+                "network_diagnostics.remediation.dns_unavailable.detection",
+                "network_diagnostics.remediation.dns_unavailable.cause",
+                "network_diagnostics.remediation.dns_unavailable.action"
+            )
+        } else if result.id == .path && result.status == .abnormal {
+            (
+                "network_diagnostics.remediation.path_unavailable.detection",
+                "network_diagnostics.remediation.path_unavailable.cause",
+                "network_diagnostics.remediation.path_unavailable.action"
+            )
+        } else if result.status == .indeterminate {
+            (
+                "network_diagnostics.remediation.indeterminate.detection",
+                "network_diagnostics.remediation.indeterminate.cause",
+                "network_diagnostics.remediation.indeterminate.action"
+            )
+        } else {
+            (
+                "network_diagnostics.remediation.generic.detection",
+                "network_diagnostics.remediation.generic.cause",
+                "network_diagnostics.remediation.generic.action"
+            )
+        }
+
+        return .init(
+            detectionKey: base.0,
+            causeKey: base.1,
+            actionKey: base.2,
+            rerunKey: "network_diagnostics.remediation.rerun"
+        )
+    }
+}
+
+struct NetworkPathSummary: Equatable, Sendable {
+    let segments: [String]
+
+    var text: String { segments.joined(separator: " → ") }
+
+    static func from(results: [NetworkDiagnosticResult]) -> Self? {
+        guard let path = results.first(where: { $0.id == .path }) else { return nil }
+        let pathEvidence = Dictionary(uniqueKeysWithValues: path.evidence.compactMap { evidence in
+            evidence.value.map { (evidence.code, $0) }
+        })
+        let interfaceName = pathEvidence["path.interface-name"]
+        let interfaceType = pathEvidence["path.interface-type"]
+        let interfaceLabel: String = switch interfaceType {
+        case "wifi": "Wi-Fi"
+        case "wiredEthernet": "Ethernet"
+        default: "Network"
+        }
+        var segments = ["Mac", interfaceName.map { "\(interfaceLabel) \($0)" } ?? interfaceLabel]
+
+        if let tunnel = pathEvidence["path.routed-tunnel"] {
+            segments.append("VPN/Tunnel \(tunnel)")
+        }
+
+        if let proxy = results.first(where: { $0.id == .proxy }) {
+            let routeType = proxy.evidence.first {
+                $0.code == "proxy.https.route-type" && $0.value != "direct"
+            }?.value ?? proxy.evidence.first {
+                $0.code == "proxy.http.route-type" && $0.value != "direct"
+            }?.value
+            if let routeType {
+                segments.append("\(routeType.uppercased()) proxy")
+            }
+        }
+        segments.append("Internet")
+        return .init(segments: segments)
+    }
+}
+
+extension NetworkDiagnosticConclusion {
+    static func primaryIssue(in results: [NetworkDiagnosticResult]) -> NetworkDiagnosticResult? {
+        let priority: [NetworkDiagnosticCheckID] = [.path, .dns, .internet, .proxy, .ipv6]
+        return priority.compactMap { id in
+            results.first {
+                $0.id == id && ($0.status == .abnormal || $0.status == .indeterminate)
+            }
+        }.first
+    }
+}
+
 struct NetworkDiagnosticResult: Equatable, Identifiable, Sendable {
     let id: NetworkDiagnosticCheckID
     let status: NetworkDiagnosticStatus

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -154,6 +154,14 @@ struct NetworkDiagnosticsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                if conclusion == .needsAttention,
+                   let issue = NetworkDiagnosticConclusion.primaryIssue(in: Array(viewModel.results.values)) {
+                    let remediation = NetworkDiagnosticRemediation.forResult(issue)
+                    Text(String(localized: .init(stringLiteral: remediation.actionKey), comment: "Network self-check primary remediation action"))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -169,8 +177,28 @@ struct NetworkDiagnosticsView: View {
         if viewModel.phase == .idle {
             readyWorkspace
         } else {
-            resultTable(mode)
+            VStack(alignment: .leading, spacing: 12) {
+                if let pathSummary {
+                    pathSummaryCard(pathSummary)
+                }
+                resultTable(mode)
+            }
         }
+    }
+
+    private func pathSummaryCard(_ summary: NetworkPathSummary) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "network_diagnostics.path_summary.title", comment: "Network self-check observed path title"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(summary.text)
+                .font(.callout.monospaced())
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 14)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("network-diagnostics-path-summary")
     }
 
     private var readyWorkspace: some View {
@@ -305,9 +333,28 @@ struct NetworkDiagnosticsView: View {
                         .foregroundStyle(.secondary)
                         .lineSpacing(1)
                 }
+                if result.status == .abnormal || result.status == .indeterminate {
+                    remediationView(for: result)
+                }
             }
             .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private func remediationView(for result: NetworkDiagnosticResult) -> some View {
+        let remediation = NetworkDiagnosticRemediation.forResult(result)
+        return VStack(alignment: .leading, spacing: 2) {
+            Text(String(localized: .init(stringLiteral: remediation.detectionKey), comment: "Network self-check remediation detected condition"))
+                .font(.caption.weight(.medium))
+            Text(String(localized: .init(stringLiteral: remediation.actionKey), comment: "Network self-check remediation next action"))
+                .font(.caption)
+                .foregroundStyle(.orange)
+            Text(String(localized: .init(stringLiteral: remediation.rerunKey), comment: "Network self-check remediation rerun instruction"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, 4)
+        .accessibilityElement(children: .combine)
     }
 
     private var workbenchRows: [NetworkDiagnosticsWorkbenchRow] {
@@ -317,6 +364,10 @@ struct NetworkDiagnosticsView: View {
             results: viewModel.results,
             checkIDs: viewModel.checkIDs
         )
+    }
+
+    private var pathSummary: NetworkPathSummary? {
+        NetworkPathSummary.from(results: Array(viewModel.results.values))
     }
 
     private var activeCheckID: NetworkDiagnosticCheckID? {

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -25320,6 +25320,916 @@
           }
         }
       }
+    },
+    "network_diagnostics.path_summary.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed network path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出されたネットワーク経路"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到的网络路径"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkannter Netzwerkpfad"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta de red detectada"
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy requested sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシが認証を要求しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理要求登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Proxy verlangt eine Anmeldung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proxy solicita iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy credentials may be missing or expired."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシの認証情報が未設定または期限切れの可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理凭据可能未设置或已过期。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Proxy-Zugangsdaten fehlen möglicherweise oder sind abgelaufen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que las credenciales del proxy falten o hayan caducado."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_authentication.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the proxy credentials or sign in again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシの認証情報を確認するか、もう一度サインインしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查代理凭据，或重新登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Proxy-Zugangsdaten oder melde dich erneut an."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba las credenciales del proxy o vuelve a iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The network may require sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークでサインインが必要な可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络可能需要登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für dieses Netzwerk ist möglicherweise eine Anmeldung erforderlich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la red requiera iniciar sesión."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A captive portal may be intercepting web access."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプティブポータルがウェブアクセスを遮っている可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络门户可能正在拦截网页访问。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Captive Portal fängt möglicherweise den Webzugriff ab."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que un portal cautivo esté interceptando el acceso web."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.captive_portal.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open a browser and complete the network sign-in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザを開いてネットワークへのサインインを完了してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开浏览器并完成网络登录。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne einen Browser und schließe die Netzwerkanmeldung ab."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre un navegador y completa el inicio de sesión de la red."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The secure connection certificate time is invalid."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全な接続の証明書時刻が正しくありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全连接的证书时间无效。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zertifikatszeit der sicheren Verbindung ist ungültig."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La hora del certificado de la conexión segura no es válida."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac date or time may be incorrect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macの日付または時刻が正しくない可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 的日期或时间可能不正确。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum oder Uhrzeit des Mac sind möglicherweise falsch."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la fecha o la hora del Mac sean incorrectas."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.certificate_time.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on automatic date and time, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付と時刻の自動設定を有効にして、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启自动设置日期和时间，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviere Datum und Uhrzeit automatisch und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa la fecha y hora automáticas y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A configured proxy route could not be reached."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定されたプロキシ経路に接続できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法访问已配置的代理路径。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine konfigurierte Proxyroute war nicht erreichbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo alcanzar una ruta de proxy configurada."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The proxy app may be stopped, or an old proxy setting may remain enabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシアプリが停止しているか、古いプロキシ設定が有効な可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理应用可能已停止，或旧代理设置仍处于启用状态。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Proxy-App wurde möglicherweise beendet oder eine alte Proxy-Einstellung ist noch aktiv."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la app del proxy esté detenida o que una configuración antigua siga activa."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.proxy_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start the proxy app, or disable the stale system proxy."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロキシアプリを起動するか、古いシステムプロキシを無効にしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动代理应用，或禁用失效的系统代理。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte die Proxy-App oder deaktiviere den veralteten Systemproxy."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia la app del proxy o desactiva el proxy del sistema obsoleto."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name lookup is unavailable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前解決を利用できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域名解析不可用。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Namensauflösung ist nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La resolución de nombres no está disponible."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current network or DNS configuration may not be responding."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のネットワークまたはDNS設定が応答していない可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前网络或 DNS 配置可能没有响应。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das aktuelle Netzwerk oder die DNS-Konfiguration antwortet möglicherweise nicht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la red actual o la configuración DNS no respondan."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.dns_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect to the network or try another DNS configuration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークに再接続するか、別のDNS設定を試してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新连接网络，或尝试其他 DNS 配置。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde dich erneut mit dem Netzwerk oder probiere eine andere DNS-Konfiguration."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a conectarte a la red o prueba otra configuración DNS."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac does not have a usable network path."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macに利用可能なネットワーク経路がありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 没有可用的网络路径。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Mac hat keinen nutzbaren Netzwerkpfad."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El Mac no tiene una ruta de red utilizable."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi, Ethernet, or the selected network service may be disconnected."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi、Ethernet、または選択されたネットワークサービスが切断されている可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi、以太网或选中的网络服务可能已断开。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WLAN, Ethernet oder der ausgewählte Netzwerkdienst ist möglicherweise getrennt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la Wi-Fi, Ethernet o el servicio de red seleccionado estén desconectados."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.path_unavailable.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect the network, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークに再接続して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新连接网络，然后再次运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde dich erneut mit dem Netzwerk und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a conectarte a la red y ejecuta de nuevo la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This check could not be confirmed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このチェックを確認できませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确认此项检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Prüfung konnte nicht bestätigt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo confirmar esta comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The available evidence is inconclusive, so no single cause can be confirmed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠が不十分なため、原因を1つに特定できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "现有证据不足，无法确认单一原因。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die verfügbaren Hinweise sind nicht eindeutig; eine einzelne Ursache kann nicht bestätigt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las pruebas disponibles no son concluyentes, por lo que no se puede confirmar una única causa."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.indeterminate.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the network settings, then run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查网络设置，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba la configuración de red y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.detection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This network check found a problem."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークチェックで問題が見つかりました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络检查发现了问题。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Netzwerkprüfung hat ein Problem gefunden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La comprobación de red ha encontrado un problema."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.cause": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The result points to a network configuration or connectivity issue."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定または接続に問題がある可能性があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结果指向网络配置或连接问题。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Ergebnis weist auf ein Problem mit der Netzwerkkonfiguration oder Verbindung hin."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El resultado apunta a un problema de configuración o conectividad de red."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.generic.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the network settings and run the check again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定を確認して、もう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查网络设置，然后重新运行检查。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfe die Netzwerkeinstellungen und führe die Prüfung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisa la configuración de red y vuelve a ejecutar la comprobación."
+          }
+        }
+      }
+    },
+    "network_diagnostics.remediation.rerun": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Network Self-Check again after making the change."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更後にネットワークセルフチェックをもう一度実行してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成更改后，再次运行网络自检。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führe die Netzwerk-Selbstprüfung nach der Änderung erneut aus."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuelve a ejecutar la autocomprobación de red después de realizar el cambio."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -50,6 +50,59 @@ struct NetworkDiagnosticsTests {
         #expect(NetworkDiagnosticStatus.skipped.presentation != NetworkDiagnosticStatus.indeterminate.presentation)
     }
 
+    @Test("proxy authentication evidence maps to a credential remediation")
+    func proxyAuthenticationRemediation() {
+        let result = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .abnormal,
+            summary: "Proxy authentication required",
+            evidence: [.init(code: "proxy.authentication-required", value: "407")]
+        )
+
+        let remediation = NetworkDiagnosticRemediation.forResult(result)
+
+        #expect(remediation.actionKey == "network_diagnostics.remediation.proxy_authentication.action")
+        #expect(remediation.rerunKey == "network_diagnostics.remediation.rerun")
+    }
+
+    @Test("indeterminate remediation does not claim a confirmed cause")
+    func indeterminateRemediationIsTentative() {
+        let result = NetworkDiagnosticResult(
+            id: .dns,
+            status: .indeterminate,
+            summary: "DNS could not be determined"
+        )
+
+        let remediation = NetworkDiagnosticRemediation.forResult(result)
+
+        #expect(remediation.causeKey == "network_diagnostics.remediation.indeterminate.cause")
+        #expect(remediation.actionKey == "network_diagnostics.remediation.indeterminate.action")
+    }
+
+    @Test("path summary composes interface tunnel proxy and internet segments")
+    func pathSummaryComposition() {
+        let results = [
+            NetworkDiagnosticResult(
+                id: .path,
+                status: .normal,
+                summary: "Path available",
+                evidence: [
+                    .init(code: "path.interface-type", value: "wifi"),
+                    .init(code: "path.interface-name", value: "en0"),
+                    .init(code: "path.routed-tunnel", value: "utun6"),
+                ]
+            ),
+            NetworkDiagnosticResult(
+                id: .proxy,
+                status: .normal,
+                summary: "Proxy route available",
+                evidence: [.init(code: "proxy.https.route-type", value: "https")]
+            ),
+        ]
+
+        #expect(NetworkPathSummary.from(results: results)?.text == "Mac → Wi-Fi en0 → VPN/Tunnel utun6 → HTTPS proxy → Internet")
+    }
+
     @Test("a blocked probe does not become an independent network fault")
     func blockedProbeIsNotAbnormal() {
         let result = NetworkDiagnosticResult.blocked(id: .internet, summary: "DNS is unavailable")


### PR DESCRIPTION
Closes #36

## Summary
- Add evidence-based remediation guidance for common diagnostic failures.
- Show a compact network path summary and primary remediation action.
- Add English, Japanese, Simplified Chinese, German, and Spanish localization entries.

## Verification
- OSS and Pro Debug builds: passed
- Network diagnostics tests: 106 passed
- Localization scan: all translations complete
- Full OSS unit tests: one pre-existing IEEE fixture failure due to missing /private/tmp/wifi-lens-ieee-current/oui.csv