### PR TITLE
fix: stabilize MAC vendor database async test waits

### DIFF
--- a/WiFiLens/Tests/WiFiLensTests/MACVendorDatabaseManagerTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/MACVendorDatabaseManagerTests.swift
@@ -926,12 +926,16 @@ private func fourFixtureURLs() -> [URL] {
     MACVendorRegistry.allCases.map { URL(fileURLWithPath: "/tmp/\($0.rawValue).csv") }
 }
 
+/// Polls an asynchronous condition with a generous budget. These tests await
+/// cross-actor handshakes (main-actor manager → fake service actor → back) that can
+/// take well over a second under full-suite parallel load; the original 1000 × 1ms
+/// budget timed out intermittently on busy machines.
 private func waitUntil(
     _ condition: @escaping @Sendable () async -> Bool
 ) async {
     for _ in 0..<1_000 {
         if await condition() { return }
-        try? await Task.sleep(for: .milliseconds(1))
+        try? await Task.sleep(for: .milliseconds(5))
     }
     Issue.record("Timed out waiting for asynchronous test state")
 }


### PR DESCRIPTION
## Summary

Three tests in `MACVendorDatabaseManagerTests` (`onlyOperationOwnerCanCancelDownload`, `onlyOperationOwnerCanObserveOrCancelManualPreparation`, `waitingStaleCancellationHandleCannotSettleReplacementOperation`) intermittently fail in full-suite runs with:

```
Issue recorded: Timed out waiting for asynchronous test state
```

They pass in isolation and on a clean tree — the failures are a timing race, not a code defect.

## Root cause

The tests start an operation with `Task { await manager.downloadAndInstall() }` and wait for the fake service actor to report it started, via `waitUntil { await service.downloadCallCount == 1 }`. That condition requires a cross-actor handshake — the main-actor manager must start the operation, call into the `FakeMACVendorDatabaseService` actor, and the actor must update its counter before the poller observes it. `waitUntil` budgeted only **~1 second** (1000 polls × 1ms). Under full-suite parallel load the main actor is contended by hundreds of other tests, the handshake exceeds the budget, and the test times out even though the code under test is correct. The three failing tests are the ones that wait for an intermediate "operation started" state right after launching the task — the narrowest window in the file.

## Fix

Raise the poll interval from 1ms to 5ms, extending the effective budget to ~5s while keeping fast-path detection just as quick (conditions normally become true within the first few polls, so the added latency is negligible).

## Verification

- Three consecutive full `WiFiLensTests` runs (833 tests / 93 suites): **all pass** (previously 3 failures per run)
- Test suite duration unchanged (~3.3s per run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)