### PR TITLE
Stabilize concurrency tests

### DIFF
--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
@@ -288,6 +288,18 @@ private extension ProxyEndpoint {
     }
 }
 
+protocol ProxyCheckClock: Sendable {
+    func now() -> ContinuousClock.Instant
+}
+
+struct ContinuousProxyCheckClock: ProxyCheckClock {
+    private let clock = ContinuousClock()
+
+    func now() -> ContinuousClock.Instant {
+        clock.now
+    }
+}
+
 struct SystemProxyCheck: DiagnosticCheck {
     let id = NetworkDiagnosticCheckID.proxy
     private static let defaultHTTPTarget = URL(
@@ -301,6 +313,7 @@ struct SystemProxyCheck: DiagnosticCheck {
     private let httpTarget: URL
     private let httpsTarget: URL
     private let timeout: Duration
+    private let clock: any ProxyCheckClock
 
     init(
         resolver: any ProxyResolving = SystemProxyResolver(),
@@ -308,7 +321,8 @@ struct SystemProxyCheck: DiagnosticCheck {
         egressLoader: any ProxyEgressLoading = SystemProxyEgressLoader(),
         httpTarget: URL = Self.defaultHTTPTarget,
         httpsTarget: URL = Self.defaultHTTPSTarget,
-        timeout: Duration = .seconds(3)
+        timeout: Duration = .seconds(3),
+        clock: any ProxyCheckClock = ContinuousProxyCheckClock()
     ) {
         self.resolver = resolver
         self.connector = connector
@@ -316,6 +330,7 @@ struct SystemProxyCheck: DiagnosticCheck {
         self.httpTarget = httpTarget
         self.httpsTarget = httpsTarget
         self.timeout = timeout
+        self.clock = clock
     }
 
     func run() async -> NetworkDiagnosticResult {
@@ -358,8 +373,7 @@ struct SystemProxyCheck: DiagnosticCheck {
         resolution: ProxyCandidateResolution,
         timeout: Duration
     ) async -> ProxyTargetRouteResult {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
+        let deadline = clock.now().advanced(by: timeout)
         let evidencePrefix = "proxy.\(target.scheme?.lowercased() ?? "unknown")"
         var evidence = resolution.evidenceCodes.map {
             NetworkDiagnosticEvidence(code: "\(evidencePrefix).resolution", value: $0)
@@ -397,7 +411,7 @@ struct SystemProxyCheck: DiagnosticCheck {
                     stage: "candidate"
                 )
             }
-            let attemptStart = clock.now
+            let attemptStart = clock.now()
             let remaining = attemptStart.duration(to: deadline)
             guard remaining > .zero else {
                 evidence.append(.init(code: "\(evidencePrefix).timeout", value: "expired"))
@@ -450,7 +464,7 @@ struct SystemProxyCheck: DiagnosticCheck {
             }
             evidence.append(.init(code: "\(evidencePrefix).endpoint-status", value: "available"))
 
-            let egressTimeout = clock.now.duration(to: attemptDeadline)
+            let egressTimeout = clock.now().duration(to: attemptDeadline)
             guard egressTimeout > .zero else {
                 evidence.append(.init(code: "\(evidencePrefix).authentication-status", value: "not-tested"))
                 evidence.append(.init(code: "\(evidencePrefix).egress-status", value: "timed-out"))

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -785,14 +785,27 @@ func resolvedWindowFocusIntent(hasExistingMainWindow: Bool) -> ResolvedMainWindo
 }
 
 @MainActor
+func performApplicationTermination(
+    stopRuntime: @MainActor () async -> Void,
+    terminateEdition: @MainActor () async -> Void
+) async -> Bool {
+    await stopRuntime()
+    guard !Task.isCancelled else { return false }
+    await terminateEdition()
+    return true
+}
+
+@MainActor
 final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
     typealias TerminationStep = @MainActor () async -> Void
+    typealias DeadlineWait = @MainActor (Duration) async throws -> Void
 
     static let defaultTerminationDeadline: Duration = .seconds(3)
 
     private var stopRuntime: TerminationStep = {}
     private var terminateEdition: TerminationStep = {}
     private let terminationDeadline: Duration
+    private let waitForDeadline: DeadlineWait
     private let reply: @MainActor (Bool) -> Void
     private var terminationTask: Task<Void, Never>?
     private var deadlineTask: Task<Void, Never>?
@@ -807,9 +820,13 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
 
     init(
         terminationDeadline: Duration = defaultTerminationDeadline,
+        waitForDeadline: @escaping DeadlineWait = { duration in
+            try await Task.sleep(for: duration)
+        },
         reply: @escaping @MainActor (Bool) -> Void
     ) {
         self.terminationDeadline = terminationDeadline
+        self.waitForDeadline = waitForDeadline
         self.reply = reply
         super.init()
     }
@@ -827,16 +844,19 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
         guard terminationTask == nil, !hasReplied else { return .terminateLater }
         let stopRuntime = stopRuntime
         let terminateEdition = terminateEdition
+        let waitForDeadline = waitForDeadline
         terminationTask = Task { @MainActor [weak self] in
-            await stopRuntime()
-            guard !Task.isCancelled else { return }
-            await terminateEdition()
+            let completed = await performApplicationTermination(
+                stopRuntime: stopRuntime,
+                terminateEdition: terminateEdition
+            )
+            guard completed else { return }
             self?.finishTermination(cancelOperation: false)
         }
         deadlineTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await Task.sleep(for: terminationDeadline)
+                try await waitForDeadline(terminationDeadline)
             } catch {
                 return
             }

--- a/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
@@ -279,7 +279,12 @@ struct EditionCompositionTests {
         let stopGate = TerminationTestGate()
         let replyProbe = TerminationBoolProbe()
         var steps: [String] = []
-        let coordinator = ApplicationTerminationCoordinator(reply: { replyProbe.record($0) })
+        let coordinator = ApplicationTerminationCoordinator(
+            waitForDeadline: { _ in
+                try await Task.sleep(for: .seconds(3_600))
+            },
+            reply: { replyProbe.record($0) }
+        )
         coordinator.configure(
             stopRuntime: {
                 steps.append("runtime")

--- a/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
@@ -277,7 +277,7 @@ struct EditionCompositionTests {
     @Test("repeated termination requests share one ordered operation and one AppKit reply")
     func repeatedTerminationRequestsShareOneOperation() async {
         let stopGate = TerminationTestGate()
-        let replyProbe = TerminationReplyProbe()
+        let replyProbe = TerminationBoolProbe()
         var steps: [String] = []
         let coordinator = ApplicationTerminationCoordinator(reply: { replyProbe.record($0) })
         coordinator.configure(
@@ -294,15 +294,15 @@ struct EditionCompositionTests {
         #expect(coordinator.requestTermination() == .terminateLater)
         await stopGate.waitUntilEntered()
         #expect(steps == ["runtime"])
-        #expect(replyProbe.replies.isEmpty)
+        #expect(replyProbe.values.isEmpty)
 
         await stopGate.open()
-        await replyProbe.waitForFirstReply()
+        await replyProbe.waitForFirstValue()
 
         #expect(steps == ["runtime", "edition"])
-        #expect(replyProbe.replies == [true])
+        #expect(replyProbe.values == [true])
         #expect(coordinator.requestTermination() == .terminateLater)
-        #expect(replyProbe.replies == [true])
+        #expect(replyProbe.values == [true])
     }
 
     @MainActor
@@ -310,7 +310,8 @@ struct EditionCompositionTests {
     func terminationDeadlineDoesNotAwaitNonCooperativeRuntimeStop() async {
         let stopGate = TerminationTestGate()
         let deadlineGate = TerminationTestGate()
-        let replyProbe = TerminationReplyProbe()
+        let replyProbe = TerminationBoolProbe()
+        let cancellationProbe = TerminationBoolProbe()
         var editionCalls = 0
         let coordinator = ApplicationTerminationCoordinator(
             terminationDeadline: .seconds(3),
@@ -320,6 +321,7 @@ struct EditionCompositionTests {
         coordinator.configure(
             stopRuntime: {
                 await stopGate.wait()
+                cancellationProbe.record(Task.isCancelled)
             },
             terminateEdition: {
                 editionCalls += 1
@@ -329,16 +331,20 @@ struct EditionCompositionTests {
         #expect(coordinator.requestTermination() == .terminateLater)
         await stopGate.waitUntilEntered()
         await deadlineGate.waitUntilEntered()
-        #expect(replyProbe.replies.isEmpty)
+        #expect(replyProbe.values.isEmpty)
 
         await deadlineGate.open()
-        await replyProbe.waitForFirstReply()
+        await replyProbe.waitForFirstValue()
 
-        #expect(replyProbe.replies == [true])
+        #expect(replyProbe.values == [true])
         #expect(editionCalls == 0)
 
         await stopGate.open()
-        #expect(replyProbe.replies == [true])
+        await cancellationProbe.waitForFirstValue()
+
+        #expect(cancellationProbe.values == [true])
+        #expect(editionCalls == 0)
+        #expect(replyProbe.values == [true])
     }
 
     @MainActor
@@ -428,23 +434,48 @@ private func eventually(
 }
 
 private actor TerminationTestGate {
+    private struct EntryWaiter {
+        let continuation: CheckedContinuation<Bool, Never>
+        let watchdog: Task<Void, Never>
+    }
+
     private var isOpen = false
     private var hasEntered = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
-    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var entryWaiters: [UUID: EntryWaiter] = [:]
 
     func wait() async {
         hasEntered = true
-        let pendingEntryWaiters = entryWaiters
+        let pendingEntryWaiters = entryWaiters.values
         entryWaiters.removeAll()
-        pendingEntryWaiters.forEach { $0.resume() }
+        pendingEntryWaiters.forEach {
+            $0.watchdog.cancel()
+            $0.continuation.resume(returning: true)
+        }
         if isOpen { return }
         await withCheckedContinuation { waiters.append($0) }
     }
 
-    func waitUntilEntered() async {
+    func waitUntilEntered(watchdogDuration: Duration = .seconds(5)) async {
         if hasEntered { return }
-        await withCheckedContinuation { entryWaiters.append($0) }
+        let id = UUID()
+        let entered = await withCheckedContinuation { continuation in
+            let watchdog = Task.detached { [weak self] in
+                do {
+                    try await Task.sleep(for: watchdogDuration)
+                } catch {
+                    return
+                }
+                await self?.expireEntryWaiter(id)
+            }
+            entryWaiters[id] = EntryWaiter(
+                continuation: continuation,
+                watchdog: watchdog
+            )
+        }
+        if !entered {
+            Issue.record("Termination operation did not enter the test gate before the watchdog expired")
+        }
     }
 
     func open() {
@@ -453,23 +484,58 @@ private actor TerminationTestGate {
         waiters.removeAll()
         pending.forEach { $0.resume() }
     }
+
+    private func expireEntryWaiter(_ id: UUID) {
+        guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(returning: false)
+    }
 }
 
 @MainActor
-private final class TerminationReplyProbe {
-    private(set) var replies: [Bool] = []
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func record(_ reply: Bool) {
-        replies.append(reply)
-        let pending = waiters
-        waiters.removeAll()
-        pending.forEach { $0.resume() }
+private final class TerminationBoolProbe {
+    private struct Waiter {
+        let continuation: CheckedContinuation<Bool, Never>
+        let watchdog: Task<Void, Never>
     }
 
-    func waitForFirstReply() async {
-        if !replies.isEmpty { return }
-        await withCheckedContinuation { waiters.append($0) }
+    private(set) var values: [Bool] = []
+    private var waiters: [UUID: Waiter] = [:]
+
+    func record(_ value: Bool) {
+        values.append(value)
+        let pending = waiters.values
+        waiters.removeAll()
+        pending.forEach {
+            $0.watchdog.cancel()
+            $0.continuation.resume(returning: true)
+        }
+    }
+
+    func waitForFirstValue(watchdogDuration: Duration = .seconds(5)) async {
+        if !values.isEmpty { return }
+        let id = UUID()
+        let recorded = await withCheckedContinuation { continuation in
+            let watchdog = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: watchdogDuration)
+                } catch {
+                    return
+                }
+                self?.expireWaiter(id)
+            }
+            waiters[id] = Waiter(
+                continuation: continuation,
+                watchdog: watchdog
+            )
+        }
+        if !recorded {
+            Issue.record("Expected termination event was not recorded before the watchdog expired")
+        }
+    }
+
+    private func expireWaiter(_ id: UUID) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(returning: false)
     }
 }
 

--- a/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
@@ -277,9 +277,9 @@ struct EditionCompositionTests {
     @Test("repeated termination requests share one ordered operation and one AppKit reply")
     func repeatedTerminationRequestsShareOneOperation() async {
         let stopGate = TerminationTestGate()
+        let replyProbe = TerminationReplyProbe()
         var steps: [String] = []
-        var replies: [Bool] = []
-        let coordinator = ApplicationTerminationCoordinator(reply: { replies.append($0) })
+        let coordinator = ApplicationTerminationCoordinator(reply: { replyProbe.record($0) })
         coordinator.configure(
             stopRuntime: {
                 steps.append("runtime")
@@ -292,32 +292,30 @@ struct EditionCompositionTests {
 
         #expect(coordinator.requestTermination() == .terminateLater)
         #expect(coordinator.requestTermination() == .terminateLater)
-        await Task.yield()
+        await stopGate.waitUntilEntered()
         #expect(steps == ["runtime"])
-        #expect(replies.isEmpty)
+        #expect(replyProbe.replies.isEmpty)
 
         await stopGate.open()
-        for _ in 0..<1_000 {
-            if replies == [true] { break }
-            await Task.yield()
-        }
+        await replyProbe.waitForFirstReply()
 
         #expect(steps == ["runtime", "edition"])
-        #expect(replies == [true])
+        #expect(replyProbe.replies == [true])
         #expect(coordinator.requestTermination() == .terminateLater)
-        await Task.yield()
-        #expect(replies == [true])
+        #expect(replyProbe.replies == [true])
     }
 
     @MainActor
     @Test("termination deadline replies once when runtime stop ignores cancellation")
     func terminationDeadlineDoesNotAwaitNonCooperativeRuntimeStop() async {
         let stopGate = TerminationTestGate()
+        let deadlineGate = TerminationTestGate()
+        let replyProbe = TerminationReplyProbe()
         var editionCalls = 0
-        var replies: [Bool] = []
         let coordinator = ApplicationTerminationCoordinator(
-            terminationDeadline: .milliseconds(20),
-            reply: { replies.append($0) }
+            terminationDeadline: .seconds(3),
+            waitForDeadline: { _ in await deadlineGate.wait() },
+            reply: { replyProbe.record($0) }
         )
         coordinator.configure(
             stopRuntime: {
@@ -329,17 +327,37 @@ struct EditionCompositionTests {
         )
 
         #expect(coordinator.requestTermination() == .terminateLater)
-        for _ in 0..<200 {
-            if !replies.isEmpty { break }
-            try? await Task.sleep(for: .milliseconds(1))
-        }
+        await stopGate.waitUntilEntered()
+        await deadlineGate.waitUntilEntered()
+        #expect(replyProbe.replies.isEmpty)
 
-        #expect(replies == [true])
+        await deadlineGate.open()
+        await replyProbe.waitForFirstReply()
+
+        #expect(replyProbe.replies == [true])
         #expect(editionCalls == 0)
 
         await stopGate.open()
-        for _ in 0..<20 { await Task.yield() }
-        #expect(replies == [true])
+        #expect(replyProbe.replies == [true])
+    }
+
+    @MainActor
+    @Test("a cancelled termination operation skips edition cleanup")
+    func cancelledTerminationOperationSkipsEditionCleanup() async {
+        let stopGate = TerminationTestGate()
+        var editionCalls = 0
+        let operation = Task { @MainActor in
+            await performApplicationTermination(
+                stopRuntime: { await stopGate.wait() },
+                terminateEdition: { editionCalls += 1 }
+            )
+        }
+
+        await stopGate.waitUntilEntered()
+        operation.cancel()
+        await stopGate.open()
+
+        #expect(await operation.value == false)
         #expect(editionCalls == 0)
     }
 
@@ -411,11 +429,22 @@ private func eventually(
 
 private actor TerminationTestGate {
     private var isOpen = false
+    private var hasEntered = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
+        hasEntered = true
+        let pendingEntryWaiters = entryWaiters
+        entryWaiters.removeAll()
+        pendingEntryWaiters.forEach { $0.resume() }
         if isOpen { return }
         await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        if hasEntered { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
     }
 
     func open() {
@@ -423,6 +452,24 @@ private actor TerminationTestGate {
         let pending = waiters
         waiters.removeAll()
         pending.forEach { $0.resume() }
+    }
+}
+
+@MainActor
+private final class TerminationReplyProbe {
+    private(set) var replies: [Bool] = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func record(_ reply: Bool) {
+        replies.append(reply)
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func waitForFirstReply() async {
+        if !replies.isEmpty { return }
+        await withCheckedContinuation { waiters.append($0) }
     }
 }
 

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -1294,10 +1294,9 @@ struct NetworkDiagnosticsTests {
         #expect(result.evidence.contains(.init(code: "proxy.http.fallback-used", value: "true")))
     }
 
-    @Test("candidate attempts share one overall timeout")
+    @Test("candidate attempts share one controlled overall timeout")
     func proxyCandidateAttemptsShareTimeout() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
         let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
         let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
         let connector = SequencedProxyConnector(outcomes: [true, true])
@@ -1308,27 +1307,73 @@ struct NetworkDiagnosticsTests {
             ],
             delays: [.zero, .zero]
         )
+        let clock = SequencedProxyCheckClock(offsets: [
+            .zero,
+            .zero,
+            .milliseconds(250),
+            .milliseconds(1_200),
+            .milliseconds(1_300),
+        ])
         let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [
-                httpURL: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
-                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
-            ]),
+            resolver: RecordingProxyResolver(resolutions: [:]),
             connector: connector,
             egressLoader: egressLoader,
+            timeout: .seconds(2),
+            clock: clock
+        )
+
+        let result = await check.evaluate(
+            target: target,
+            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
             timeout: .seconds(2)
         )
 
-        let result = await check.run()
-        let connectorTimeouts = await connector.timeouts
-        let egressTimeouts = await egressLoader.timeouts
+        #expect(result.status == .proxied)
+        #expect(result.selectedCandidateIndex == 1)
+        #expect(result.selectedProxy == secondProxy)
+        #expect(await connector.endpoints == [
+            .init(host: "first.example", port: 8080),
+            .init(host: "second.example", port: 8081),
+        ])
+        #expect(await connector.timeouts == [.seconds(1), .milliseconds(800)])
+        #expect(await egressLoader.timeouts == [.milliseconds(750), .milliseconds(700)])
+    }
 
-        #expect(result.status == .indeterminate)
-        #expect(connectorTimeouts.count == 2)
-        #expect(egressTimeouts.count == 2)
-        #expect(connectorTimeouts.first.map { $0 > .zero && $0 <= .milliseconds(1_050) } == true)
-        #expect(egressTimeouts.first.map { $0 > .zero && $0 <= .milliseconds(1_050) } == true)
-        #expect(connectorTimeouts.last.map { $0 > .zero && $0 < .seconds(2) } == true)
-        #expect(egressTimeouts.last.map { $0 > .zero && $0 < .seconds(2) } == true)
+    @Test("an expired overall proxy timeout does not start another candidate")
+    func expiredProxyTimeoutStopsCandidateFallback() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
+        let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
+        let connector = SequencedProxyConnector(outcomes: [true, true])
+        let egressLoader = SequencedProxyEgressLoader(
+            responses: [.init(statusCode: nil, errorCode: "timed-out")],
+            delays: [.zero]
+        )
+        let clock = SequencedProxyCheckClock(offsets: [
+            .zero,
+            .zero,
+            .milliseconds(250),
+            .milliseconds(2_100),
+        ])
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [:]),
+            connector: connector,
+            egressLoader: egressLoader,
+            timeout: .seconds(2),
+            clock: clock
+        )
+
+        let result = await check.evaluate(
+            target: target,
+            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
+            timeout: .seconds(2)
+        )
+
+        #expect(result.status == .unavailable)
+        #expect(await connector.endpoints == [.init(host: "first.example", port: 8080)])
+        #expect(await connector.timeouts == [.seconds(1)])
+        #expect(await egressLoader.timeouts == [.milliseconds(750)])
+        #expect(result.evidence.contains(.init(code: "proxy.http.timeout", value: "expired")))
     }
 
     @Test("proxy check resolves the HTTP and HTTPS targets independently")
@@ -1351,8 +1396,10 @@ struct NetworkDiagnosticsTests {
         )
 
         let result = await check.run()
+        let resolvedURLs = await recorder.urls
 
-        #expect(await recorder.urls == [httpURL.absoluteString, httpsURL.absoluteString])
+        #expect(resolvedURLs.count == 2)
+        #expect(Set(resolvedURLs) == Set([httpURL.absoluteString, httpsURL.absoluteString]))
         #expect(result.status == .indeterminate)
         #expect(result.summary == String(
             localized: "network_diagnostics.proxy.mixed_routing.summary",
@@ -3106,6 +3153,25 @@ private actor SequencedProxyEgressLoader: ProxyEgressLoading {
             return ProxyEgressResponse(statusCode: nil, errorCode: "fixture-exhausted")
         }
         return responses[index]
+    }
+}
+
+private final class SequencedProxyCheckClock: ProxyCheckClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private let instants: [ContinuousClock.Instant]
+    private var index = 0
+
+    init(offsets: [Duration]) {
+        let origin = ContinuousClock().now
+        instants = offsets.map { origin.advanced(by: $0) }
+    }
+
+    func now() -> ContinuousClock.Instant {
+        lock.lock()
+        defer { lock.unlock() }
+        precondition(index < instants.count, "Proxy test clock exhausted")
+        defer { index += 1 }
+        return instants[index]
     }
 }
 


### PR DESCRIPTION
## Summary

- Inject a controllable clock into the proxy candidate budget tests so they verify exact timeout allocation without depending on wall-clock scheduling.
- Replace application termination polling and short real deadlines with event-driven gates and an injectable deadline waiter.
- Make the concurrent HTTP/HTTPS resolution assertion independent of unspecified `async let` start order.

## Root cause

The flaky tests treated scheduler timing, bounded `Task.yield()` polling, and concurrent task start order as deterministic behavior. Under CI load, those implementation details varied even though the product behavior remained correct.

## Impact

The tests now validate the actual contracts: shared proxy timeout budgets, termination ordering and cancellation, one AppKit reply, and independent target resolution. Production defaults continue to use `ContinuousClock` and `Task.sleep`.

## Validation

- `.agents/skills/verify-build/scripts/verify.sh`
  - OSS Debug build
  - Pro Debug build
  - 825 OSS unit tests in 91 suites
- 10 independent sequential runs of the affected NetworkDiagnostics and EditionComposition suites
- `git diff --check`

UI test bundles were not run.