### PR TITLE
fix: adapt detail pages to the minimum window width

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
@@ -109,19 +109,27 @@ struct OverviewView: View {
                     Text(wifi.displaySSID)
                         .font(.title3)
                         .fontWeight(.semibold)
+                        // Long SSIDs are a single unbreakable token; without a line
+                        // limit they widen the card past the detail column at the
+                        // minimum window size. Truncate instead of overflowing.
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help(wifi.displaySSID)
                     HStack(spacing: 6) {
                         Circle().fill(Color.green).frame(width: 6, height: 6).accessibilityHidden(true)
                         Text(String(localized: "common.label.connected", comment: "Connected state indicator"))
                             .font(.caption)
                             .foregroundColor(.secondary)
+                            .lineLimit(1)
                         if let ch = wifi.channel {
                             Text("·  \(bandName(ch))  ·  Ch \(ch)")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
+                                .lineLimit(1)
                         }
                     }
                 }
-                Spacer()
+                Spacer(minLength: 12)
 
                 VStack(alignment: .trailing, spacing: 4) {
                     Text("\(wifi.rssi ?? -100) dBm")
@@ -130,6 +138,9 @@ struct OverviewView: View {
                         .accessibilityLabel(String(format: String(localized: "roaming.accessibility.rssi_fmt", comment: "RSSI accessibility label with value and quality"), wifi.rssi ?? -100, signalLabel(wifi.rssi ?? -100)))
                     signalBars(wifi.rssi ?? -100)
                 }
+                // Keep the RSSI cluster intact at its intrinsic width when the SSID
+                // compresses; all squeezing happens on the truncatable left side.
+                .fixedSize(horizontal: true, vertical: false)
             }
 
             GeometryReader { geo in

--- a/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
+++ b/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
@@ -75,10 +75,12 @@ struct ChannelQualityView: View {
                 tableView
             }
         }
-        // Same guardrail as Spectrum.ContentView: these ideal dimensions are page
-        // layout hints, not a signal to resize the app window. Do not pair them with
-        // scene-level `.windowResizability(.contentSize)`.
-        .frame(minWidth: 700, idealWidth: 1000, minHeight: 600, idealHeight: 700)
+        // Ideal dimensions are page layout hints, not a signal to resize the app window.
+        // Do not pair them with scene-level `.windowResizability(.contentSize)`. The
+        // minimums were removed because `minWidth: 700` forces the whole page to lay out
+        // 700pt wide — wider than the ~600pt detail column at the minimum window size,
+        // which clips the page's right edge.
+        .frame(idealWidth: 1000, idealHeight: 700)
     }
 
     // MARK: - Recommendation Status

--- a/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
+++ b/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
@@ -99,6 +99,12 @@ struct InterfacesView: View {
                     Text(wifi.displaySSID)
                         .font(.title3)
                         .fontWeight(.semibold)
+                        // Same guardrail as OverviewView.connectionCard: a long SSID
+                        // is one unbreakable token that would widen the hero past the
+                        // detail column at the minimum window size.
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help(wifi.displaySSID)
                     HStack(spacing: 6) {
                         Circle().fill(.green).frame(width: 6, height: 6).accessibilityHidden(true)
                         Text(String(localized: "common.label.connected", comment: "Connected state indicator"))

--- a/WiFiLens/Sources/WiFiLens/Roaming/RoamingTestView.swift
+++ b/WiFiLens/Sources/WiFiLens/Roaming/RoamingTestView.swift
@@ -153,12 +153,20 @@ struct RoamingTestView: View {
                         .accessibilityHidden(true)
                     Text(viewModel.currentSSID ?? "—")
                         .font(.title3.weight(.semibold))
+                        // Same guardrail as OverviewView.connectionCard: without a line
+                        // limit, an unbreakable long SSID would push the metrics off
+                        // the card at narrow widths.
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help(viewModel.currentSSID ?? "")
                 }
                 HStack(spacing: 8) {
                     if let bssid = viewModel.currentBSSID {
                         Text(bssid)
                             .font(.caption.monospaced())
                             .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                     }
                     if let phy = viewModel.currentPhyMode {
                         Text("·")

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -109,7 +109,11 @@ struct ContentView: View {
         VStack(spacing: 0) {
             contentArea
         }
-        .frame(minWidth: 700, idealWidth: 1000, minHeight: 600)
+        // Same guardrail as Channels.ChannelQualityView: `minWidth: 700` forces the
+        // whole dashboard to lay out 700pt wide — wider than the ~600pt detail column
+        // at the minimum window size, clipping the right edge. Keep only the ideals as
+        // page layout hints.
+        .frame(idealWidth: 1000, idealHeight: 700)
         .onChange(of: viewModel.hiddenBands) { _, _ in viewModel.applyGlobalFilterToBands() }
         .onChange(of: viewModel.hideHiddenSSIDs) { _, _ in viewModel.applyGlobalFilterToBands() }
     }

--- a/WiFiLens/Tests/WiFiLensTests/DetailPageHorizontalOverflowTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/DetailPageHorizontalOverflowTests.swift
@@ -1,0 +1,352 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import WiFi_Lens
+
+/// At the main window's minimum size (820x620) the NavigationSplitView detail column is
+/// about 600pt wide (820 - ~180 sidebar - divider). Detail pages must stay fully usable at
+/// that width: page-level `minWidth` hints force a page to lay out wider than the column
+/// (clipping its right edge), and an SSID `Text` without a `lineLimit` wraps a pathological
+/// (out-of-spec, unbreakable) SSID across multiple lines, pushing the connection card past
+/// the visible area. See `.agents/references/project/WINDOWING.md` for the sizing policy
+/// that makes 600pt the floor the pages have to fit into.
+///
+/// Measurement notes (verified against the macOS 27 SDK): a page whose minimum width
+/// exceeds the proposal reports that minimum through `NSHostingController.sizeThatFits`
+/// (Channels and Spectrum measured 700pt before the `minWidth` hints were removed). When
+/// content cannot fit, SwiftUI prefers to wrap text rather than widen the layout, so the
+/// height the content needs at the fixed width proposal is the signal for wrapped text
+/// (wrapped text is taller). `sizeThatFits` cannot see inside a ScrollView (its document
+/// height is unbounded), so scroll-based pages are measured through their
+/// `NSScrollView.documentView` frame.
+@MainActor
+struct DetailPageHorizontalOverflowTests {
+    /// Conservative minimum detail-column width: 820 window - 180 sidebar - divider.
+    private static let detailWidth: CGFloat = 600
+
+    /// Glass materials and shadows can paint a hair outside a view's frame.
+    private static let tolerance: CGFloat = 2
+
+    /// One line of `.title3` text; two lines exceed it.
+    private static let singleLineHeight: CGFloat = 30
+
+    /// Out-of-spec SSID length (real SSIDs are at most 32 bytes), one unbreakable token —
+    /// the worst case the card must degrade gracefully for.
+    private static let pathologicalSSID = String(repeating: "W", count: 100)
+
+    // MARK: - Harness
+
+    private func host(_ view: some View, width: CGFloat = Self.detailWidth) -> (NSHostingController<some View>, NSWindow) {
+        let controller = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: controller)
+        window.styleMask = [.titled, .resizable]
+        window.setContentSize(NSSize(width: width, height: 800))
+        window.layoutIfNeeded()
+        return (controller, window)
+    }
+
+    /// The width the content requires when the column proposes `width`. A page with a
+    /// `minWidth` hint above the proposal reports that minimum — the clipping regression.
+    private func requiredWidth(of view: some View, width: CGFloat = Self.detailWidth) -> CGFloat {
+        let (controller, _) = host(view, width: width)
+        return controller.sizeThatFits(
+            in: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        ).width
+    }
+
+    /// The height the content requires when the column proposes `width`. Wrapped text
+    /// grows this; truncated text does not.
+    private func requiredHeight(of view: some View, width: CGFloat = Self.detailWidth) -> CGFloat {
+        let (controller, _) = host(view, width: width)
+        return controller.sizeThatFits(
+            in: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        ).height
+    }
+
+    /// The laid-out size of a scroll-based view's document at `width` — what the user can
+    /// scroll through. Wrapped text grows the height; clipped content grows the width.
+    private func scrollDocumentSize(of view: some View, width: CGFloat = Self.detailWidth) -> CGSize? {
+        let (controller, _) = host(view, width: width)
+        var found: NSScrollView?
+        func walk(_ subject: NSView) {
+            if found == nil, let scroll = subject as? NSScrollView {
+                found = scroll
+                return
+            }
+            subject.subviews.forEach(walk)
+        }
+        walk(controller.view)
+        guard let doc = found?.documentView else { return nil }
+        return doc.frame.size
+    }
+
+    /// A page must not require more width than the column offers. This is the assertion
+    /// that catches page-level `minWidth` hints (Channels and Spectrum previously laid
+    /// out 700pt wide inside a 600pt column).
+    private func assertFitsWidth(_ view: some View) {
+        let required = requiredWidth(of: view)
+        #expect(
+            required <= Self.detailWidth + Self.tolerance,
+            "Page requires \(required)pt at a \(Self.detailWidth)pt proposal — right edge would be clipped"
+        )
+    }
+
+    /// A scroll-based page must not clip horizontally: its document must not be wider
+    /// than the scroll view's clip view.
+    private func assertNoScrollClipping(_ view: some View) {
+        let (controller, _) = host(view)
+        var problems: [String] = []
+        func walk(_ subject: NSView) {
+            if let scroll = subject as? NSScrollView,
+               !scroll.hasHorizontalScroller,
+               let doc = scroll.documentView {
+                let clip = scroll.contentView.bounds.width
+                if doc.frame.width > clip + Self.tolerance {
+                    problems.append("doc \(doc.frame.width) > clip \(clip)")
+                }
+            }
+            subject.subviews.forEach(walk)
+        }
+        walk(controller.view)
+        #expect(problems.isEmpty, "Scroll content clips horizontally: \(problems)")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeScannerViewModel(ssid: String) -> ScannerViewModel {
+        let viewModel = ScannerViewModel(store: .shared)
+        // Explicit state so the test does not depend on real hardware state. On macOS
+        // the location authorization state that grants SSID access is `.authorized`.
+        viewModel.locationManager.authorizationStatus = .authorized
+        viewModel.wifiPowerState = .poweredOn
+        viewModel.networkInfo = [
+            NetworkInterfaceInfo(
+                interfaceName: "en0",
+                hardwareMAC: "AA:BB:CC:DD:EE:FF",
+                ipv4Addresses: ["192.168.1.10"],
+                subnetMasks: ["255.255.255.0"],
+                router: "192.168.1.1",
+                dnsServers: ["8.8.8.8"],
+                ssid: ssid,
+                bssid: "AA:BB:CC:DD:EE:FF",
+                channel: 149,
+                band: .band5GHz,
+                rssi: -62,
+                txRate: 866,
+                phyMode: "802.11ax",
+                security: "WPA3"
+            )
+        ]
+        viewModel.channelRecommendations = channelFixtures
+        return viewModel
+    }
+
+    /// A current channel plus a recommended channel, so the connection card, health row,
+    /// and channel advice/status cards all render.
+    private var channelFixtures: [ChannelRecommendation] {
+        var current = ChannelRecommendation(from: ChannelQuality(
+            channel: 149, band: "5", bandDisplay: "5 GHz", qualityScore: 82,
+            qualityLevel: .excellent, apCount: 3, coChannelCount: 2, adjacentCount: 1,
+            interferenceScore: 40, overlapLevel: .low, strongestNeighborRSSI: -70,
+            isRecommended: false, isCurrentChannel: true, showInSimpleView: true,
+            recommendationScore: 82, recommendationLevel: .excellent,
+            recommendationConfidence: .exact, recommendationState: .currentGoodEnough
+        ))
+        current.scoreSelected = true
+        current.recommendationReasons = [.lowInterference]
+
+        var recommended = ChannelRecommendation(from: ChannelQuality(
+            channel: 36, band: "5", bandDisplay: "5 GHz", qualityScore: 90,
+            qualityLevel: .excellent, apCount: 1, coChannelCount: 0, adjacentCount: 0,
+            interferenceScore: 10, overlapLevel: .low, strongestNeighborRSSI: -80,
+            isRecommended: true, isCurrentChannel: false, showInSimpleView: true,
+            recommendationScore: 92, recommendationLevel: .excellent,
+            recommendationConfidence: .exact, recommendationState: .recommended
+        ))
+        recommended.scoreSelected = true
+        recommended.recommendationReasons = [.clearSpectrum]
+        return [current, recommended]
+    }
+
+    private func makeRoamingViewModel() -> RoamingTestViewModel {
+        let viewModel = RoamingTestViewModel()
+        viewModel.state = .running
+        viewModel.currentSSID = "Office-Guest-Network-5GHz-Extended-2"
+        viewModel.currentBSSID = "AA:BB:CC:DD:EE:FF"
+        viewModel.currentRSSI = -62
+        viewModel.currentChannel = 149
+        viewModel.currentTxRate = 866
+        viewModel.gatewayLatency = 12.3
+        let start = Date(timeIntervalSinceNow: -60)
+        viewModel.segments = [
+            RoamingSegment(bssid: "AA:BB:CC:DD:EE:FF", startTime: start, endTime: nil, samples: [
+                RoamingSample(timestamp: start, rssi: -60, channel: 149, txRate: 866, gatewayLatency: 10),
+                RoamingSample(timestamp: start.addingTimeInterval(10), rssi: -62, channel: 149, txRate: 700, gatewayLatency: 12),
+            ]),
+            RoamingSegment(bssid: "00:11:22:33:44:55", startTime: start.addingTimeInterval(20), endTime: nil, samples: [
+                RoamingSample(timestamp: start.addingTimeInterval(20), rssi: -65, channel: 36, txRate: 600, gatewayLatency: 15),
+                RoamingSample(timestamp: start.addingTimeInterval(30), rssi: -64, channel: 36, txRate: 640, gatewayLatency: 14),
+            ]),
+        ]
+        viewModel.transitions = [
+            APTransitionEvent(
+                timestamp: start.addingTimeInterval(20),
+                fromBSSID: "AA:BB:CC:DD:EE:FF",
+                toBSSID: "00:11:22:33:44:55",
+                rssiBefore: -62, rssiAfter: -65,
+                channelBefore: 149, channelAfter: 36
+            )
+        ]
+        return viewModel
+    }
+
+    // MARK: - Regression: every page fits the minimum detail width
+
+    @Test("Overview fits the minimum detail width")
+    func overviewFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        assertFitsWidth(OverviewView(viewModel: viewModel))
+        assertNoScrollClipping(OverviewView(viewModel: viewModel))
+    }
+
+    @Test("Channels simple mode fits the minimum detail width")
+    func channelsSimpleFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        let view = ChannelQualityView(channels: viewModel.channelRecommendations, mode: .simple)
+        assertFitsWidth(view)
+        assertNoScrollClipping(view)
+    }
+
+    @Test("Channels table mode fits the minimum detail width")
+    func channelsTableFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        let view = ChannelQualityView(channels: viewModel.channelRecommendations, mode: .table)
+        assertFitsWidth(view)
+        assertNoScrollClipping(view)
+    }
+
+    @Test("Interfaces simple mode fits the minimum detail width")
+    func interfacesSimpleFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        let view = InterfacesView(
+            interfaces: viewModel.networkInfo,
+            scannerViewModel: viewModel,
+            throughputMonitor: viewModel.throughputMonitor,
+            mode: .simple
+        )
+        assertFitsWidth(view)
+        assertNoScrollClipping(view)
+    }
+
+    @Test("Interfaces details mode fits the minimum detail width")
+    func interfacesDetailsFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        let view = InterfacesView(
+            interfaces: viewModel.networkInfo,
+            scannerViewModel: viewModel,
+            throughputMonitor: viewModel.throughputMonitor,
+            mode: .details
+        )
+        assertFitsWidth(view)
+        assertNoScrollClipping(view)
+    }
+
+    @Test("Spectrum dashboard fits the minimum detail width")
+    func spectrumFitsMinimumDetailWidth() {
+        let viewModel = makeScannerViewModel(ssid: "Office")
+        assertFitsWidth(ContentView(viewModel: viewModel, isVendorColumnAvailable: true))
+    }
+
+    @Test("Network self-check fits the minimum detail width")
+    func networkDiagnosticsFitsMinimumDetailWidth() {
+        assertFitsWidth(NetworkDiagnosticsView(viewModel: NetworkDiagnosticsViewModel()))
+    }
+
+    @Test("Roaming active state fits the minimum detail width")
+    func roamingActiveFitsMinimumDetailWidth() {
+        let view = RoamingTestView(viewModel: makeRoamingViewModel())
+        assertFitsWidth(view)
+        assertNoScrollClipping(view)
+    }
+
+    // MARK: - Regression: pathological SSID truncates instead of wrapping
+
+    @Test("Overview connection card truncates a pathological SSID at the minimum detail width")
+    func overviewConnectionCardTruncatesPathologicalSSID() {
+        // Relative measurement: both hosts share every layout cost (globe, cards, locale,
+        // fonts); only the SSID differs. If the card wraps instead of truncating, the
+        // pathological host grows by a full text line.
+        let shortSize = scrollDocumentSize(
+            of: OverviewView(viewModel: makeScannerViewModel(ssid: "Office")),
+            width: Self.detailWidth
+        )
+        let pathologicalSize = scrollDocumentSize(
+            of: OverviewView(viewModel: makeScannerViewModel(ssid: Self.pathologicalSSID)),
+            width: Self.detailWidth
+        )
+
+        let delta = (pathologicalSize?.height ?? 0) - (shortSize?.height ?? 0)
+        #expect(
+            delta <= Self.singleLineHeight,
+            "Pathological SSID must truncate to one line, not wrap: document grew by \(delta)pt"
+        )
+    }
+
+    // MARK: - Detector controls
+    //
+    // These validate the measurement itself. If either fails, the height probe is not a
+    // reliable overflow detector on this macOS version and the regressions above must not
+    // be trusted until the harness is reworked.
+
+    @Test("Control: the detector reports a layout known to overflow")
+    func controlDetectorCatchesKnownOverflow() {
+        // Same shape as the connection card before the fix: an unbounded SSID text that
+        // cannot compress must wrap, pushing the layout past one line of text.
+        let overflowing = HStack(spacing: 12) {
+            Text(Self.pathologicalSSID)
+                .font(.title3)
+                .fontWeight(.semibold)
+            Spacer()
+            Text("-62 dBm")
+        }
+        let height = requiredHeight(of: overflowing)
+        #expect(
+            height > Self.singleLineHeight,
+            "Detector must flag an unconstrained long-text layout (height \(height))"
+        )
+    }
+
+    @Test("Control: the detector accepts the same layout once the text is truncatable")
+    func controlDetectorAcceptsTruncatableLayout() {
+        // The fixed shape: a line-limited text truncates and the trailing cluster stays
+        // intact at its intrinsic width, so the layout fits within one text line.
+        let fixed = HStack(spacing: 12) {
+            Text(Self.pathologicalSSID)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 12)
+            Text("-62 dBm")
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        let height = requiredHeight(of: fixed)
+        #expect(
+            height <= Self.singleLineHeight,
+            "Detector must accept the truncatable layout (height \(height))"
+        )
+    }
+
+    @Test("Control: the width probe reports a page-level minimum above the proposal")
+    func controlWidthProbeCatchesMinimumWidthHint() {
+        // A `minWidth` hint above the proposal forces the layout wider than the column —
+        // exactly what Channels and Spectrum did before the fix. The width probe must
+        // report it.
+        let hinted = Color.clear.frame(minWidth: 700)
+        let required = requiredWidth(of: hinted)
+        #expect(
+            required > Self.detailWidth + Self.tolerance,
+            "Width probe must flag a 700pt minimum inside a 600pt proposal (width \(required))"
+        )
+    }
+}

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		1B8B239E2A11401AB0C0D51B /* WindowFramePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92298452F334CDAAA9695D3 /* WindowFramePolicyTests.swift */; };
 		A1C4E7BA2F0148D3B6E90A22 /* DetailPageMinimumHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C4E7B92F0148D3B6E90A21 /* DetailPageMinimumHeightTests.swift */; };
 		A1C4E7BC2F0148D3B6E90A24 /* MainWindowMinimumSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C4E7BB2F0148D3B6E90A23 /* MainWindowMinimumSizeTests.swift */; };
+		A1C4E7BD2F0148D3B6E90A26 /* DetailPageHorizontalOverflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C4E7BE2F0148D3B6E90A27 /* DetailPageHorizontalOverflowTests.swift */; };
 		1E5141F704005BF06DB684A1 /* CoreWLAN.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1067F6AA96EC6320C6472F59 /* CoreWLAN.framework */; };
 		237EB0EBBBFBAC33EAE1380B /* BluetoothPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CDF2DB455AB04A0A7C8BBF /* BluetoothPermissionManager.swift */; };
 		23F1AB88A28C6E035AA916AA /* BandChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF378E09090DEBAAFA77F6 /* BandChartViewModel.swift */; };
@@ -545,6 +546,7 @@
 		D74387CFA1E33037E9F1888E /* ScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewModel.swift; sourceTree = "<group>"; };
 		A1C4E7B92F0148D3B6E90A21 /* DetailPageMinimumHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPageMinimumHeightTests.swift; sourceTree = "<group>"; };
 		A1C4E7BB2F0148D3B6E90A23 /* MainWindowMinimumSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowMinimumSizeTests.swift; sourceTree = "<group>"; };
+		A1C4E7BE2F0148D3B6E90A27 /* DetailPageHorizontalOverflowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPageHorizontalOverflowTests.swift; sourceTree = "<group>"; };
 		D92298452F334CDAAA9695D3 /* WindowFramePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowFramePolicyTests.swift; sourceTree = "<group>"; };
 		E4A2B3C4D5E6F708112233AA /* BandPanelSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandPanelSelectionTests.swift; sourceTree = "<group>"; };
 		E4A2B3C4D5E6F708112233AD /* BandPanelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandPanelSelection.swift; sourceTree = "<group>"; };
@@ -1249,6 +1251,7 @@
 				D92298452F334CDAAA9695D3 /* WindowFramePolicyTests.swift */,
 				A1C4E7B92F0148D3B6E90A21 /* DetailPageMinimumHeightTests.swift */,
 				A1C4E7BB2F0148D3B6E90A23 /* MainWindowMinimumSizeTests.swift */,
+				A1C4E7BE2F0148D3B6E90A27 /* DetailPageHorizontalOverflowTests.swift */,
 			);
 			path = WiFiLensTests;
 			sourceTree = "<group>";
@@ -1793,6 +1796,7 @@
 				1B8B239E2A11401AB0C0D51B /* WindowFramePolicyTests.swift in Sources */,
 				A1C4E7BA2F0148D3B6E90A22 /* DetailPageMinimumHeightTests.swift in Sources */,
 				A1C4E7BC2F0148D3B6E90A24 /* MainWindowMinimumSizeTests.swift in Sources */,
+				A1C4E7BD2F0148D3B6E90A26 /* DetailPageHorizontalOverflowTests.swift in Sources */,
 				A10000000000000000000016 /* App/MenuBarWindowBehaviorTests.swift in Sources */,
 				OB0000000000000000000031 /* ModelsTests.swift in Sources */,
 				OB0000000000000000000033 /* ProviderTests.swift in Sources */,


### PR DESCRIPTION
## Summary

PR #47 fixed the P0 window sizing incident (window can no longer shrink below `820 × 620`), which left the detail column at ~600pt wide at the minimum window size. Several detail pages kept laying out at their ideal width and their right edge was clipped — the follow-up reported in issue #51.

This PR makes the pages adapt to the window instead of the other way around. All windowing guardrails from PR #47 (`MainWindowSizing`, the GeometryReader boundary, `mainWindowMinimumSize()`) are untouched.

## Root cause (measured, not guessed)

Hosted every detail page at 600pt and measured the width the content requires:

| Page | Before | After |
|---|---|---|
| Channels (simple + table) | **700pt** ❌ clipped | 600pt ✅ |
| Spectrum dashboard | **700pt** ❌ clipped | 600pt ✅ |
| Overview / Interfaces / NetworkDiagnostics / Roaming / Settings | 600pt ✅ | 600pt ✅ |

- `ChannelQualityView` and Spectrum `ContentView` carried `.frame(minWidth: 700, ...)` page hints. The GeometryReader in `WiFiLensApp.swift` kept those minimums off the `NSWindow` (which is why the windowing audit marked them "safe for windowing"), but the page still laid out 700pt wide inside the ~600pt column — visually clipped. Minimums removed; `idealWidth`/`idealHeight` kept as local layout hints (WINDOWING.md rule 6).
- Long SSIDs are one unbreakable token; without a `lineLimit` they wrap the connection card and push the trailing RSSI cluster out of view (verified: the pathological-SSID card grows by a full text line).

## Changes

- **Channels/ChannelQualityView.swift**, **Spectrum/ContentView.swift** — remove `minWidth`/`minHeight` page hints
- **App/OverviewView.swift** — connection card: SSID `lineLimit(1)` + `truncationMode(.tail)` + `.help`, caption row bounded, RSSI cluster `fixedSize(horizontal:)`
- **Interfaces/InterfacesView.swift**, **Roaming/RoamingTestView.swift** — same SSID guardrail on their connection hero / signal card

## Regression coverage

New `DetailPageHorizontalOverflowTests` (12 tests):
- every detail page fits the 600pt minimum detail width (page requires no more width than the column offers; scroll documents are not wider than their clip views)
- a pathological SSID truncates to one line instead of wrapping (relative height measurement)
- 3 detector control tests validate the measurement harness itself

Verified the suite **fails against the unfixed code** (4 assertions) and passes with the fixes. Window-size guards (`MainWindowMinimumSizeTests`, `DetailPageMinimumHeightTests`) unchanged and passing.

## Test results

- New + windowing tests: 20/20 pass
- Full `WiFiLensTests`: 845 tests, 3 pre-existing concurrency flakes in `MACVendorDatabaseManagerTests` (1s `waitUntil` polling timeouts under full-suite load; pass in isolation and on a clean tree — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)