### PR TITLE
Network self-check: detect VPN and TUN routing changes

### DIFF
--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
@@ -9,6 +9,26 @@ struct NetworkFingerprint: Equatable, Sendable {
     let pathStatus: NetworkPathState
     let dnsSettingsHash: UInt64
     let staticProxySettingsHash: UInt64
+    let tunnelInterfaces: [String]
+    let routedTunnelInterface: String?
+
+    init(
+        interfaceType: String?,
+        interfaceName: String?,
+        pathStatus: NetworkPathState,
+        dnsSettingsHash: UInt64,
+        staticProxySettingsHash: UInt64,
+        tunnelInterfaces: [String] = [],
+        routedTunnelInterface: String? = nil
+    ) {
+        self.interfaceType = interfaceType
+        self.interfaceName = interfaceName
+        self.pathStatus = pathStatus
+        self.dnsSettingsHash = dnsSettingsHash
+        self.staticProxySettingsHash = staticProxySettingsHash
+        self.tunnelInterfaces = tunnelInterfaces
+        self.routedTunnelInterface = routedTunnelInterface
+    }
 }
 
 struct NetworkFingerprintObservation: Sendable {
@@ -35,6 +55,69 @@ struct NetworkPathFingerprint: Equatable, Sendable {
     let interfaceType: String?
     let interfaceName: String?
     let pathStatus: NetworkPathState
+    let tunnelInterfaces: [String]
+    let routedTunnelInterface: String?
+
+    init(
+        interfaceType: String?,
+        interfaceName: String?,
+        pathStatus: NetworkPathState,
+        tunnelInterfaces: [String] = [],
+        routedTunnelInterface: String? = nil
+    ) {
+        self.interfaceType = interfaceType
+        self.interfaceName = interfaceName
+        self.pathStatus = pathStatus
+        self.tunnelInterfaces = tunnelInterfaces
+        self.routedTunnelInterface = routedTunnelInterface
+    }
+}
+
+enum NetworkTunnelInterfaceClassifier {
+    static let prefixes = ["utun", "ipsec", "ppp"]
+
+    static func tunnelInterfaces(from names: [String]) -> [String] {
+        names.filter { name in
+            prefixes.contains { name.hasPrefix($0) }
+        }.sorted()
+    }
+
+    static func routedTunnelInterface(
+        activeInterfaceName: String?,
+        tunnelInterfaces: [String]
+    ) -> String? {
+        guard let activeInterfaceName,
+              tunnelInterfaces.contains(activeInterfaceName) else {
+            return nil
+        }
+        return activeInterfaceName
+    }
+}
+
+struct SystemNetworkTunnelStateReader {
+    static func state(for path: NWPath) -> (
+        tunnelInterfaces: [String],
+        routedTunnelInterface: String?
+    ) {
+        let interfaceNames = NetworkInfoService.fetchAll().map(\.interfaceName)
+        let tunnels = NetworkTunnelInterfaceClassifier.tunnelInterfaces(from: interfaceNames)
+        let activeInterface = path.availableInterfaces
+            .filter { path.usesInterfaceType($0.type) }
+            .sorted { lhs, rhs in
+                if lhs.type.fingerprintName != rhs.type.fingerprintName {
+                    return lhs.type.fingerprintName < rhs.type.fingerprintName
+                }
+                return lhs.name < rhs.name
+            }
+            .first?.name
+        return (
+            tunnels,
+            NetworkTunnelInterfaceClassifier.routedTunnelInterface(
+                activeInterfaceName: activeInterface,
+                tunnelInterfaces: tunnels
+            )
+        )
+    }
 }
 
 protocol NetworkPathFingerprintSourcing: Sendable {
@@ -89,10 +172,13 @@ struct SystemNetworkPathFingerprintSource: NetworkPathFingerprintSourcing {
                 return lhs.name < rhs.name
             }
             .first
+        let tunnelState = SystemNetworkTunnelStateReader.state(for: path)
         return NetworkPathFingerprint(
             interfaceType: activeInterface?.type.fingerprintName,
             interfaceName: activeInterface?.name,
-            pathStatus: path.status.fingerprintState
+            pathStatus: path.status.fingerprintState,
+            tunnelInterfaces: tunnelState.tunnelInterfaces,
+            routedTunnelInterface: tunnelState.routedTunnelInterface
         )
     }
 }
@@ -201,7 +287,9 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
             interfaceName: path.interfaceName,
             pathStatus: path.pathStatus,
             dnsSettingsHash: settingsReader.dnsSettingsHash(),
-            staticProxySettingsHash: settingsReader.staticProxySettingsHash()
+            staticProxySettingsHash: settingsReader.staticProxySettingsHash(),
+            tunnelInterfaces: path.tunnelInterfaces,
+            routedTunnelInterface: path.routedTunnelInterface
         )
     }
 }
@@ -245,7 +333,9 @@ private actor NetworkFingerprintEmissionState {
             interfaceName: latest.interfaceName,
             pathStatus: latest.pathStatus,
             dnsSettingsHash: dnsSettingsHash,
-            staticProxySettingsHash: staticProxySettingsHash
+            staticProxySettingsHash: staticProxySettingsHash,
+            tunnelInterfaces: latest.tunnelInterfaces,
+            routedTunnelInterface: latest.routedTunnelInterface
         )
         latest = fingerprint
         return fingerprint

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -2009,6 +2009,54 @@ struct NetworkDiagnosticsTests {
         #expect(changedDiscovery != baseline)
     }
 
+    @Test("VPN and TUN interface names are classified without VPN manager access")
+    func tunnelInterfaceClassification() {
+        let tunnels = NetworkTunnelInterfaceClassifier.tunnelInterfaces(from: [
+            "en0", "utun3", "ipsec0", "ppp0", "bridge0", "utun2"
+        ])
+
+        #expect(tunnels == ["ipsec0", "ppp0", "utun2", "utun3"])
+        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
+            activeInterfaceName: "utun3",
+            tunnelInterfaces: tunnels
+        ) == "utun3")
+        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
+            activeInterfaceName: "en0",
+            tunnelInterfaces: tunnels
+        ) == nil)
+    }
+
+    @Test("tunnel presence and routed interface changes are fingerprint changes")
+    func tunnelFingerprintChangesTriggerObservation() async throws {
+        let baselinePath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en0",
+            pathStatus: .satisfied,
+            tunnelInterfaces: [],
+            routedTunnelInterface: nil
+        )
+        let changedPath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en0",
+            pathStatus: .satisfied,
+            tunnelInterfaces: ["utun3"],
+            routedTunnelInterface: "utun3"
+        )
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath, changedPath]),
+            settingsPoller: SilentNetworkFingerprintSettingsPoller()
+        )
+
+        let observation = try #require(await monitor.observation())
+        var iterator = observation.changes.makeAsyncIterator()
+        let change = await iterator.next()
+
+        #expect(observation.baseline.tunnelInterfaces.isEmpty)
+        #expect(change?.tunnelInterfaces == ["utun3"])
+        #expect(change?.routedTunnelInterface == "utun3")
+    }
+
     private func makeResults(
         path: NetworkDiagnosticStatus,
         dns: NetworkDiagnosticStatus,


### PR DESCRIPTION
Closes #35

## Summary
- Include VPN and TUN interface state in the network fingerprint.
- Detect routing changes that do not emit a path update.
- Add regression coverage for tunnel and same-interface path changes.

## Verification
- OSS and Pro Debug builds: passed
- Network diagnostics tests: passed