### PR TITLE
feat: add lifecycle guidance, first-run welcome, and debug controls

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/Logging.swift
+++ b/WiFiLens/Sources/WiFiLens/App/Logging.swift
@@ -44,6 +44,7 @@ enum AppLogger {
     static let throughput = Logging.Logger(label: "throughput")
     static let location   = Logging.Logger(label: "location")
     static let ble        = Logging.Logger(label: "ble")
+    static let guidance   = Logging.Logger(label: "guidance")
 
     /// Backward-compatible alias for `AppLogger.app` call sites.
     static let app = general

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum EditionComposition {
@@ -9,6 +10,15 @@ enum EditionComposition {
     }
 
     static var exportSuccessPresentation: ExportSuccessPresentation { .banner }
+
+    static var onboardingConfiguration: OnboardingConfiguration {
+        OnboardingConfiguration(
+            welcomeEnabled: true,
+            showsProLink: true,
+            proURL: ExternalLinks.url(for: .appStoreCampaign),
+            startRoute: .overview
+        )
+    }
 
     @MainActor
     static var markdownExportCommandContribution: MarkdownExportCommandContribution {
@@ -92,6 +102,24 @@ enum EditionComposition {
         showMainWindow: @escaping (SidebarPage) -> Void
     ) -> some Commands {
         CommandMenu("Debug") {
+            Menu("Onboarding") {
+                Button("Reset Welcome State") {
+                    OnboardingCoordinator.shared.debugReset()
+                }
+                Button("Show Welcome Now") {
+                    OnboardingCoordinator.shared.debugRequestShowWelcome()
+                    NSApp.activate(ignoringOtherApps: true)
+                    if let mainWindow = NSApp.windows.first(where: { $0.canBecomeMain }) {
+                        mainWindow.makeKeyAndOrderFront(nil)
+                    } else {
+                        showMainWindow(.overview)
+                    }
+                }
+                Button("Log Onboarding State") {
+                    OnboardingCoordinator.shared.debugLogState(edition: "OSS")
+                }
+            }
+            Divider()
             Menu("Lifecycle Guidance") {
                 Button("Reset Lifecycle Guidance State") {
                     GuidanceCoordinator.shared.debugResetState()
@@ -101,12 +129,18 @@ enum EditionComposition {
                 }
                 Button("Trigger Diagnostics Invitation") {
                     GuidanceCoordinator.shared.debugScheduleInvitation(for: .diagnosticsCompleted)
-                    GuidanceDebugOverrides.stageDiagnosticsCompletion()
+                    GuidanceDebugOverrides.requestDiagnosticsStaging()
                     showMainWindow(.networkDiagnostics)
                 }
                 Button("Trigger Export Invitation Banner") {
                     GuidanceCoordinator.shared.debugScheduleInvitation(for: .exportSucceeded)
                     GuidanceCoordinator.shared.debugPublishExportFeedback()
+                    NSApp.activate(ignoringOtherApps: true)
+                    if let mainWindow = NSApp.windows.first(where: { $0.canBecomeMain }) {
+                        mainWindow.makeKeyAndOrderFront(nil)
+                    } else {
+                        showMainWindow(.overview)
+                    }
                 }
                 Picker("Pro Installation Override", selection: Binding(
                     get: { GuidanceDebugOverrides.proInstallationOverride },

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -84,6 +84,46 @@ enum EditionComposition {
         }
     }
 
+#if DEBUG
+    /// Debug-only manual testing controls for the OSS invitation flow. The
+    /// whole menu is compiled out of Release builds.
+    @MainActor
+    static func debugCommands(
+        showMainWindow: @escaping (SidebarPage) -> Void
+    ) -> some Commands {
+        CommandMenu("Debug") {
+            Menu("Lifecycle Guidance") {
+                Button("Reset Lifecycle Guidance State") {
+                    GuidanceCoordinator.shared.debugResetState()
+                }
+                Button("Prepare OSS Invitation Eligibility") {
+                    GuidanceCoordinator.shared.debugPrepareInvitationEligibility()
+                }
+                Button("Trigger Diagnostics Invitation") {
+                    GuidanceCoordinator.shared.debugScheduleInvitation(for: .diagnosticsCompleted)
+                    GuidanceDebugOverrides.stageDiagnosticsCompletion()
+                    showMainWindow(.networkDiagnostics)
+                }
+                Button("Trigger Export Invitation Banner") {
+                    GuidanceCoordinator.shared.debugScheduleInvitation(for: .exportSucceeded)
+                    GuidanceCoordinator.shared.debugPublishExportFeedback()
+                }
+                Picker("Pro Installation Override", selection: Binding(
+                    get: { GuidanceDebugOverrides.proInstallationOverride },
+                    set: { GuidanceDebugOverrides.setProInstallationOverride($0) }
+                )) {
+                    Text("Use Real Detection").tag(ProInstallationOverride.useRealDetection)
+                    Text("Treat Pro as Not Installed").tag(ProInstallationOverride.treatAsNotInstalled)
+                    Text("Treat Pro as Installed").tag(ProInstallationOverride.treatAsInstalled)
+                }
+                Button("Log Lifecycle Guidance State") {
+                    GuidanceCoordinator.shared.debugLogState(edition: "OSS")
+                }
+            }
+        }
+    }
+#endif
+
     static func startLifecycle(observationRuntime: WiFiObservationRuntime) {}
 
     @MainActor

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -16,7 +16,14 @@ enum EditionComposition {
             welcomeEnabled: true,
             showsProLink: true,
             proURL: ExternalLinks.url(for: .appStoreCampaign),
-            startRoute: .overview
+            startRoute: .overview,
+            startToolbarSelection: nil,
+            primaryActionKey: "onboarding.welcome.start",
+            highlights: [
+                OnboardingHighlight(icon: "wifi", titleKey: "onboarding.welcome.highlight.live"),
+                OnboardingHighlight(icon: "waveform.path.ecg", titleKey: "onboarding.welcome.highlight.diagnostics"),
+                OnboardingHighlight(icon: "square.and.arrow.up", titleKey: "onboarding.welcome.highlight.export")
+            ]
         )
     }
 

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -11,6 +11,10 @@ enum EditionComposition {
 
     static var exportSuccessPresentation: ExportSuccessPresentation { .banner }
 
+    static func makeOnboardingExistingInstallationDetector() -> any ExistingInstallationDetecting {
+        SparkleAutomaticCheckExistingInstallationDetector()
+    }
+
     static var onboardingConfiguration: OnboardingConfiguration {
         OnboardingConfiguration(
             welcomeEnabled: true,
@@ -114,6 +118,7 @@ enum EditionComposition {
                     OnboardingCoordinator.shared.debugReset()
                 }
                 Button("Show Welcome Now") {
+                    guard EditionComposition.onboardingConfiguration.welcomeEnabled else { return }
                     OnboardingCoordinator.shared.debugRequestShowWelcome()
                     NSApp.activate(ignoringOtherApps: true)
                     if let mainWindow = NSApp.windows.first(where: { $0.canBecomeMain }) {

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -4,10 +4,7 @@ enum EditionComposition {
     static var guidanceConfiguration: GuidanceConfiguration {
         var config = GuidanceConfiguration()
         config.invitationEnabled = true
-        // Dev builds use the plain listing. Before release, replace this with
-        // the official App Store Connect "oss_invite" Campaign Link. Never
-        // handcraft campaign parameters.
-        config.appStoreCampaignURL = ExternalLinks.url(for: .appStore)
+        config.appStoreCampaignURL = ExternalLinks.url(for: .appStoreCampaign)
         return config
     }
 

--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 
 enum EditionComposition {
+    static var guidanceConfiguration: GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.invitationEnabled = true
+        // Dev builds use the plain listing. Before release, replace this with
+        // the official App Store Connect "oss_invite" Campaign Link. Never
+        // handcraft campaign parameters.
+        config.appStoreCampaignURL = ExternalLinks.url(for: .appStore)
+        return config
+    }
+
+    static var exportSuccessPresentation: ExportSuccessPresentation { .banner }
+
     @MainActor
     static var markdownExportCommandContribution: MarkdownExportCommandContribution {
         .lockedPreview

--- a/WiFiLens/Sources/WiFiLens/Guidance/ExportSuccessBanner.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/ExportSuccessBanner.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Bottom-anchored, non-modal export success banner (OSS `.banner` strategy
+/// only). Renders nothing while there is no feedback. When the coordinator has
+/// a pending export invitation, the banner hosts the invitation card and
+/// captures the exact rendered token for host-lifecycle end semantics — it
+/// never re-queries `pendingInvitation` later to guess which token it showed.
+struct ExportSuccessBanner: View {
+    let guidance: GuidanceCoordinator
+
+    @State private var renderedInvitationID: UUID?
+
+    var body: some View {
+        if guidance.exportFeedback != nil {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Label {
+                        Text(String(localized: "export.success_banner_message", comment: "Export success banner message"))
+                            .font(.headline)
+                    } icon: {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                    Spacer()
+                    Button {
+                        guidance.dismissExportFeedback()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.body.weight(.semibold))
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel(String(localized: "common.action.dismiss", comment: "Dismiss/close alert button"))
+                }
+
+                if let invitation = guidance.pendingInvitation, invitation.moment == .exportSucceeded {
+                    ProInvitationCard(invitation: invitation, guidance: guidance)
+                        .onAppear { renderedInvitationID = invitation.id }
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+            )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+            .onDisappear {
+                if let id = renderedInvitationID {
+                    renderedInvitationID = nil
+                    guidance.endInvitationPresentation(id: id)
+                }
+            }
+            .accessibilityIdentifier("export-success-banner")
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceConfiguration.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceConfiguration.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Edition-provided tuning for the guidance policy. Pure data — the policy
+/// never reads edition or presentation concerns from here beyond the enabled
+/// flags and thresholds.
+struct GuidanceConfiguration: Equatable, Sendable {
+    var invitationEnabled = false
+    var reviewEnabled = false
+    var minimumInvitationCompletions = 3
+    var minimumInvitationActiveDays = 2
+    var invitationCooldownDays = 30
+    var maxAutomaticInvitations = 3
+    var minimumReviewCompletions = 5
+    var minimumReviewActiveDays = 3
+    var minimumReviewAgeDays = 7
+    var reviewCooldownDays = 120
+    var appStoreCampaignURL: URL?
+}
+
+/// The value moments the guidance system observes.
+enum GuidanceValueMoment: String, Equatable, Sendable {
+    case diagnosticsCompleted
+    case exportSucceeded
+    case analysisLoaded
+    case roamingCompleted
+}
+
+/// Why no guidance decision was made. There is deliberately no `.none` case:
+/// `GuidanceDecision.none(reason)` already expresses "no action", so a
+/// meaningless `.none(.none)` must not be expressible.
+enum GuidanceSuppressionReason: String, Equatable, Sendable {
+    case editionInvitationDisabled
+    case editionReviewDisabled
+    case invitationsDisabledByUser
+    case proAppInstalled
+    case completionThresholdNotMet
+    case activeDaysThresholdNotMet
+    case invitationCooldown
+    case invitationPresentationLimit
+    case firstLaunchAgeNotMet
+    case reviewCooldown
+    case reviewAlreadyRequestedForVersion
+    case roamingPolicyNotEnabled
+    // Coordinator-level gates (checked before the pure policy; the policy
+    // itself never reads pending state):
+    case invitationAlreadyPending
+    case reviewRequestPending
+}
+
+enum GuidanceDecision: Equatable, Sendable {
+    case none(GuidanceSuppressionReason)
+    case showProInvitation
+    case requestReview
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -5,7 +5,7 @@ import Observation
 
 /// One structured guidance event. `tokenID` is a process-memory UUID used by
 /// tests to assert once-per-token behavior; the production log line never
-/// carries the full UUID (only a short prefix in `metadata`).
+/// carries the UUID or any derived prefix.
 struct GuidanceEvent: Equatable, Sendable {
     let name: String                        // "guidance.value_moment", "guidance.invitation.scheduled", ...
     let moment: GuidanceValueMoment?

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -262,9 +262,6 @@ final class GuidanceCoordinator {
         if let suppressionReason {
             metadata["reason"] = suppressionReason.rawValue
         }
-        if let tokenID {
-            metadata["token"] = String(tokenID.uuidString.prefix(8))
-        }
         eventSink(
             GuidanceEvent(
                 name: name,
@@ -294,6 +291,7 @@ extension GuidanceCoordinator {
         pendingReviewRequest = nil
         confirmedPresentedInvitationIDs.removeAll()
         exportFeedback = nil
+        GuidanceDebugOverrides.clearDiagnosticsStaging()
         stateStore.save(GuidanceState())
         emit("guidance.debug.state_reset")
     }
@@ -326,9 +324,10 @@ extension GuidanceCoordinator {
         }
         var state = GuidanceState()
         let now = now()
-        state.recordActiveDay(at: now, calendar: calendar)
-        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now) {
-            state.recordActiveDay(at: yesterday, calendar: calendar)
+        for daysAgo in 0..<configuration.minimumInvitationActiveDays {
+            if let day = calendar.date(byAdding: .day, value: -daysAgo, to: now) {
+                state.recordActiveDay(at: day, calendar: calendar)
+            }
         }
         state.meaningfulCompletionCount = configuration.minimumInvitationCompletions
         stateStore.save(state)

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -70,7 +70,20 @@ final class GuidanceCoordinator {
             Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
         },
         isProAppInstalled: @escaping () -> Bool = {
-            NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.kaoru.wifi-lens-pro") != nil
+            #if DEBUG
+            // Debug-only in-memory override for manual invitation testing;
+            // Release builds compile this block away and always use real
+            // detection.
+            switch GuidanceDebugOverrides.proInstallationOverride {
+            case .useRealDetection:
+                break
+            case .treatAsNotInstalled:
+                return false
+            case .treatAsInstalled:
+                return true
+            }
+            #endif
+            return NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.kaoru.wifi-lens-pro") != nil
         },
         eventSink: @escaping (GuidanceEvent) -> Void = { event in
             var metadata = Logging.Logger.Metadata()
@@ -263,3 +276,170 @@ final class GuidanceCoordinator {
         )
     }
 }
+
+#if DEBUG
+extension GuidanceCoordinator {
+    // MARK: - Debug-only manual test entry points
+    //
+    // These APIs exist only in Debug builds. They may bypass the eligibility
+    // policy for manual testing, but they never bypass the token lifecycle:
+    // every schedule creates a fresh UUID token, respects the pending gate,
+    // and is consumed only through the existing presentation/consume/cancel
+    // APIs. Nothing here is persisted, uploaded, or included in Release.
+
+    /// Clears every persisted guidance field and every pending in-memory
+    /// presentation.
+    func debugResetState() {
+        pendingInvitation = nil
+        pendingReviewRequest = nil
+        confirmedPresentedInvitationIDs.removeAll()
+        exportFeedback = nil
+        stateStore.save(GuidanceState())
+        emit("guidance.debug.state_reset")
+    }
+
+    /// Clears review-eligibility state (persisted review fields, completion
+    /// count, active days, first-launch age) and the pending review request,
+    /// preserving the (inert in Pro) invitation fields.
+    func debugResetReviewState() {
+        pendingReviewRequest = nil
+        let current = stateStore.load()
+        stateStore.save(GuidanceState(
+            firstLaunchDate: nil,
+            activeDays: [],
+            meaningfulCompletionCount: 0,
+            lastInvitationDate: current.lastInvitationDate,
+            invitationPresentationCount: current.invitationPresentationCount,
+            invitationDismissalCount: current.invitationDismissalCount,
+            invitationsDisabled: current.invitationsDisabled
+        ))
+        emit("guidance.debug.review_state_reset")
+    }
+
+    /// Seeds persisted state to exactly meet the invitation policy, so the
+    /// next real value moment schedules an invitation through the production
+    /// policy path. Refuses while an invitation is already pending.
+    func debugPrepareInvitationEligibility() {
+        guard pendingInvitation == nil else {
+            emit("guidance.debug.refused", metadata: ["reason": "pending_invitation"])
+            return
+        }
+        var state = GuidanceState()
+        let now = now()
+        state.recordActiveDay(at: now, calendar: calendar)
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now) {
+            state.recordActiveDay(at: yesterday, calendar: calendar)
+        }
+        state.meaningfulCompletionCount = configuration.minimumInvitationCompletions
+        stateStore.save(state)
+        emit("guidance.debug.invitation_eligibility_prepared")
+    }
+
+    /// Seeds persisted state to exactly meet the review policy, so the next
+    /// real value moment schedules a review request through the production
+    /// policy path. Refuses while a review request is already pending.
+    func debugPrepareReviewEligibility() {
+        guard pendingReviewRequest == nil else {
+            emit("guidance.debug.refused", metadata: ["reason": "pending_review"])
+            return
+        }
+        var state = GuidanceState()
+        let now = now()
+        state.firstLaunchDate = calendar.date(
+            byAdding: .day,
+            value: -configuration.minimumReviewAgeDays,
+            to: now
+        )
+        for daysAgo in 0..<configuration.minimumReviewActiveDays {
+            if let day = calendar.date(byAdding: .day, value: -daysAgo, to: now) {
+                state.recordActiveDay(at: day, calendar: calendar)
+            }
+        }
+        state.meaningfulCompletionCount = configuration.minimumReviewCompletions
+        stateStore.save(state)
+        emit("guidance.debug.review_eligibility_prepared")
+    }
+
+    /// Force-schedules an invitation for a supported moment, bypassing the
+    /// policy but keeping the pending gate and token lifecycle intact.
+    func debugScheduleInvitation(for moment: GuidanceValueMoment) {
+        guard moment == .diagnosticsCompleted || moment == .exportSucceeded else {
+            emit("guidance.debug.refused", metadata: ["reason": "unsupported_moment"])
+            return
+        }
+        guard pendingInvitation == nil else {
+            emit("guidance.debug.refused", metadata: ["reason": "pending_invitation"])
+            return
+        }
+        let invitation = InvitationPresentation(id: UUID(), moment: moment, scheduledAt: now())
+        pendingInvitation = invitation
+        emit("guidance.invitation.scheduled", moment: moment, tokenID: invitation.id)
+        emit("guidance.debug.invitation_triggered", moment: moment, tokenID: invitation.id)
+    }
+
+    /// Force-schedules a review request, bypassing the policy but keeping the
+    /// pending gate and token lifecycle intact. Consumed only by the real
+    /// Pro-only bridge; never by direct StoreKit calls.
+    func debugScheduleReview(for moment: GuidanceValueMoment) {
+        guard moment != .roamingCompleted else {
+            emit("guidance.debug.refused", metadata: ["reason": "unsupported_moment"])
+            return
+        }
+        guard pendingReviewRequest == nil else {
+            emit("guidance.debug.refused", metadata: ["reason": "pending_review"])
+            return
+        }
+        let request = ReviewRequestPresentation(id: UUID(), moment: moment, scheduledAt: now())
+        pendingReviewRequest = request
+        emit("guidance.review.scheduled", moment: moment, tokenID: request.id)
+        emit("guidance.debug.review_triggered", moment: moment, tokenID: request.id)
+    }
+
+    /// Publishes export feedback so the real OSS banner host renders, without
+    /// running a real file save.
+    func debugPublishExportFeedback() {
+        exportFeedback = ExportFeedback(occurredAt: now())
+        emit("guidance.debug.export_feedback_published")
+    }
+
+    /// Emits a sanitized state summary for local Debug logs. Contains no
+    /// UUIDs, SSIDs, BSSIDs, IPs, DNS data, or diagnostic results.
+    func debugLogState(edition: String) {
+        let state = stateStore.load()
+        var metadata: [String: String] = [
+            "edition": edition,
+            "completionCount": String(state.meaningfulCompletionCount),
+            "activeDayCount": String(state.activeDays.count),
+            "invitationPresentationCount": String(state.invitationPresentationCount),
+            "invitationDismissalCount": String(state.invitationDismissalCount),
+            "invitationsDisabled": String(state.invitationsDisabled),
+            "hasReviewRequestHistory": String(state.lastReviewRequestDate != nil),
+            "reviewConsumedForCurrentVersion": String(state.lastReviewRequestVersion == appVersion()),
+            "hasPendingInvitation": String(pendingInvitation != nil),
+            "hasPendingReviewRequest": String(pendingReviewRequest != nil),
+            "proInstallationOverride": GuidanceDebugOverrides.proInstallationOverride.rawValue,
+        ]
+        if let lastInvitationDate = state.lastInvitationDate {
+            metadata["invitationCooldownActive"] = String(
+                debugWholeDaysSince(lastInvitationDate) < configuration.invitationCooldownDays
+            )
+        } else {
+            metadata["invitationCooldownActive"] = "false"
+        }
+        if let lastReviewRequestDate = state.lastReviewRequestDate {
+            metadata["reviewCooldownActive"] = String(
+                debugWholeDaysSince(lastReviewRequestDate) < configuration.reviewCooldownDays
+            )
+        } else {
+            metadata["reviewCooldownActive"] = "false"
+        }
+        emit("guidance.debug.state_summary", metadata: metadata)
+    }
+
+    private func debugWholeDaysSince(_ date: Date) -> Int {
+        let start = calendar.startOfDay(for: date)
+        let startNow = calendar.startOfDay(for: now())
+        return calendar.dateComponents([.day], from: start, to: startNow).day ?? 0
+    }
+}
+#endif

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -118,7 +118,7 @@ final class GuidanceCoordinator {
                 now: now(),
                 calendar: calendar,
                 appVersion: appVersion(),
-                isProAppInstalled: isProAppInstalled()
+                isProAppInstalled: canInvite && configuration.invitationEnabled ? isProAppInstalled() : false
             )
         }
 
@@ -163,7 +163,7 @@ final class GuidanceCoordinator {
     func dismissExportFeedback() {
         exportFeedback = nil
         if let invitation = pendingInvitation, invitation.moment == .exportSucceeded {
-            dismissInvitation(id: invitation.id)
+            endInvitationPresentation(id: invitation.id)
         }
     }
 

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -1,0 +1,265 @@
+import AppKit
+import Foundation
+import Logging
+import Observation
+
+/// One structured guidance event. `tokenID` is a process-memory UUID used by
+/// tests to assert once-per-token behavior; the production log line never
+/// carries the full UUID (only a short prefix in `metadata`).
+struct GuidanceEvent: Equatable, Sendable {
+    let name: String                        // "guidance.value_moment", "guidance.invitation.scheduled", ...
+    let moment: GuidanceValueMoment?
+    let tokenID: UUID?
+    let suppressionReason: GuidanceSuppressionReason?
+    let metadata: [String: String]
+}
+
+/// Records value moments, schedules presentations in memory only, consumes
+/// persisted counts only on real UI/system interaction via token-gated APIs,
+/// publishes observable state, and emits structured events through an injected
+/// sink. It never executes StoreKit and never presents UI.
+@MainActor @Observable
+final class GuidanceCoordinator {
+    static let shared: GuidanceCoordinator = GuidanceCoordinator(
+        configuration: EditionComposition.guidanceConfiguration,
+        stateStore: UserDefaultsGuidanceStateStore()
+    )
+
+    struct InvitationPresentation: Equatable, Identifiable, Sendable {
+        let id: UUID
+        let moment: GuidanceValueMoment
+        let scheduledAt: Date
+    }
+
+    struct ReviewRequestPresentation: Equatable, Identifiable, Sendable {
+        let id: UUID
+        let moment: GuidanceValueMoment
+        let scheduledAt: Date
+    }
+
+    struct ExportFeedback: Equatable {
+        let occurredAt: Date
+    }
+
+    private(set) var pendingInvitation: InvitationPresentation?
+    private(set) var pendingReviewRequest: ReviewRequestPresentation?
+    private(set) var exportFeedback: ExportFeedback?
+
+    var appStoreCampaignURL: URL? { configuration.appStoreCampaignURL }
+
+    private let configuration: GuidanceConfiguration
+    private let stateStore: any GuidanceStateStoring
+    private let now: () -> Date
+    private let calendar: Calendar
+    private let appVersion: () -> String
+    private let isProAppInstalled: () -> Bool
+    private let eventSink: (GuidanceEvent) -> Void
+
+    /// Invitation tokens whose first real `onAppear` was confirmed. Memory-only,
+    /// used to make `invitationPresented(id:)` and `endInvitationPresentation(id:)`
+    /// idempotent per token and to distinguish "cancelled unpresented" from
+    /// "dismissed as Later".
+    private var confirmedPresentedInvitationIDs: Set<UUID> = []
+
+    init(
+        configuration: GuidanceConfiguration,
+        stateStore: any GuidanceStateStoring,
+        now: @escaping () -> Date = Date.init,
+        calendar: Calendar = .current,
+        appVersion: @escaping () -> String = {
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+        },
+        isProAppInstalled: @escaping () -> Bool = {
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.kaoru.wifi-lens-pro") != nil
+        },
+        eventSink: @escaping (GuidanceEvent) -> Void = { event in
+            var metadata = Logging.Logger.Metadata()
+            for (key, value) in event.metadata {
+                metadata[key] = .string(value)
+            }
+            AppLogger.guidance.info("\(event.name)", metadata: metadata)
+        }
+    ) {
+        self.configuration = configuration
+        self.stateStore = stateStore
+        self.now = now
+        self.calendar = calendar
+        self.appVersion = appVersion
+        self.isProAppInstalled = isProAppInstalled
+        self.eventSink = eventSink
+    }
+
+    // MARK: - Recording
+
+    @discardableResult
+    func record(_ moment: GuidanceValueMoment) -> GuidanceDecision {
+        var state = stateStore.load()
+
+        switch moment {
+        case .diagnosticsCompleted, .exportSucceeded, .analysisLoaded:
+            state.meaningfulCompletionCount += 1
+        case .roamingCompleted:
+            break
+        }
+
+        let canInvite = moment == .diagnosticsCompleted || moment == .exportSucceeded
+        let canReview = moment == .diagnosticsCompleted || moment == .exportSucceeded || moment == .analysisLoaded
+
+        let decision: GuidanceDecision
+        if canInvite, pendingInvitation != nil {
+            decision = .none(.invitationAlreadyPending)
+        } else if canReview, pendingReviewRequest != nil {
+            decision = .none(.reviewRequestPending)
+        } else {
+            decision = GuidancePolicy.decide(
+                for: moment,
+                state: state,
+                config: configuration,
+                now: now(),
+                calendar: calendar,
+                appVersion: appVersion(),
+                isProAppInstalled: isProAppInstalled()
+            )
+        }
+
+        switch decision {
+        case .showProInvitation:
+            let invitation = InvitationPresentation(id: UUID(), moment: moment, scheduledAt: now())
+            pendingInvitation = invitation
+            emit("guidance.invitation.scheduled", moment: moment, tokenID: invitation.id)
+        case .requestReview:
+            let request = ReviewRequestPresentation(id: UUID(), moment: moment, scheduledAt: now())
+            pendingReviewRequest = request
+            emit("guidance.review.scheduled", moment: moment, tokenID: request.id)
+        case let .none(reason):
+            emit("guidance.no_action", moment: moment, suppressionReason: reason)
+        }
+
+        stateStore.save(state)
+        emit(
+            "guidance.value_moment",
+            moment: moment,
+            metadata: ["completionCount": String(state.meaningfulCompletionCount)]
+        )
+        return decision
+    }
+
+    func recordAppActive() {
+        var state = stateStore.load()
+        if state.firstLaunchDate == nil {
+            state.firstLaunchDate = now()
+        }
+        state.recordActiveDay(at: now(), calendar: calendar)
+        stateStore.save(state)
+    }
+
+    // MARK: - Export feedback
+
+    func handleExportSucceeded() {
+        record(.exportSucceeded)
+        exportFeedback = ExportFeedback(occurredAt: now())
+    }
+
+    func dismissExportFeedback() {
+        exportFeedback = nil
+        if let invitation = pendingInvitation, invitation.moment == .exportSucceeded {
+            dismissInvitation(id: invitation.id)
+        }
+    }
+
+    // MARK: - Invitation consumption (token-gated)
+
+    func invitationPresented(id: UUID) {
+        guard let invitation = pendingInvitation, invitation.id == id else { return }
+        guard !confirmedPresentedInvitationIDs.contains(id) else { return }
+        confirmedPresentedInvitationIDs.insert(id)
+        var state = stateStore.load()
+        state.invitationPresentationCount += 1
+        state.lastInvitationDate = now()
+        stateStore.save(state)
+        emit("guidance.invitation.presented", moment: invitation.moment, tokenID: id)
+    }
+
+    func dismissInvitation(id: UUID) {
+        guard let invitation = pendingInvitation, invitation.id == id else { return }
+        pendingInvitation = nil
+        var state = stateStore.load()
+        state.invitationDismissalCount += 1
+        stateStore.save(state)
+        emit("guidance.invitation.dismissed", moment: invitation.moment, tokenID: id)
+    }
+
+    func disableInvitations(id: UUID) {
+        guard let invitation = pendingInvitation, invitation.id == id else { return }
+        pendingInvitation = nil
+        var state = stateStore.load()
+        state.invitationsDisabled = true
+        stateStore.save(state)
+        emit("guidance.invitation.disabled", moment: invitation.moment, tokenID: id)
+    }
+
+    func openInvitation(id: UUID) {
+        guard let invitation = pendingInvitation, invitation.id == id else { return }
+        pendingInvitation = nil
+        emit("guidance.invitation.view_selected", moment: invitation.moment, tokenID: id)
+    }
+
+    /// Host-lifecycle end, called from the host view's `onDisappear` with the
+    /// exact token the host rendered. An unpresented invitation is cancelled
+    /// without any count or cooldown; a presented one without a user choice is
+    /// consumed as Later.
+    func endInvitationPresentation(id: UUID) {
+        guard let invitation = pendingInvitation, invitation.id == id else { return }
+        pendingInvitation = nil
+        if confirmedPresentedInvitationIDs.contains(id) {
+            var state = stateStore.load()
+            state.invitationDismissalCount += 1
+            stateStore.save(state)
+            emit("guidance.invitation.dismissed", moment: invitation.moment, tokenID: id)
+        } else {
+            emit("guidance.invitation.cancelled", moment: invitation.moment, tokenID: id)
+        }
+    }
+
+    // MARK: - Review consumption (token-gated)
+
+    func reviewRequestPresented(id: UUID) {
+        guard let request = pendingReviewRequest, request.id == id else { return }
+        pendingReviewRequest = nil
+        var state = stateStore.load()
+        state.lastReviewRequestDate = now()
+        state.lastReviewRequestVersion = appVersion()
+        stateStore.save(state)
+        emit("guidance.review.request_invoked", moment: request.moment, tokenID: id)
+    }
+
+    // MARK: - Events
+
+    private func emit(
+        _ name: String,
+        moment: GuidanceValueMoment? = nil,
+        tokenID: UUID? = nil,
+        suppressionReason: GuidanceSuppressionReason? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        var metadata = metadata
+        if let moment {
+            metadata["moment"] = moment.rawValue
+        }
+        if let suppressionReason {
+            metadata["reason"] = suppressionReason.rawValue
+        }
+        if let tokenID {
+            metadata["token"] = String(tokenID.uuidString.prefix(8))
+        }
+        eventSink(
+            GuidanceEvent(
+                name: name,
+                moment: moment,
+                tokenID: tokenID,
+                suppressionReason: suppressionReason,
+                metadata: metadata
+            )
+        )
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceDebug.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceDebug.swift
@@ -17,21 +17,33 @@ enum ProInstallationOverride: String, Equatable, Sendable {
 enum GuidanceDebugOverrides {
     private(set) static var proInstallationOverride: ProInstallationOverride = .useRealDetection
 
-    /// Debug-only staging hook installed by the diagnostics host so the Debug
-    /// menu can render the production result host without running a real
-    /// diagnostic. Memory-only; never persisted.
-    private static var diagnosticsStaging: (() -> Void)?
+    /// Debug-only request flag consumed atomically by the real diagnostics
+    /// host. The Debug menu only sets the flag and navigates; the host that
+    /// is actually on screen consumes it and stages its synthetic result.
+    /// Never holds a reference to a view model or window.
+    private static var pendingDiagnosticsStaging = false
 
     static func setProInstallationOverride(_ override: ProInstallationOverride) {
         proInstallationOverride = override
     }
 
-    static func installDiagnosticsStaging(_ staging: @escaping () -> Void) {
-        diagnosticsStaging = staging
+    static func requestDiagnosticsStaging() {
+        pendingDiagnosticsStaging = true
     }
 
-    static func stageDiagnosticsCompletion() {
-        diagnosticsStaging?()
+    /// Consumed by the real `NetworkDiagnosticsView` host. Returns true at
+    /// most once per request; a fresh window can consume a request that an
+    /// older, closed window never did.
+    static func consumeDiagnosticsStaging() -> Bool {
+        guard pendingDiagnosticsStaging else { return false }
+        pendingDiagnosticsStaging = false
+        return true
+    }
+
+    /// Cleared by `debugResetState()` so a stale request cannot stage into a
+    /// future diagnostics host after a reset.
+    static func clearDiagnosticsStaging() {
+        pendingDiagnosticsStaging = false
     }
 }
 #endif

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceDebug.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceDebug.swift
@@ -1,0 +1,37 @@
+#if DEBUG
+import Foundation
+
+/// Debug-only, in-memory override of the Pro installation detection used by
+/// the OSS invitation flow. Exists only for the current process: never
+/// persisted, never uploaded, never included in Release builds.
+enum ProInstallationOverride: String, Equatable, Sendable {
+    case useRealDetection
+    case treatAsNotInstalled
+    case treatAsInstalled
+}
+
+/// Debug-only holder for lifecycle-guidance manual-testing overrides.
+/// The production installation checker is unchanged; the coordinator's
+/// default detection closure consults this holder only in Debug builds.
+@MainActor
+enum GuidanceDebugOverrides {
+    private(set) static var proInstallationOverride: ProInstallationOverride = .useRealDetection
+
+    /// Debug-only staging hook installed by the diagnostics host so the Debug
+    /// menu can render the production result host without running a real
+    /// diagnostic. Memory-only; never persisted.
+    private static var diagnosticsStaging: (() -> Void)?
+
+    static func setProInstallationOverride(_ override: ProInstallationOverride) {
+        proInstallationOverride = override
+    }
+
+    static func installDiagnosticsStaging(_ staging: @escaping () -> Void) {
+        diagnosticsStaging = staging
+    }
+
+    static func stageDiagnosticsCompletion() {
+        diagnosticsStaging?()
+    }
+}
+#endif

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidancePolicy.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidancePolicy.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Pure eligibility and cooldown decisions. No I/O, no clock (all dates are
+/// injected), no edition knowledge, and no pending-state awareness — the
+/// coordinator applies its own pending gates before consulting the policy.
+enum GuidancePolicy {
+    static func decide(
+        for moment: GuidanceValueMoment,
+        state: GuidanceState,
+        config: GuidanceConfiguration,
+        now: Date,
+        calendar: Calendar,
+        appVersion: String,
+        isProAppInstalled: Bool
+    ) -> GuidanceDecision {
+        switch moment {
+        case .roamingCompleted:
+            // Roaming participates in events and logs in v1, never in policy.
+            return .none(.roamingPolicyNotEnabled)
+        case .analysisLoaded:
+            // Analysis is Pro-exclusive: the invitation path never applies.
+            guard config.reviewEnabled else {
+                return .none(.editionReviewDisabled)
+            }
+            return reviewDecision(
+                state: state,
+                config: config,
+                now: now,
+                calendar: calendar,
+                appVersion: appVersion
+            )
+        case .diagnosticsCompleted, .exportSucceeded:
+            guard config.invitationEnabled else {
+                if config.reviewEnabled {
+                    return reviewDecision(
+                        state: state,
+                        config: config,
+                        now: now,
+                        calendar: calendar,
+                        appVersion: appVersion
+                    )
+                }
+                return .none(.editionInvitationDisabled)
+            }
+            return invitationDecision(
+                state: state,
+                config: config,
+                now: now,
+                calendar: calendar,
+                isProAppInstalled: isProAppInstalled
+            )
+        }
+    }
+
+    private static func invitationDecision(
+        state: GuidanceState,
+        config: GuidanceConfiguration,
+        now: Date,
+        calendar: Calendar,
+        isProAppInstalled: Bool
+    ) -> GuidanceDecision {
+        guard !state.invitationsDisabled else {
+            return .none(.invitationsDisabledByUser)
+        }
+        guard !isProAppInstalled else {
+            return .none(.proAppInstalled)
+        }
+        guard state.meaningfulCompletionCount >= config.minimumInvitationCompletions else {
+            return .none(.completionThresholdNotMet)
+        }
+        guard state.activeDays.count >= config.minimumInvitationActiveDays else {
+            return .none(.activeDaysThresholdNotMet)
+        }
+        if let lastInvitationDate = state.lastInvitationDate,
+           daysSince(lastInvitationDate, now: now, calendar: calendar) < config.invitationCooldownDays {
+            return .none(.invitationCooldown)
+        }
+        guard state.invitationPresentationCount < config.maxAutomaticInvitations else {
+            return .none(.invitationPresentationLimit)
+        }
+        return .showProInvitation
+    }
+
+    private static func reviewDecision(
+        state: GuidanceState,
+        config: GuidanceConfiguration,
+        now: Date,
+        calendar: Calendar,
+        appVersion: String
+    ) -> GuidanceDecision {
+        guard let firstLaunchDate = state.firstLaunchDate,
+              daysSince(firstLaunchDate, now: now, calendar: calendar) >= config.minimumReviewAgeDays else {
+            return .none(.firstLaunchAgeNotMet)
+        }
+        guard state.activeDays.count >= config.minimumReviewActiveDays else {
+            return .none(.activeDaysThresholdNotMet)
+        }
+        guard state.meaningfulCompletionCount >= config.minimumReviewCompletions else {
+            return .none(.completionThresholdNotMet)
+        }
+        guard state.lastReviewRequestVersion != appVersion else {
+            return .none(.reviewAlreadyRequestedForVersion)
+        }
+        if let lastReviewRequestDate = state.lastReviewRequestDate,
+           daysSince(lastReviewRequestDate, now: now, calendar: calendar) < config.reviewCooldownDays {
+            return .none(.reviewCooldown)
+        }
+        return .requestReview
+    }
+
+    /// Whole local days between `date` and `now`, using the injected calendar.
+    /// A cooldown boundary at exactly `cooldownDays` days is eligible because
+    /// the callers compare with `>=` / `<`.
+    private static func daysSince(_ date: Date, now: Date, calendar: Calendar) -> Int {
+        let start = calendar.startOfDay(for: date)
+        let end = calendar.startOfDay(for: now)
+        return calendar.dateComponents([.day], from: start, to: end).day ?? 0
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceState.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceState.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Persisted Issue #17 state. The struct owns its invariants both on live
+/// mutation (`recordActiveDay`) and on restore (the normalized initializer),
+/// so corrupted storage can never violate them.
+struct GuidanceState: Equatable, Sendable {
+    static let maxActiveDayCount = 120
+
+    var firstLaunchDate: Date?
+    private(set) var activeDays: [String]
+    var meaningfulCompletionCount: Int
+    var lastInvitationDate: Date?
+    var invitationPresentationCount: Int
+    var invitationDismissalCount: Int
+    var invitationsDisabled: Bool
+    var lastReviewRequestDate: Date?
+    var lastReviewRequestVersion: String?
+
+    /// Restore/creation initializer. Normalizes `activeDays` (filter invalid
+    /// keys, dedupe, sort, cap at `maxActiveDayCount`) so persisted or damaged
+    /// data can never violate the state invariants.
+    init(
+        firstLaunchDate: Date? = nil,
+        activeDays: [String] = [],
+        meaningfulCompletionCount: Int = 0,
+        lastInvitationDate: Date? = nil,
+        invitationPresentationCount: Int = 0,
+        invitationDismissalCount: Int = 0,
+        invitationsDisabled: Bool = false,
+        lastReviewRequestDate: Date? = nil,
+        lastReviewRequestVersion: String? = nil
+    ) {
+        self.firstLaunchDate = firstLaunchDate
+        self.activeDays = Self.normalizedActiveDays(activeDays)
+        self.meaningfulCompletionCount = meaningfulCompletionCount
+        self.lastInvitationDate = lastInvitationDate
+        self.invitationPresentationCount = invitationPresentationCount
+        self.invitationDismissalCount = invitationDismissalCount
+        self.invitationsDisabled = invitationsDisabled
+        self.lastReviewRequestDate = lastReviewRequestDate
+        self.lastReviewRequestVersion = lastReviewRequestVersion
+    }
+
+    /// Records a distinct local calendar day with the injected calendar.
+    /// Appends, deduplicates, sorts, and truncates to `maxActiveDayCount`.
+    mutating func recordActiveDay(at date: Date, calendar: Calendar) {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        guard let year = components.year, let month = components.month, let day = components.day else {
+            return
+        }
+        let key = String(format: "%04d-%02d-%02d", year, month, day)
+        if !activeDays.contains(key) {
+            activeDays.append(key)
+            activeDays.sort()
+        }
+        if activeDays.count > Self.maxActiveDayCount {
+            activeDays.removeFirst(activeDays.count - Self.maxActiveDayCount)
+        }
+    }
+
+    /// Returns true when `key` matches `YYYY-MM-DD` and forms a real Gregorian
+    /// calendar date. The round-trip check rejects impossible dates such as
+    /// `2026-02-30` and `2026-13-01`.
+    static func isValidDayKey(_ key: String) -> Bool {
+        guard key.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil else {
+            return false
+        }
+        let parts = key.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else {
+            return false
+        }
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
+        var components = DateComponents()
+        components.year = parts[0]
+        components.month = parts[1]
+        components.day = parts[2]
+        guard let date = gregorian.date(from: components) else {
+            return false
+        }
+        let roundTrip = gregorian.dateComponents([.year, .month, .day], from: date)
+        return roundTrip.year == parts[0] && roundTrip.month == parts[1] && roundTrip.day == parts[2]
+    }
+
+    private static func normalizedActiveDays(_ keys: [String]) -> [String] {
+        let unique = Array(Set(keys.filter(isValidDayKey))).sorted()
+        if unique.count > maxActiveDayCount {
+            return Array(unique.suffix(maxActiveDayCount))
+        }
+        return unique
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceState.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Persisted Issue #17 state. The struct owns its invariants both on live
+/// Persisted lifecycle-guidance state. The struct owns its invariants both on live
 /// mutation (`recordActiveDay`) and on restore (the normalized initializer),
 /// so corrupted storage can never violate them.
 struct GuidanceState: Equatable, Sendable {

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceStateStore.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceStateStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Serialization boundary for `GuidanceState`. The coordinator serializes all
+/// access on the main actor, so no `Sendable` requirements are needed.
+@MainActor
+protocol GuidanceStateStoring {
+    func load() -> GuidanceState
+    func save(_ state: GuidanceState)
+}
+
+/// `UserDefaults`-backed store. Stays a struct — it writes through the
+/// external `UserDefaults` instance.
+struct UserDefaultsGuidanceStateStore: GuidanceStateStoring {
+    private enum Key {
+        static let firstLaunchDate = "guidance.firstLaunchDate"
+        static let activeDays = "guidance.activeDays"
+        static let completionCount = "guidance.completionCount"
+        static let lastInvitationDate = "guidance.lastInvitationDate"
+        static let invitationPresentationCount = "guidance.invitationPresentationCount"
+        static let invitationDismissalCount = "guidance.invitationDismissalCount"
+        static let invitationsDisabled = "guidance.invitationsDisabled"
+        static let lastReviewRequestDate = "guidance.lastReviewRequestDate"
+        static let lastReviewRequestVersion = "guidance.lastReviewRequestVersion"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> GuidanceState {
+        GuidanceState(
+            firstLaunchDate: defaults.object(forKey: Key.firstLaunchDate) as? Date,
+            activeDays: defaults.stringArray(forKey: Key.activeDays) ?? [],
+            meaningfulCompletionCount: defaults.integer(forKey: Key.completionCount),
+            lastInvitationDate: defaults.object(forKey: Key.lastInvitationDate) as? Date,
+            invitationPresentationCount: defaults.integer(forKey: Key.invitationPresentationCount),
+            invitationDismissalCount: defaults.integer(forKey: Key.invitationDismissalCount),
+            invitationsDisabled: defaults.bool(forKey: Key.invitationsDisabled),
+            lastReviewRequestDate: defaults.object(forKey: Key.lastReviewRequestDate) as? Date,
+            lastReviewRequestVersion: defaults.string(forKey: Key.lastReviewRequestVersion)
+        )
+    }
+
+    func save(_ state: GuidanceState) {
+        defaults.set(state.firstLaunchDate, forKey: Key.firstLaunchDate)
+        defaults.set(state.activeDays, forKey: Key.activeDays)
+        defaults.set(state.meaningfulCompletionCount, forKey: Key.completionCount)
+        defaults.set(state.lastInvitationDate, forKey: Key.lastInvitationDate)
+        defaults.set(state.invitationPresentationCount, forKey: Key.invitationPresentationCount)
+        defaults.set(state.invitationDismissalCount, forKey: Key.invitationDismissalCount)
+        defaults.set(state.invitationsDisabled, forKey: Key.invitationsDisabled)
+        defaults.set(state.lastReviewRequestDate, forKey: Key.lastReviewRequestDate)
+        defaults.set(state.lastReviewRequestVersion, forKey: Key.lastReviewRequestVersion)
+    }
+}
+
+/// In-memory store for tests and previews. A `final class` because its
+/// non-mutating `save` must replace stored state; a struct cannot do that.
+@MainActor
+final class InMemoryGuidanceStateStore: GuidanceStateStoring {
+    private var state: GuidanceState
+
+    init(initial: GuidanceState = GuidanceState()) {
+        self.state = initial
+    }
+
+    func load() -> GuidanceState {
+        state
+    }
+
+    func save(_ state: GuidanceState) {
+        self.state = state
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Guidance/ProInvitationCard.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/ProInvitationCard.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+
+/// Non-modal OSS→Pro invitation card. A dumb presentation component: the host
+/// resolves the pending invitation by moment and passes it in; the card never
+/// queries the coordinator's `pendingInvitation` and never filters moments
+/// itself. Every action routes through the invitation's `id`.
+struct ProInvitationCard: View {
+    let invitation: GuidanceCoordinator.InvitationPresentation
+    let guidance: GuidanceCoordinator
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label {
+                Text(String(localized: "guidance.invitation.title", comment: "Invitation card title"))
+                    .font(.headline)
+            } icon: {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            Text(
+                String(
+                    localized: .init(stringLiteral: Self.messageKey(for: invitation.moment)),
+                    comment: "Invitation card body message"
+                )
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Button {
+                    openAppStore()
+                } label: {
+                    Text(String(localized: "guidance.invitation.view_pro", comment: "Open the Pro product page in the App Store"))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("guidance-invitation-view-pro")
+
+                Button {
+                    guidance.dismissInvitation(id: invitation.id)
+                } label: {
+                    Text(String(localized: "guidance.invitation.later", comment: "Dismiss the invitation for now"))
+                }
+                .accessibilityIdentifier("guidance-invitation-later")
+
+                Button {
+                    guidance.disableInvitations(id: invitation.id)
+                } label: {
+                    Text(String(localized: "guidance.invitation.dont_show_again", comment: "Disable future invitations"))
+                }
+                .accessibilityIdentifier("guidance-invitation-dont-show-again")
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.accentColor.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+        .onAppear { guidance.invitationPresented(id: invitation.id) }
+    }
+
+    private func openAppStore() {
+        guard let url = guidance.appStoreCampaignURL,
+              NSWorkspace.shared.open(url) else {
+            return
+        }
+        guidance.openInvitation(id: invitation.id)
+    }
+
+    /// Testable copy selection. The card renders copy for whatever moment it is
+    /// given; analysis and roaming never produce invitations in v1, so they
+    /// fall back to the diagnostics copy (unreachable through the policy).
+    static func messageKey(for moment: GuidanceValueMoment) -> String {
+        switch moment {
+        case .diagnosticsCompleted:
+            "guidance.invitation.message.diagnostics"
+        case .exportSucceeded:
+            "guidance.invitation.message.export"
+        case .analysisLoaded, .roamingCompleted:
+            "guidance.invitation.message.diagnostics"
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -35,6 +35,16 @@ struct NetworkDiagnosticsView: View {
             }
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.24), value: viewModel.phase)
+#if DEBUG
+        // Debug-only: the current, real host consumes the one-shot staging
+        // request set by the Debug menu, so a closed old window can never
+        // stage into a stale view model.
+        .onAppear {
+            if GuidanceDebugOverrides.consumeDiagnosticsStaging() {
+                viewModel.debugStageCompletedResult()
+            }
+        }
+#endif
         .onDisappear {
             viewModel.cancel()
             if let id = renderedInvitationID {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 struct NetworkDiagnosticsView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var viewModel: NetworkDiagnosticsViewModel
+    let guidance: GuidanceCoordinator = .shared
     @State private var expandedGroupOverride: [String: Bool] = [:]
+    @State private var renderedInvitationID: UUID?
 
     var body: some View {
         GeometryReader { geometry in
@@ -19,6 +21,12 @@ struct NetworkDiagnosticsView: View {
                 } else if let conclusion = viewModel.conclusion {
                     conclusionStrip(conclusion)
                     Divider()
+                    if let invitation = guidance.pendingInvitation,
+                       invitation.moment == .diagnosticsCompleted {
+                        ProInvitationCard(invitation: invitation, guidance: guidance)
+                            .padding(.horizontal)
+                            .onAppear { renderedInvitationID = invitation.id }
+                    }
                 }
 
                 workspace(layoutMode)
@@ -26,7 +34,13 @@ struct NetworkDiagnosticsView: View {
             }
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.24), value: viewModel.phase)
-        .onDisappear { viewModel.cancel() }
+        .onDisappear {
+            viewModel.cancel()
+            if let id = renderedInvitationID {
+                guidance.endInvitationPresentation(id: id)
+                renderedInvitationID = nil
+            }
+        }
     }
 
     private var commandBar: some View {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -24,7 +24,8 @@ struct NetworkDiagnosticsView: View {
                     if let invitation = guidance.pendingInvitation,
                        invitation.moment == .diagnosticsCompleted {
                         ProInvitationCard(invitation: invitation, guidance: guidance)
-                            .padding(.horizontal)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 12)
                             .onAppear { renderedInvitationID = invitation.id }
                     }
                 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -133,6 +133,7 @@ final class NetworkDiagnosticsViewModel {
     @ObservationIgnored private let checks: [any DiagnosticCheck]
     @ObservationIgnored private let minimumStepDuration: Duration
     @ObservationIgnored private let fingerprintMonitor: any NetworkFingerprintMonitoring
+    @ObservationIgnored private let guidance: GuidanceCoordinator
     @ObservationIgnored private var activeTask: Task<Void, Never>?
 
     init(checks: [any DiagnosticCheck] = [
@@ -144,11 +145,13 @@ final class NetworkDiagnosticsViewModel {
         SystemProxyCheck(),
     ],
     minimumStepDuration: Duration = NetworkDiagnosticsViewModel.defaultMinimumStepDuration,
-    fingerprintMonitor: any NetworkFingerprintMonitoring = SystemNetworkFingerprintMonitor()
+    fingerprintMonitor: any NetworkFingerprintMonitoring = SystemNetworkFingerprintMonitor(),
+    guidance: GuidanceCoordinator = .shared
     ) {
         self.checks = checks
         self.minimumStepDuration = minimumStepDuration
         self.fingerprintMonitor = fingerprintMonitor
+        self.guidance = guidance
         self.checkIDs = checks.map(\.id)
         self.executionPhases = Dictionary(
             uniqueKeysWithValues: checks.map { ($0.id, .waiting) }
@@ -288,6 +291,7 @@ final class NetworkDiagnosticsViewModel {
         }
         self.conclusion = conclusion
         phase = .completed
+        guidance.record(.diagnosticsCompleted)
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -342,3 +342,28 @@ actor NetworkDiagnosticRestartController {
         currentRun = nil
     }
 }
+
+#if DEBUG
+extension NetworkDiagnosticsViewModel {
+    /// Debug-only: publishes a synthetic completed result so the real
+    /// diagnostics host renders its production conclusion strip and the
+    /// production invitation card, without running a real diagnostic. Never
+    /// writes Timeline, diagnostic history, or user data; the production
+    /// `record(.diagnosticsCompleted)` path is not invoked (Debug triggers
+    /// schedule invitations explicitly).
+    func debugStageCompletedResult() {
+        activeTask?.cancel()
+        activeTask = nil
+        let staged = checkIDs.map { id in
+            NetworkDiagnosticResult(id: id, status: .normal, summary: "Debug staged result")
+        }
+        results = Dictionary(uniqueKeysWithValues: staged.map { ($0.id, $0) })
+        executionPhases = Dictionary(uniqueKeysWithValues: staged.map { ($0.id, .completed) })
+        conclusion = NetworkDiagnosticConclusion.evaluate(
+            staged,
+            requiredIDs: Set(checkIDs)
+        )
+        phase = .completed
+    }
+}
+#endif

--- a/WiFiLens/Sources/WiFiLens/Onboarding/ExistingInstallationDetector.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/ExistingInstallationDetector.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Decides whether the current device already had a WiFi Lens install before
+/// the first-run onboarding feature shipped. Pure evidence check; the
+/// onboarding coordinator turns the answer into a one-time migration.
+protocol ExistingInstallationDetecting {
+    func hasExistingInstallationEvidence() -> Bool
+}
+
+/// Uses Sparkle's automatic-check key, which every build since May 2026
+/// writes on first launch. The migration must run before `SparkleUpdater`
+/// initializes, otherwise a brand-new install would already carry the key and
+/// the welcome would never show for clean installs.
+struct SparkleAutomaticCheckExistingInstallationDetector: ExistingInstallationDetecting {
+    static let defaultsKey = "SUEnableAutomaticChecks"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func hasExistingInstallationEvidence() -> Bool {
+        defaults.object(forKey: Self.defaultsKey) != nil
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/ExistingInstallationDetector.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/ExistingInstallationDetector.swift
@@ -7,6 +7,15 @@ protocol ExistingInstallationDetecting {
     func hasExistingInstallationEvidence() -> Bool
 }
 
+/// Edition with no reliable pre-onboarding install marker. The migration
+/// still writes a `false` result on first launch, but never marks anyone
+/// completed based on a foreign marker (e.g. Sparkle, which is OSS-only).
+struct NoExistingInstallationDetector: ExistingInstallationDetecting {
+    func hasExistingInstallationEvidence() -> Bool {
+        false
+    }
+}
+
 /// Uses Sparkle's automatic-check key, which every build since May 2026
 /// writes on first launch. The migration must run before `SparkleUpdater`
 /// initializes, otherwise a brand-new install would already carry the key and

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingConfiguration.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingConfiguration.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Edition-provided onboarding tuning. The shared welcome view reads only
+/// this configuration — it never checks bundle identifiers, target names,
+/// Pro files, StoreKit, or receipts.
+struct OnboardingConfiguration: Equatable, Sendable {
+    var welcomeEnabled: Bool
+    var showsProLink: Bool
+    var proURL: URL?
+    var startRoute: SidebarPage?
+
+    static let disabled = OnboardingConfiguration(
+        welcomeEnabled: false,
+        showsProLink: false,
+        proURL: nil,
+        startRoute: nil
+    )
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingConfiguration.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingConfiguration.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// One short first-run highlight shown in the welcome sheet. Keeps the card
+/// visually balanced without turning onboarding into a feature tour.
+struct OnboardingHighlight: Equatable, Sendable {
+    var icon: String
+    var titleKey: String
+}
+
 /// Edition-provided onboarding tuning. The shared welcome view reads only
 /// this configuration — it never checks bundle identifiers, target names,
 /// Pro files, StoreKit, or receipts.
@@ -8,11 +15,17 @@ struct OnboardingConfiguration: Equatable, Sendable {
     var showsProLink: Bool
     var proURL: URL?
     var startRoute: SidebarPage?
+    var startToolbarSelection: SecondaryToolbarItemID?
+    var primaryActionKey: String
+    var highlights: [OnboardingHighlight]
 
     static let disabled = OnboardingConfiguration(
         welcomeEnabled: false,
         showsProLink: false,
         proURL: nil,
-        startRoute: nil
+        startRoute: nil,
+        startToolbarSelection: nil,
+        primaryActionKey: "onboarding.welcome.start",
+        highlights: []
     )
 }

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingCoordinator.swift
@@ -11,7 +11,8 @@ import Observation
 final class OnboardingCoordinator {
     static let shared = OnboardingCoordinator(
         store: UserDefaultsOnboardingStateStore(),
-        existingInstallationDetector: SparkleAutomaticCheckExistingInstallationDetector()
+        existingInstallationDetector: EditionComposition.makeOnboardingExistingInstallationDetector(),
+        welcomeEnabled: EditionComposition.onboardingConfiguration.welcomeEnabled
     )
 
     /// The main window currently hosting the welcome, if any. Process-memory
@@ -25,13 +26,16 @@ final class OnboardingCoordinator {
 
     private let store: any OnboardingStateStoring
     private let existingInstallationDetector: any ExistingInstallationDetecting
+    private let welcomeEnabled: Bool
 
     init(
         store: any OnboardingStateStoring,
-        existingInstallationDetector: any ExistingInstallationDetecting
+        existingInstallationDetector: any ExistingInstallationDetecting,
+        welcomeEnabled: Bool = true
     ) {
         self.store = store
         self.existingInstallationDetector = existingInstallationDetector
+        self.welcomeEnabled = welcomeEnabled
     }
 
     var hasCompletedWelcome: Bool {
@@ -40,18 +44,17 @@ final class OnboardingCoordinator {
 
     // MARK: - Existing-install migration
 
-    /// One-time migration: when the onboarding key is absent but a reliable
-    /// pre-onboarding install marker exists, existing users are marked
-    /// completed so they never see the welcome. Must run before
-    /// `SparkleUpdater` initializes (see
-    /// `SparkleAutomaticCheckExistingInstallationDetector`).
+    /// One-time migration that only runs while the onboarding key is absent,
+    /// and always writes a result: `true` for a detected existing install,
+    /// `false` for a clean install. Writing the key on the first launch
+    /// permanently locks the classification, so a marker that appears later
+    /// (e.g. Sparkle writing `SUEnableAutomaticChecks` after first launch)
+    /// can never re-migrate an incomplete clean install into "completed".
     func migrateExistingInstallationIfNeeded() {
-        let state = store.load()
-        guard !state.hasCompletedWelcome else { return }
-        guard existingInstallationDetector.hasExistingInstallationEvidence() else { return }
-        var migrated = state
-        migrated.hasCompletedWelcome = true
-        store.save(migrated)
+        guard !store.hasStoredState() else { return }
+        store.save(OnboardingState(
+            hasCompletedWelcome: existingInstallationDetector.hasExistingInstallationEvidence()
+        ))
     }
 
     // MARK: - Host claim (multi-window exclusivity)
@@ -60,6 +63,7 @@ final class OnboardingCoordinator {
     /// a later host is refused until the current host releases or completes.
     @discardableResult
     func claimWelcome(hostID: UUID) -> Bool {
+        guard welcomeEnabled else { return false }
         guard !hasCompletedWelcome else { return false }
         guard welcomeHostID == nil || welcomeHostID == hostID else { return false }
         welcomeHostID = hostID
@@ -121,6 +125,7 @@ final class OnboardingCoordinator {
     /// The actual sheet still goes through the real host claim and the real
     /// `WelcomeView`; the first visible main window consumes the request.
     func debugRequestShowWelcome() {
+        guard welcomeEnabled else { return }
         store.save(OnboardingState())
         welcomeHostID = nil
         debugShowRequested = true

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingCoordinator.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Logging
+import Observation
+
+/// Process-wide owner of first-run welcome state. Manages the persisted
+/// completion flag, the one-time existing-install migration, and the
+/// single-host presentation claim so at most one main window can show the
+/// welcome at a time. Never touches `GuidanceState`, `GuidanceCoordinator`,
+/// Timeline, or any permission API.
+@MainActor @Observable
+final class OnboardingCoordinator {
+    static let shared = OnboardingCoordinator(
+        store: UserDefaultsOnboardingStateStore(),
+        existingInstallationDetector: SparkleAutomaticCheckExistingInstallationDetector()
+    )
+
+    /// The main window currently hosting the welcome, if any. Process-memory
+    /// only; never persisted.
+    private(set) var welcomeHostID: UUID?
+
+    /// Debug-only force-show request. Process-memory only.
+    #if DEBUG
+    private(set) var debugShowRequested = false
+    #endif
+
+    private let store: any OnboardingStateStoring
+    private let existingInstallationDetector: any ExistingInstallationDetecting
+
+    init(
+        store: any OnboardingStateStoring,
+        existingInstallationDetector: any ExistingInstallationDetecting
+    ) {
+        self.store = store
+        self.existingInstallationDetector = existingInstallationDetector
+    }
+
+    var hasCompletedWelcome: Bool {
+        store.load().hasCompletedWelcome
+    }
+
+    // MARK: - Existing-install migration
+
+    /// One-time migration: when the onboarding key is absent but a reliable
+    /// pre-onboarding install marker exists, existing users are marked
+    /// completed so they never see the welcome. Must run before
+    /// `SparkleUpdater` initializes (see
+    /// `SparkleAutomaticCheckExistingInstallationDetector`).
+    func migrateExistingInstallationIfNeeded() {
+        let state = store.load()
+        guard !state.hasCompletedWelcome else { return }
+        guard existingInstallationDetector.hasExistingInstallationEvidence() else { return }
+        var migrated = state
+        migrated.hasCompletedWelcome = true
+        store.save(migrated)
+    }
+
+    // MARK: - Host claim (multi-window exclusivity)
+
+    /// A host window claims the welcome. Only one host succeeds at a time;
+    /// a later host is refused until the current host releases or completes.
+    @discardableResult
+    func claimWelcome(hostID: UUID) -> Bool {
+        guard !hasCompletedWelcome else { return false }
+        guard welcomeHostID == nil || welcomeHostID == hostID else { return false }
+        welcomeHostID = hostID
+        return true
+    }
+
+    /// Host disappeared without any explicit user action. Does not mark
+    /// completion; a later host may claim again.
+    func releaseWelcome(hostID: UUID) {
+        guard welcomeHostID == hostID else { return }
+        welcomeHostID = nil
+    }
+
+    // MARK: - Completion
+
+    /// `Start Analyzing`: marks complete and returns the route to navigate
+    /// to exactly once.
+    func completeWelcomeStart(hostID: UUID, startRoute: SidebarPage?) -> SidebarPage? {
+        guard welcomeHostID == hostID else { return nil }
+        markCompleted()
+        return startRoute
+    }
+
+    /// `Skip` or the explicit close button: marks complete without routing.
+    func completeWelcomeWithoutRouting(hostID: UUID) {
+        guard welcomeHostID == hostID else { return }
+        markCompleted()
+    }
+
+    /// OSS `Learn about WiFi Lens Pro`: completes only when the system
+    /// accepted opening the campaign URL. On failure the welcome stays up
+    /// and nothing is persisted.
+    func completeWelcomeAfterOpeningProURL(hostID: UUID, openedSuccessfully: Bool) {
+        guard welcomeHostID == hostID else { return }
+        guard openedSuccessfully else { return }
+        markCompleted()
+    }
+
+    private func markCompleted() {
+        var state = store.load()
+        state.hasCompletedWelcome = true
+        store.save(state)
+        welcomeHostID = nil
+    }
+
+    // MARK: - Debug-only manual test entry points
+
+    #if DEBUG
+    /// Clears only onboarding state: the completion flag, any in-memory host
+    /// claim, and any force-show request. Never touches guidance, Timeline,
+    /// or user settings.
+    func debugReset() {
+        store.save(OnboardingState())
+        welcomeHostID = nil
+        debugShowRequested = false
+    }
+
+    /// Requests the welcome regardless of completion or clean-install state.
+    /// The actual sheet still goes through the real host claim and the real
+    /// `WelcomeView`; the first visible main window consumes the request.
+    func debugRequestShowWelcome() {
+        store.save(OnboardingState())
+        welcomeHostID = nil
+        debugShowRequested = true
+    }
+
+    func consumeDebugShowRequest() -> Bool {
+        guard debugShowRequested else { return false }
+        debugShowRequested = false
+        return true
+    }
+
+    /// Emits a sanitized state summary. No UUIDs, tokens, SSIDs, URLs, or
+    /// user identity.
+    func debugLogState(edition: String) {
+        let state = store.load()
+        let hasHost = welcomeHostID != nil
+        let hasExistingInstallation = existingInstallationDetector.hasExistingInstallationEvidence()
+        var metadata = Logging.Logger.Metadata()
+        metadata["edition"] = .string(edition)
+        metadata["completed"] = .string(String(state.hasCompletedWelcome))
+        metadata["pending"] = .string(String(hasHost))
+        metadata["hasHost"] = .string(String(hasHost))
+        metadata["existingInstallation"] = .string(String(hasExistingInstallation))
+        AppLogger.guidance.info("onboarding.debug.state_summary", metadata: metadata)
+    }
+    #endif
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingState.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingState.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Persisted first-run onboarding state. Independent from `GuidanceState`:
+/// onboarding never records value moments, invitation/review counts, or any
+/// lifecycle-guidance field.
+struct OnboardingState: Equatable, Sendable {
+    var hasCompletedWelcome: Bool
+
+    init(hasCompletedWelcome: Bool = false) {
+        self.hasCompletedWelcome = hasCompletedWelcome
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingStateStore.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingStateStore.swift
@@ -6,6 +6,12 @@ import Foundation
 @MainActor
 protocol OnboardingStateStoring {
     func load() -> OnboardingState
+
+    /// Whether a value for the onboarding key exists. Distinguishes "never
+    /// migrated / key absent" from "key present with `false`", which matters
+    /// for the one-time existing-install migration.
+    func hasStoredState() -> Bool
+
     func save(_ state: OnboardingState)
 }
 
@@ -28,6 +34,10 @@ struct UserDefaultsOnboardingStateStore: OnboardingStateStoring {
         )
     }
 
+    func hasStoredState() -> Bool {
+        defaults.object(forKey: Key.welcomeCompleted) != nil
+    }
+
     func save(_ state: OnboardingState) {
         defaults.set(state.hasCompletedWelcome, forKey: Key.welcomeCompleted)
     }
@@ -37,16 +47,23 @@ struct UserDefaultsOnboardingStateStore: OnboardingStateStoring {
 @MainActor
 final class InMemoryOnboardingStateStore: OnboardingStateStoring {
     private var state: OnboardingState
+    private var stored: Bool
 
-    init(initial: OnboardingState = OnboardingState()) {
+    init(initial: OnboardingState = OnboardingState(), hasStoredState: Bool = false) {
         self.state = initial
+        self.stored = hasStoredState
     }
 
     func load() -> OnboardingState {
         state
     }
 
+    func hasStoredState() -> Bool {
+        stored
+    }
+
     func save(_ state: OnboardingState) {
         self.state = state
+        stored = true
     }
 }

--- a/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingStateStore.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/OnboardingStateStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Serialization boundary for `OnboardingState`. Mirrors the guidance store:
+/// the coordinator serializes access on the main actor, so the protocol needs
+/// no `Sendable` requirement.
+@MainActor
+protocol OnboardingStateStoring {
+    func load() -> OnboardingState
+    func save(_ state: OnboardingState)
+}
+
+/// `UserDefaults`-backed onboarding store. Uses a versioned key so a future
+/// intentional `v2` onboarding can ship without breaking `v1` semantics.
+struct UserDefaultsOnboardingStateStore: OnboardingStateStoring {
+    private enum Key {
+        static let welcomeCompleted = "onboarding.welcome.completed.v1"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> OnboardingState {
+        OnboardingState(
+            hasCompletedWelcome: defaults.bool(forKey: Key.welcomeCompleted)
+        )
+    }
+
+    func save(_ state: OnboardingState) {
+        defaults.set(state.hasCompletedWelcome, forKey: Key.welcomeCompleted)
+    }
+}
+
+/// In-memory store for tests and previews.
+@MainActor
+final class InMemoryOnboardingStateStore: OnboardingStateStoring {
+    private var state: OnboardingState
+
+    init(initial: OnboardingState = OnboardingState()) {
+        self.state = initial
+    }
+
+    func load() -> OnboardingState {
+        state
+    }
+
+    func save(_ state: OnboardingState) {
+        self.state = state
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/WelcomeView.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/WelcomeView.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+/// First-run welcome sheet. A dumb presentation component: it receives the
+/// edition configuration and the claiming host id, and every action routes
+/// through `OnboardingCoordinator`. It never checks bundle identifiers,
+/// StoreKit, or receipts, and it never calls any permission API.
+struct WelcomeView: View {
+    let configuration: OnboardingConfiguration
+    let coordinator: OnboardingCoordinator
+    let hostID: UUID
+    var onStart: (SidebarPage) -> Void = { _ in }
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(String(localized: "onboarding.welcome.title", comment: "First-run welcome sheet title"))
+                        .font(.title2.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
+
+                    Text(String(localized: "onboarding.welcome.body", comment: "First-run welcome sheet body"))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Button {
+                    coordinator.completeWelcomeWithoutRouting(hostID: hostID)
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.body.weight(.semibold))
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(String(localized: "onboarding.welcome.close", comment: "Close first-run welcome sheet"))
+                .keyboardShortcut(.cancelAction)
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Button {
+                    startAnalyzing()
+                } label: {
+                    Label {
+                        Text(String(localized: "onboarding.welcome.start", comment: "Primary first-run welcome action"))
+                    } icon: {
+                        Image(systemName: "chart.bar.xaxis")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("onboarding-start-analyzing")
+
+                if configuration.showsProLink, let proURL = configuration.proURL {
+                    Button {
+                        learnAboutPro(proURL)
+                    } label: {
+                        Text(String(localized: "onboarding.welcome.learn_pro", comment: "OSS secondary first-run welcome action"))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .accessibilityIdentifier("onboarding-learn-pro")
+                }
+
+                Button {
+                    coordinator.completeWelcomeWithoutRouting(hostID: hostID)
+                    dismiss()
+                } label: {
+                    Text(String(localized: "onboarding.welcome.skip", comment: "Skip first-run welcome action"))
+                        .frame(maxWidth: .infinity)
+                }
+                .accessibilityIdentifier("onboarding-skip")
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+    }
+
+    private func startAnalyzing() {
+        let route = configuration.startRoute ?? .overview
+        if let resolved = coordinator.completeWelcomeStart(hostID: hostID, startRoute: route) {
+            onStart(resolved)
+        }
+        dismiss()
+    }
+
+    private func learnAboutPro(_ url: URL) {
+        guard NSWorkspace.shared.open(url) else {
+            // Keep the welcome visible and do not mark completion.
+            AppLogger.guidance.error("onboarding pro link open failed")
+            return
+        }
+        coordinator.completeWelcomeAfterOpeningProURL(hostID: hostID, openedSuccessfully: true)
+        dismiss()
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Onboarding/WelcomeView.swift
+++ b/WiFiLens/Sources/WiFiLens/Onboarding/WelcomeView.swift
@@ -9,81 +9,150 @@ struct WelcomeView: View {
     let configuration: OnboardingConfiguration
     let coordinator: OnboardingCoordinator
     let hostID: UUID
-    var onStart: (SidebarPage) -> Void = { _ in }
+    var onStart: (SidebarPage, SecondaryToolbarItemID?) -> Void = { _, _ in }
 
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(String(localized: "onboarding.welcome.title", comment: "First-run welcome sheet title"))
-                        .font(.title2.weight(.semibold))
-                        .accessibilityAddTraits(.isHeader)
-
-                    Text(String(localized: "onboarding.welcome.body", comment: "First-run welcome sheet body"))
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 12)
-
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
                 Button {
                     coordinator.completeWelcomeWithoutRouting(hostID: hostID)
                     dismiss()
                 } label: {
                     Image(systemName: "xmark")
                         .font(.body.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel(String(localized: "onboarding.welcome.close", comment: "Close first-run welcome sheet"))
                 .keyboardShortcut(.cancelAction)
             }
 
-            VStack(alignment: .leading, spacing: 10) {
+            appIcon
+                .padding(.top, 2)
+
+            Text(String(localized: "onboarding.welcome.title", comment: "First-run welcome sheet title"))
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .accessibilityAddTraits(.isHeader)
+                .padding(.top, 16)
+
+            Text(String(localized: "onboarding.welcome.body", comment: "First-run welcome sheet body"))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 300)
+                .padding(.top, 6)
+
+            if !configuration.highlights.isEmpty {
+                highlightsList
+                    .padding(.top, 20)
+            }
+
+            Button {
+                startAnalyzing()
+            } label: {
+                Label {
+                    Text(
+                        String(
+                            localized: .init(stringLiteral: configuration.primaryActionKey),
+                            comment: "Primary first-run welcome action"
+                        )
+                    )
+                } icon: {
+                    Image(systemName: "play.fill")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("onboarding-start-analyzing")
+            .padding(.top, 20)
+
+            if configuration.showsProLink, let proURL = configuration.proURL {
                 Button {
-                    startAnalyzing()
+                    learnAboutPro(proURL)
                 } label: {
                     Label {
-                        Text(String(localized: "onboarding.welcome.start", comment: "Primary first-run welcome action"))
+                        Text(String(localized: "onboarding.welcome.learn_pro", comment: "OSS secondary first-run welcome action"))
                     } icon: {
-                        Image(systemName: "chart.bar.xaxis")
+                        Image(systemName: "arrow.up.right")
+                            .font(.caption.weight(.semibold))
                     }
                     .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("onboarding-start-analyzing")
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("onboarding-learn-pro")
+                .padding(.top, 12)
+            }
 
-                if configuration.showsProLink, let proURL = configuration.proURL {
-                    Button {
-                        learnAboutPro(proURL)
-                    } label: {
-                        Text(String(localized: "onboarding.welcome.learn_pro", comment: "OSS secondary first-run welcome action"))
-                            .frame(maxWidth: .infinity)
-                    }
-                    .accessibilityIdentifier("onboarding-learn-pro")
-                }
+            Button {
+                coordinator.completeWelcomeWithoutRouting(hostID: hostID)
+                dismiss()
+            } label: {
+                Text(String(localized: "onboarding.welcome.skip", comment: "Skip first-run welcome action"))
+                    .font(.callout)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier("onboarding-skip")
+            .padding(.top, 14)
+        }
+        .padding(22)
+        .frame(width: 400)
+    }
 
-                Button {
-                    coordinator.completeWelcomeWithoutRouting(hostID: hostID)
-                    dismiss()
-                } label: {
-                    Text(String(localized: "onboarding.welcome.skip", comment: "Skip first-run welcome action"))
-                        .frame(maxWidth: .infinity)
-                }
-                .accessibilityIdentifier("onboarding-skip")
+    private var appIcon: some View {
+        Group {
+            if let icon = NSImage(named: "AppIcon") {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 76, height: 76)
+            } else {
+                // Fallback only when the asset catalog icon is unavailable.
+                Image(systemName: "wifi")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 76, height: 76)
             }
         }
-        .padding(20)
-        .frame(width: 380)
+        .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
+        .accessibilityHidden(true)
+    }
+
+    private var highlightsList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(configuration.highlights, id: \.titleKey) { highlight in
+                Label {
+                    Text(
+                        String(
+                            localized: .init(stringLiteral: highlight.titleKey),
+                            comment: "First-run welcome feature highlight"
+                        )
+                    )
+                    .font(.callout)
+                } icon: {
+                    Image(systemName: highlight.icon)
+                        .font(.body)
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 22)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(Color.accentColor.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
     }
 
     private func startAnalyzing() {
         let route = configuration.startRoute ?? .overview
         if let resolved = coordinator.completeWelcomeStart(hostID: hostID, startRoute: route) {
-            onStart(resolved)
+            onStart(resolved, configuration.startToolbarSelection)
         }
         dismiss()
     }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -2,61 +2,6 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
-    "guidance.invitation.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Explore WiFi Lens Pro"
-          }
-        }
-      }
-    },
-    "guidance.invitation.message.diagnostics": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
-          }
-        }
-      }
-    },
-    "guidance.invitation.view_pro": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View WiFi Lens Pro"
-          }
-        }
-      }
-    },
-    "guidance.invitation.later": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Later"
-          }
-        }
-      }
-    },
-    "guidance.invitation.dont_show_again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do not show again"
-          }
-        }
-      }
-    },
     " · %@": {
       "shouldTranslate": false
     },
@@ -222,6 +167,321 @@
     },
     "WiFi Lens": {
       "shouldTranslate": false
+    },
+    "analysis.insight.limitation.ambiguous_normal_behavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal behavior cannot be ruled out"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normales Verhalten kann nicht ausgeschlossen werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede descartar un comportamiento normal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正常な動作を除外できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法排除正常行为"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.coverage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura no disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖率不可用"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.cross_network_evidence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence spans networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege erstrecken sich über mehrere Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La evidencia abarca varias redes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンスが複数ネットワークにわたります"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据跨多个网络"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.incomplete_coverage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage incomplete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura incompleta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジが不完全です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖率不完整"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_bssid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el BSSID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 BSSID"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_gateway_identity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway identity missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Identität fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta la identidad de la puerta de enlace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ ID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少网关标识"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_ssid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el SSID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 SSID"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.session_boundary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence crosses a session boundary"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege überschreiten eine Sitzungsgrenze"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La evidencia cruza un límite de sesión"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンスがセッション境界をまたいでいます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据跨越会话边界"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.threshold_not_met": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Threshold not met"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwelle nicht erreicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral no alcanzado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "しきい値に達していません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未达到阈值"
+          }
+        }
+      }
     },
     "analysis.insight.repeated_disconnection.message": {
       "extractionState": "manual",
@@ -538,6 +798,321 @@
         }
       }
     },
+    "analysis.insights.applicability.applicable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwendbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用"
+          }
+        }
+      }
+    },
+    "analysis.insights.applicability.limited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limited applicability"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkt anwendbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicabilidad limitada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用は限定的"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用性有限"
+          }
+        }
+      }
+    },
+    "analysis.insights.bssid_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.connectivity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectivity"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnektivität"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectividad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続性"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接性"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.performance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performance"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leistung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendimiento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パフォーマンス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "性能"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.stability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stability"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stabilität"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estabilidad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安定性"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稳定性"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.high": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hohe Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza alta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 高"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高置信度"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.low": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niedrige Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza baja"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 低"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低置信度"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittlere Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza media"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中等置信度"
+          }
+        }
+      }
+    },
     "analysis.insights.evidence_count": {
       "extractionState": "manual",
       "localizations": {
@@ -573,6 +1148,76 @@
         }
       }
     },
+    "analysis.insights.evidence_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence: %d events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege: %d Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidencia: %d eventos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンス: %d 件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据：%d 个事件"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_duration_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cluster duration: %d min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clusterdauer: %d Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración del clúster: %d min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラスターの継続時間: %d 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚类持续时长：%d 分钟"
+          }
+        }
+      }
+    },
     "analysis.insights.evidence_kind": {
       "extractionState": "manual",
       "localizations": {
@@ -604,6 +1249,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "证据：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_range_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
           }
         }
       }
@@ -709,6 +1389,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "这些发现描述已记录的观测，并链接回 Timeline 证据。"
+          }
+        }
+      }
+    },
+    "analysis.insights.gateway_identity_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关：%@"
           }
         }
       }
@@ -849,6 +1564,181 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在评估本地观测…"
+          }
+        }
+      }
+    },
+    "analysis.insights.metadata_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Category %@ · %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie %@ · %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categoría %@ · %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カテゴリ %@ · %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类别 %@ · %@ · %@"
+          }
+        }
+      }
+    },
+    "analysis.insights.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_access_point_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_logical_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_unattributed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: unattributed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: nicht zugeordnet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: no atribuida"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク: 未分類"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：无法归属"
           }
         }
       }
@@ -1098,6 +1988,76 @@
         }
       }
     },
+    "analysis.insights.severity.informational": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informational"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informativo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
+        }
+      }
+    },
+    "analysis.insights.severity.warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
     "analysis.insights.shell_description": {
       "comment": "Static Insights page shell description",
       "extractionState": "manual",
@@ -1134,6 +2094,41 @@
         }
       }
     },
+    "analysis.insights.trust_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        }
+      }
+    },
     "analysis.insights.view_timeline": {
       "extractionState": "manual",
       "localizations": {
@@ -1165,6 +2160,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 Timeline 中查看"
+          }
+        }
+      }
+    },
+    "analysis.readiness.coverage_gap_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage gaps: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckungslücken: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brechas de cobertura: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "範囲の欠落: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖缺口：%lld"
           }
         }
       }
@@ -1239,6 +2269,76 @@
         }
       }
     },
+    "analysis.readiness.duration_hours_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld h %lld min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Std. %lld Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld h %lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 時間 %lld 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小时 %lld 分钟"
+          }
+        }
+      }
+    },
+    "analysis.readiness.duration_minutes_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分钟"
+          }
+        }
+      }
+    },
     "analysis.readiness.incomplete_coverage": {
       "extractionState": "manual",
       "localizations": {
@@ -1305,6 +2405,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测间隔限制了可得出的结论。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.local_storage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is stored locally on this Mac."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial se almacena localmente en este Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴はこの Mac にローカル保存されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储在本机本地。"
           }
         }
       }
@@ -1379,6 +2514,741 @@
         }
       }
     },
+    "analysis.readiness.not_observing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording local observations is inactive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Aufzeichnung lokaler Beobachtungen ist inaktiv"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación de observaciones locales está inactiva"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測の記録は停止中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未在记录本地观测"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observation_range_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed %@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtet %@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observado %@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測 %@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测 %@ – %@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observed_duration_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed duration: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungsdauer: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración observada: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測時間: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测时长：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording local observations is active"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Beobachtungen werden aktiv aufgezeichnet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación de observaciones locales está activa"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測の記録中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在记录本地观测"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_limited_basis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Judgment is based only on recorded events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Bewertung basiert nur auf aufgezeichneten Ereignissen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El juicio se basa solo en los eventos registrados"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録されたイベントのみに基づく判断です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅根据已经记录的事件进行判断"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_limited_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limited analysis: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkte Analyse: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análisis limitado: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "限定分析：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有限分析：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.all_networks_overview": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The overview scope can only provide informational conclusions"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Überblicksbereich kann nur informative Schlussfolgerungen liefern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El ámbito de resumen solo puede proporcionar conclusiones informativas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要スコープは情報提供のみの結論しか出せません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概览范围只能提供信息性结论"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.coverage_incomplete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage is incomplete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Beobachtungsabdeckung ist unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura de observación está incompleta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測カバレッジが不完全です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测覆盖不完整"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.coverage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage is unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Beobachtungsabdeckung ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura de observación no está disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測カバレッジを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测覆盖不可用"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.history_too_short": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The recorded history is too short"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aufgezeichnete Historie ist zu kurz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial registrado es demasiado corto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録された履歴が短すぎます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录太短"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_bssid_metadata": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access point information is missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Informationen fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta información del AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 情報がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 AP 信息"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_event_capability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current data lacks the event type this rule needs"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den aktuellen Daten fehlt der Ereignistyp, den diese Regel benötigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los datos actuales no incluyen el tipo de evento que requiere esta regla"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のデータには、このルールが必要とするイベントタイプがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前数据缺少该规则需要的事件类型"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_router_identity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The gateway identity cannot be confirmed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Gateway-Identität kann nicht bestätigt werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede confirmar la identidad de la puerta de enlace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイの識別情報を確認できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确认网关身份"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_ssid_attribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The required network name information is missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die erforderlichen Netzwerknamen-Informationen fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta la información del nombre de red necesaria"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必要なネットワーク名の情報がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少必要的网络名称信息"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.not_single_network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current analysis scope is not a single network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der aktuelle Analysebereich ist kein einzelnes Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El ámbito de análisis actual no es una única red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の分析スコープは単一ネットワークではありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前分析范围不是单一网络"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.storage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The storage layer is unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Speicherebene ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capa de almacenamiento no está disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ層を利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储层不可用"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.unattributed_scope": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Events cannot be attributed to a specific network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse können keinem bestimmten Netzwerk zugeordnet werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los eventos no pueden atribuirse a una red específica"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントを特定のネットワークに帰属できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件无法归属到具体网络"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason_prefix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reason: "
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grund: "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo: "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "理由："
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原因："
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_unavailable_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot evaluate now: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuell nicht bewertbar: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede evaluar ahora: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在は評価できません：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前无法评估：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rules_blocked_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rules unavailable: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regeln nicht verfügbar: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reglas no disponibles: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行できないルール: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法运行的规则：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rules_eligible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All rules can run for the selected scope."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Regeln können für den ausgewählten Bereich ausgeführt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las reglas pueden ejecutarse para el ámbito seleccionado."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したスコープではすべてのルールを実行できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选作用域可以运行所有规则。"
+          }
+        }
+      }
+    },
     "analysis.readiness.short_history": {
       "extractionState": "manual",
       "localizations": {
@@ -1445,6 +3315,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测历史太短，无法进行完整分析。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.storage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local history storage is unavailable."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der lokale Historienspeicher ist nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El almacenamiento de historial local no está disponible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴ストレージを利用できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地历史记录存储不可用。"
           }
         }
       }
@@ -1519,6 +3424,286 @@
         }
       }
     },
+    "analysis.rule.category.gateway_interruption": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated gateway-latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Gateway-Latenz-Beobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones repetidas de latencia de gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の繰り返し"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重复的网关延迟观测"
+          }
+        }
+      }
+    },
+    "analysis.rule.category.repeated_disconnection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated disconnection"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Trennung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconexión repetida"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断の繰り返し"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重复断开"
+          }
+        }
+      }
+    },
+    "analysis.rule.category.roaming_instability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP switching"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Wechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切り替え"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切换"
+          }
+        }
+      }
+    },
+    "analysis.statistics.ap_switching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP switching"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Wechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切り替え"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切换"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_percent_change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative change: %.1f%%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative Änderung: %.1f%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio relativo: %.1f%%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相対変化：%.1f%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相对变化：%.1f%%"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compared with previous period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vergleich mit dem vorherigen Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comparación con el período anterior"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前の期間との比較"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与上一周期比较"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_total_change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event total change: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderung der Ereignisanzahl: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio total de eventos: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント合計の変化：%lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件总数变化：%lld"
+          }
+        }
+      }
+    },
+    "analysis.statistics.connection_changes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection changes"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindungswechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de conexión"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接变化"
+          }
+        }
+      }
+    },
     "analysis.statistics.connections": {
       "extractionState": "manual",
       "localizations": {
@@ -1585,6 +3770,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测范围：%@ 至 %@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.coverage_percent_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage: %lld%%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung: %lld%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura: %lld%%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジ：%lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖：%lld%%"
           }
         }
       }
@@ -1764,6 +3984,76 @@
         }
       }
     },
+    "analysis.statistics.gateway_latency_observations": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Latenzbeobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones de latencia del gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关延迟观测"
+          }
+        }
+      }
+    },
+    "analysis.statistics.latest_notable_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest notable event: %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letztes bemerkenswertes Ereignis: %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Último evento notable: %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近の注目イベント：%@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近的重要事件：%@ · %@"
+          }
+        }
+      }
+    },
     "analysis.statistics.load_failed": {
       "extractionState": "manual",
       "localizations": {
@@ -1834,6 +4124,461 @@
         }
       }
     },
+    "analysis.statistics.local_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is stored locally on this Mac. You can clear it in Settings → Data."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert. Sie können sie unter Einstellungen → Daten löschen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial se almacena localmente en este Mac. Puedes borrarlo en Ajustes → Datos."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴はこの Mac にローカル保存されます。設定 → データで消去できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.local_history_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local history"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Historie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial local"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地历史记录"
+          }
+        }
+      }
+    },
+    "analysis.statistics.most_concentrated_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Most concentrated interval: %@ · %lld events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konzentriertestes Intervall: %@ · %lld Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo más concentrado: %@ · %lld eventos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最も集中している期間：%@（%lld 件）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最集中区间：%@（%lld 个事件）"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_access_point_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_all": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las redes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_logical_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：%@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_multiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redes seleccionadas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中的网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_unattributed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unattributed events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht zugeordnete Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos sin atribución"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帰属なしのイベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未归属事件"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens has not recorded Timeline history for this period. This is not a statement about network health."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat für diesen Zeitraum keine Timeline-Historie aufgezeichnet. Das ist keine Aussage über die Netzwerkgesundheit."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens no registró historial de línea de tiempo para este período. Esto no es una afirmación sobre la salud de la red."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間のタイムライン履歴は WiFi Lens に記録されていません。これはネットワークの健全性を示すものではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_history_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No local history"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine lokale Historie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin historial local"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有本地历史记录"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_matching_events_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens observed this time range, but no events match the current network and filter."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat diesen Zeitraum beobachtet, aber keine Ereignisse passen zum aktuellen Netzwerk und Filter."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens observó este rango de tiempo, pero ningún evento coincide con la red y el filtro actuales."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens はこの期間を観測しましたが、現在のネットワークとフィルターに一致するイベントはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_matching_events_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin eventos coincidentes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するイベントがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的事件"
+          }
+        }
+      }
+    },
     "analysis.statistics.no_result_message": {
       "extractionState": "manual",
       "localizations": {
@@ -1900,6 +4645,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有分析结果"
+          }
+        }
+      }
+    },
+    "analysis.statistics.observation_state_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens records local Timeline observations while the app is observing. New history appears as observations continue."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens zeichnet lokale Timeline-Beobachtungen auf, während die App beobachtet. Neue Historie erscheint, während die Beobachtungen fortgesetzt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens registra observaciones locales de la línea de tiempo mientras la app está observando. El historial nuevo aparece a medida que continúan las observaciones."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリが観測している間、WiFi Lens はローカルのタイムライン観測を記録します。観測が続くにつれて新しい履歴が表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.observation_state_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation state"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungsstatus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de observación"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測状態"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测状态"
           }
         }
       }
@@ -2044,6 +4859,41 @@
         }
       }
     },
+    "analysis.statistics.period_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period: %@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitraum: %@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período: %@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間：%@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周期：%@ – %@"
+          }
+        }
+      }
+    },
     "analysis.statistics.roaming": {
       "extractionState": "manual",
       "localizations": {
@@ -2075,6 +4925,216 @@
           "stringUnit": {
             "state": "translated",
             "value": "漫游"
+          }
+        }
+      }
+    },
+    "analysis.statistics.scope_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scope"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ámbito"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "範囲"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "范围"
+          }
+        }
+      }
+    },
+    "analysis.statistics.session_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesiones: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション数：%lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "会话数：%lld"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_critical": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Critical"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kritisch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crítico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "严重"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_distribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Severity distribution"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schweregrad-Verteilung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribución por gravedad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要度の分布"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "严重度分布"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencias"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
           }
         }
       }
@@ -8252,6 +11312,17 @@
         }
       }
     },
+    "export.success_banner_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot exported successfully"
+          }
+        }
+      }
+    },
     "format.band_channel_separator": {
       "comment": "Band name and channel number in status bar",
       "extractionState": "manual",
@@ -8758,6 +11829,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 秒前"
+          }
+        }
+      }
+    },
+    "guidance.invitation.dont_show_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not show again"
+          }
+        }
+      }
+    },
+    "guidance.invitation.later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        }
+      }
+    },
+    "guidance.invitation.message.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        }
+      }
+    },
+    "guidance.invitation.message.export": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This snapshot captures the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        }
+      }
+    },
+    "guidance.invitation.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explore WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "guidance.invitation.view_pro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View WiFi Lens Pro"
           }
         }
       }
@@ -11636,6 +14773,29 @@
         }
       }
     },
+    "network_diagnostics.check.gateway_reachability.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway Reachability"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关可达性"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ到達性"
+          }
+        }
+      }
+    },
     "network_diagnostics.check.internet.title": {
       "extractionState": "manual",
       "localizations": {
@@ -12126,6 +15286,29 @@
         }
       }
     },
+    "network_diagnostics.diagram.router.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Router"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路由器"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ルーター"
+          }
+        }
+      }
+    },
     "network_diagnostics.dns.abnormal.summary": {
       "extractionState": "manual",
       "localizations": {
@@ -12367,6 +15550,75 @@
           "stringUnit": {
             "state": "translated",
             "value": "La resolución de DNS falló para todos los nombres de prueba"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway unreachable"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关不可达"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイに到達できません"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway reachability unknown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关状态未知"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ到達性不明"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway reachable"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关可达"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイに到達"
           }
         }
       }
@@ -13347,6 +16599,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las rutas de proxy probadas están disponibles"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.tunnel_routes.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routing through a virtual network interface"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过虚拟网卡路由"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仮想ネットワークインターフェース経由でルーティングしています"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routing über eine virtuelle Netzwerkschnittstelle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enrutamiento a través de una interfaz de red virtual"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.tunnel_routes_active.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active virtual network interface detected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブな仮想ネットワークインターフェースを検出しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到活跃的虚拟网络接口"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktive virtuelle Netzwerkschnittstelle erkannt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó una interfaz de red virtual activa"
           }
         }
       }
@@ -14397,6 +17719,98 @@
           "stringUnit": {
             "state": "translated",
             "value": "状态"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.additional.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Additional Checks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附加检测"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加チェック"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.internet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "互联网"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インターネット"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.lan.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "局域网连通性"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.this_mac.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机环境"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMac"
           }
         }
       }
@@ -26530,6 +29944,426 @@
         }
       }
     },
+    "timeline.evidence.context.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Events before and after the selected evidence, shown for context."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse vor und nach den ausgewählten Belegen, zur Einordnung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos anteriores y posteriores a las pruebas seleccionadas, como contexto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した根拠の前後にあるイベントを、前後関係として表示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选证据前后的事件，供参考上下文。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.context.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surrounding events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umgebende Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos circundantes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周辺のイベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周边事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.no_matching.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens was observing during this period, but no events match the selected network and event type."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat in diesem Zeitraum beobachtet, aber keine Ereignisse entsprechen dem ausgewählten Netzwerk und Ereignistyp."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens estaba observando durante este período, pero ningún evento coincide con la red y el tipo de evento seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間に WiFi Lens は観測していましたが、選択したネットワークとイベントタイプに一致するイベントはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.no_matching.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay eventos coincidentes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するイベントがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.not_found.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None of the supporting events for this insight exist in the selected period and network."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keines der Belegereignisse für diese Erkenntnis existiert im ausgewählten Zeitraum und Netzwerk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguno de los eventos de respaldo de esta conclusión existe en el período y la red seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークには存在しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.not_found.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supporting events not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belegereignisse nicht gefunden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron eventos de respaldo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根拠となるイベントが見つかりません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到支持事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.partial.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only %lld of %lld supporting events for this insight exist in the selected period and network."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur %lld von %lld Belegereignissen für diese Erkenntnis existieren im ausgewählten Zeitraum und Netzwerk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo %lld de %lld eventos de respaldo de esta conclusión existen en el período y la red seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークに %2$lld 件中 %1$lld 件のみ存在します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.partial.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some supporting events are missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige Belegereignisse fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltan algunos eventos de respaldo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部の根拠イベントが見つかりません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分支持事件缺失"
+          }
+        }
+      }
+    },
+    "timeline.evidence.query_failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The supporting Timeline history could not be read, so no events are shown instead of incomplete evidence."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die unterstützende Timeline-Historie konnte nicht gelesen werden. Es werden keine Ereignisse angezeigt, statt unvollständiger Belege."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el historial de la línea de tiempo de respaldo, por lo que no se muestran eventos en lugar de evidencias incompletas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根拠となるタイムライン履歴を読み取れなかったため、不完全な証拠の代わりにイベントを表示しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.query_failure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence query failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abfrage der Belege fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al consultar las evidencias"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠のクエリに失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据查询失败"
+          }
+        }
+      }
+    },
+    "timeline.evidence.storage_failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Timeline history could not be read, so the supporting events cannot be verified."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die lokale Timeline-Historie konnte nicht gelesen werden, daher können die Belegereignisse nicht überprüft werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el historial local de la línea de tiempo, por lo que no se pueden verificar los eventos de respaldo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルのタイムライン履歴を読み取れないため、根拠となるイベントを確認できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取本地时间线历史，因此无法验证支持事件。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.storage_failure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History storage unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historienspeicher nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento de historial no disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴ストレージを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储不可用"
+          }
+        }
+      }
+    },
     "timeline.filter.all": {
       "comment": "Timeline filter for all events",
       "extractionState": "manual",
@@ -28497,3818 +32331,6 @@
     },
     "⌘Q": {
       "shouldTranslate": false
-    },
-    "analysis.statistics.scope_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scope"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bereich"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ámbito"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "範囲"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "范围"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_all": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todas las redes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべてのネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全部网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_logical_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：%@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_access_point_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_multiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selected networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausgewählte Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redes seleccionadas"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选中的网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_unattributed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unattributed events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nicht zugeordnete Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos sin atribución"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "帰属なしのイベント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未归属事件"
-          }
-        }
-      }
-    },
-    "analysis.statistics.period_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period: %@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zeitraum: %@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Período: %@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "期間：%@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周期：%@ – %@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.coverage_percent_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage: %lld%%"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung: %lld%%"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura: %lld%%"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジ：%lld%%"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖：%lld%%"
-          }
-        }
-      }
-    },
-    "analysis.statistics.session_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sessions: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sessions: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesiones: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッション数：%lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "会话数：%lld"
-          }
-        }
-      }
-    },
-    "analysis.statistics.connection_changes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection changes"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindungswechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de conexión"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続変更"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接变化"
-          }
-        }
-      }
-    },
-    "analysis.statistics.gateway_latency_observations": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway latency observations"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway-Latenzbeobachtungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observaciones de latencia del gateway"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ遅延の観測"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关延迟观测"
-          }
-        }
-      }
-    },
-    "analysis.statistics.ap_switching": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP switching"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Wechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切り替え"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切换"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_distribution": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Severity distribution"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schweregrad-Verteilung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Distribución por gravedad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重要度の分布"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "严重度分布"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信息"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnings"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advertencias"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_critical": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Critical"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kritisch"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crítico"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重大"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "严重"
-          }
-        }
-      }
-    },
-    "analysis.statistics.most_concentrated_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Most concentrated interval: %@ · %lld events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konzentriertestes Intervall: %@ · %lld Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intervalo más concentrado: %@ · %lld eventos"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最も集中している期間：%@（%lld 件）"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最集中区间：%@（%lld 个事件）"
-          }
-        }
-      }
-    },
-    "analysis.statistics.latest_notable_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest notable event: %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Letztes bemerkenswertes Ereignis: %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Último evento notable: %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近の注目イベント：%@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近的重要事件：%@ · %@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compared with previous period"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vergleich mit dem vorherigen Zeitraum"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comparación con el período anterior"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前の期間との比較"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "与上一周期比较"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_total_change": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Event total change: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Änderung der Ereignisanzahl: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambio total de eventos: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イベント合計の変化：%lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "事件总数变化：%lld"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_percent_change": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relative change: %.1f%%"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relative Änderung: %.1f%%"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambio relativo: %.1f%%"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "相対変化：%.1f%%"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "相对变化：%.1f%%"
-          }
-        }
-      }
-    },
-    "analysis.insights.metadata_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Category %@ · %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kategorie %@ · %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categoría %@ · %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カテゴリ %@ · %@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "类别 %@ · %@ · %@"
-          }
-        }
-      }
-    },
-    "analysis.insights.evidence_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence: %d events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege: %d Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidencia: %d eventos"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンス: %d 件"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据：%d 个事件"
-          }
-        }
-      }
-    },
-    "analysis.insights.evidence_range_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        }
-      }
-    },
-    "analysis.insights.evidence_duration_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cluster duration: %d min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clusterdauer: %d Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duración del clúster: %d min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラスターの継続時間: %d 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "聚类持续时长：%d 分钟"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.connectivity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connectivity"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konnektivität"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectividad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続性"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接性"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.performance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Performance"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leistung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendimiento"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パフォーマンス"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "性能"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.stability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stability"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stabilität"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estabilidad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安定性"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "稳定性"
-          }
-        }
-      }
-    },
-    "analysis.insights.severity.informational": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informational"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informativo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信息"
-          }
-        }
-      }
-    },
-    "analysis.insights.severity.warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warning"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advertencia"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.high": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "High confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hohe Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza alta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 高"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "高置信度"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.medium": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medium confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mittlere Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza media"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中等置信度"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.low": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Low confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niedrige Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza baja"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 低"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "低置信度"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.coverage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura no disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖率不可用"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.incomplete_coverage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage incomplete"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung unvollständig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura incompleta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジが不完全です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖率不完整"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.session_boundary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence crosses a session boundary"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege überschreiten eine Sitzungsgrenze"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La evidencia cruza un límite de sesión"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンスがセッション境界をまたいでいます"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据跨越会话边界"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_ssid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el SSID"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 SSID"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_bssid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el BSSID"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 BSSID"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_gateway_identity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway identity missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway-Identität fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta la identidad de la puerta de enlace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ ID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少网关标识"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.ambiguous_normal_behavior": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Normal behavior cannot be ruled out"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Normales Verhalten kann nicht ausgeschlossen werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede descartar un comportamiento normal"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正常な動作を除外できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法排除正常行为"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.cross_network_evidence": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence spans networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege erstrecken sich über mehrere Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La evidencia abarca varias redes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンスが複数ネットワークにわたります"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据跨多个网络"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.threshold_not_met": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Threshold not met"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schwelle nicht erreicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umbral no alcanzado"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "しきい値に達していません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未达到阈值"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_history_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No local history"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine lokale Historie"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin historial local"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有本地历史记录"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_history_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens has not recorded Timeline history for this period. This is not a statement about network health."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat für diesen Zeitraum keine Timeline-Historie aufgezeichnet. Das ist keine Aussage über die Netzwerkgesundheit."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens no registró historial de línea de tiempo para este período. Esto no es una afirmación sobre la salud de la red."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この期間のタイムライン履歴は WiFi Lens に記録されていません。これはネットワークの健全性を示すものではありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.observation_state_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation state"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtungsstatus"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado de observación"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測状態"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测状态"
-          }
-        }
-      }
-    },
-    "analysis.statistics.observation_state_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens records local Timeline observations while the app is observing. New history appears as observations continue."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens zeichnet lokale Timeline-Beobachtungen auf, während die App beobachtet. Neue Historie erscheint, während die Beobachtungen fortgesetzt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens registra observaciones locales de la línea de tiempo mientras la app está observando. El historial nuevo aparece a medida que continúan las observaciones."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリが観測している間、WiFi Lens はローカルのタイムライン観測を記録します。観測が続くにつれて新しい履歴が表示されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.local_history_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local history"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokale Historie"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Historial local"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地历史记录"
-          }
-        }
-      }
-    },
-    "analysis.statistics.local_history_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History is stored locally on this Mac. You can clear it in Settings → Data."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Historie wird lokal auf diesem Mac gespeichert. Sie können sie unter Einstellungen → Daten löschen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial se almacena localmente en este Mac. Puedes borrarlo en Ajustes → Datos."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴はこの Mac にローカル保存されます。設定 → データで消去できます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_matching_events_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matching events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine passenden Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin eventos coincidentes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するイベントがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有匹配的事件"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_matching_events_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens observed this time range, but no events match the current network and filter."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat diesen Zeitraum beobachtet, aber keine Ereignisse passen zum aktuellen Netzwerk und Filter."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens observó este rango de tiempo, pero ningún evento coincide con la red y el filtro actuales."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens はこの期間を観測しましたが、現在のネットワークとフィルターに一致するイベントはありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording local observations is active"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokale Beobachtungen werden aktiv aufgezeichnet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La grabación de observaciones locales está activa"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル観測の記録中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在记录本地观测"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observation_range_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observed %@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtet %@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observado %@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測 %@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测 %@ – %@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observed_duration_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observed duration: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtungsdauer: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duración observada: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測時間: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测时长：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.coverage_gap_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage gaps: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckungslücken: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brechas de cobertura: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "範囲の欠落: %lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖缺口：%lld"
-          }
-        }
-      }
-    },
-    "analysis.readiness.local_storage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History is stored locally on this Mac."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Historie wird lokal auf diesem Mac gespeichert."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial se almacena localmente en este Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴はこの Mac にローカル保存されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储在本机本地。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.storage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local history storage is unavailable."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der lokale Historienspeicher ist nicht verfügbar."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El almacenamiento de historial local no está disponible."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴ストレージを利用できません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地历史记录存储不可用。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rules_eligible": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All rules can run for the selected scope."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Regeln können für den ausgewählten Bereich ausgeführt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todas las reglas pueden ejecutarse para el ámbito seleccionado."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したスコープではすべてのルールを実行できます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选作用域可以运行所有规则。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rules_blocked_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rules unavailable: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regeln nicht verfügbar: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reglas no disponibles: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "実行できないルール: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法运行的规则：%@"
-          }
-        }
-      }
-    },
-    "analysis.rule.category.repeated_disconnection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repeated disconnection"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederholte Trennung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconexión repetida"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切断の繰り返し"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重复断开"
-          }
-        }
-      }
-    },
-    "analysis.rule.category.gateway_interruption": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repeated gateway-latency observations"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederholte Gateway-Latenz-Beobachtungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observaciones repetidas de latencia de gateway"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ遅延の繰り返し"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重复的网关延迟观测"
-          }
-        }
-      }
-    },
-    "analysis.rule.category.roaming_instability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP switching"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Wechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切り替え"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切换"
-          }
-        }
-      }
-    },
-    "analysis.readiness.duration_minutes_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 分钟"
-          }
-        }
-      }
-    },
-    "analysis.readiness.duration_hours_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld h %lld min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld Std. %lld Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld h %lld min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 時間 %lld 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 小时 %lld 分钟"
-          }
-        }
-      }
-    },
-    "analysis.insights.network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_logical_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_access_point_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_unattributed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: unattributed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: nicht zugeordnet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: no atribuida"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク: 未分類"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：无法归属"
-          }
-        }
-      }
-    },
-    "analysis.insights.gateway_identity_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.bssid_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.trust_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        }
-      }
-    },
-    "analysis.insights.applicability.applicable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Applicable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anwendbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicable"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "適用"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "适用"
-          }
-        }
-      }
-    },
-    "analysis.insights.applicability.limited": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limited applicability"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingeschränkt anwendbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicabilidad limitada"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "適用は限定的"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "适用性有限"
-          }
-        }
-      }
-    },
-    "timeline.evidence.query_failure.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence query failed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abfrage der Belege fehlgeschlagen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al consultar las evidencias"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "証拠のクエリに失敗しました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据查询失败"
-          }
-        }
-      }
-    },
-    "timeline.evidence.query_failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The supporting Timeline history could not be read, so no events are shown instead of incomplete evidence."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die unterstützende Timeline-Historie konnte nicht gelesen werden. Es werden keine Ereignisse angezeigt, statt unvollständiger Belege."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer el historial de la línea de tiempo de respaldo, por lo que no se muestran eventos en lugar de evidencias incompletas."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根拠となるタイムライン履歴を読み取れなかったため、不完全な証拠の代わりにイベントを表示しません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.storage_failure.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History storage unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Historienspeicher nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Almacenamiento de historial no disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴ストレージを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储不可用"
-          }
-        }
-      }
-    },
-    "timeline.evidence.storage_failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local Timeline history could not be read, so the supporting events cannot be verified."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die lokale Timeline-Historie konnte nicht gelesen werden, daher können die Belegereignisse nicht überprüft werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer el historial local de la línea de tiempo, por lo que no se pueden verificar los eventos de respaldo."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルのタイムライン履歴を読み取れないため、根拠となるイベントを確認できません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取本地时间线历史，因此无法验证支持事件。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.not_found.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supporting events not found"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belegereignisse nicht gefunden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontraron eventos de respaldo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根拠となるイベントが見つかりません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到支持事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.not_found.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "None of the supporting events for this insight exist in the selected period and network."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keines der Belegereignisse für diese Erkenntnis existiert im ausgewählten Zeitraum und Netzwerk."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguno de los eventos de respaldo de esta conclusión existe en el período y la red seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークには存在しません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.no_matching.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matching events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine passenden Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay eventos coincidentes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するイベントがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有匹配的事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.no_matching.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens was observing during this period, but no events match the selected network and event type."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat in diesem Zeitraum beobachtet, aber keine Ereignisse entsprechen dem ausgewählten Netzwerk und Ereignistyp."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens estaba observando durante este período, pero ningún evento coincide con la red y el tipo de evento seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この期間に WiFi Lens は観測していましたが、選択したネットワークとイベントタイプに一致するイベントはありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_unavailable_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cannot evaluate now: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktuell nicht bewertbar: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede evaluar ahora: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在は評価できません：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前无法评估：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_limited_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limited analysis: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingeschränkte Analyse: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Análisis limitado: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "限定分析：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有限分析：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_limited_basis": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Judgment is based only on recorded events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Bewertung basiert nur auf aufgezeichneten Ereignissen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El juicio se basa solo en los eventos registrados"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記録されたイベントのみに基づく判断です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅根据已经记录的事件进行判断"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason_prefix": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason: "
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grund: "
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Motivo: "
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "理由："
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "原因："
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.not_single_network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The current analysis scope is not a single network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der aktuelle Analysebereich ist kein einzelnes Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El ámbito de análisis actual no es una única red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在の分析スコープは単一ネットワークではありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前分析范围不是单一网络"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.unattributed_scope": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events cannot be attributed to a specific network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ereignisse können keinem bestimmten Netzwerk zugeordnet werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los eventos no pueden atribuirse a una red específica"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イベントを特定のネットワークに帰属できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "事件无法归属到具体网络"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_ssid_attribution": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The required network name information is missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die erforderlichen Netzwerknamen-Informationen fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta la información del nombre de red necesaria"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "必要なネットワーク名の情報がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少必要的网络名称信息"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_event_capability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The current data lacks the event type this rule needs"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Den aktuellen Daten fehlt der Ereignistyp, den diese Regel benötigt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los datos actuales no incluyen el tipo de evento que requiere esta regla"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在のデータには、このルールが必要とするイベントタイプがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前数据缺少该规则需要的事件类型"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_router_identity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The gateway identity cannot be confirmed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Gateway-Identität kann nicht bestätigt werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede confirmar la identidad de la puerta de enlace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイの識別情報を確認できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法确认网关身份"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.coverage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation coverage is unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Beobachtungsabdeckung ist nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La cobertura de observación no está disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測カバレッジを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测覆盖不可用"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.coverage_incomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation coverage is incomplete"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Beobachtungsabdeckung ist unvollständig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La cobertura de observación está incompleta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測カバレッジが不完全です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测覆盖不完整"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.history_too_short": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The recorded history is too short"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die aufgezeichnete Historie ist zu kurz"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial registrado es demasiado corto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記録された履歴が短すぎます"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录太短"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_bssid_metadata": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Access point information is missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Informationen fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta información del AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 情報がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 AP 信息"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.all_networks_overview": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The overview scope can only provide informational conclusions"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Überblicksbereich kann nur informative Schlussfolgerungen liefern"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El ámbito de resumen solo puede proporcionar conclusiones informativas"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概要スコープは情報提供のみの結論しか出せません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概览范围只能提供信息性结论"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.storage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The storage layer is unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Speicherebene ist nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La capa de almacenamiento no está disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ストレージ層を利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "存储层不可用"
-          }
-        }
-      }
-    },
-    "analysis.readiness.not_observing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording local observations is inactive"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Aufzeichnung lokaler Beobachtungen ist inaktiv"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La grabación de observaciones locales está inactiva"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル観測の記録は停止中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未在记录本地观测"
-          }
-        }
-      }
-    },
-    "timeline.evidence.partial.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Some supporting events are missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einige Belegereignisse fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faltan algunos eventos de respaldo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一部の根拠イベントが見つかりません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "部分支持事件缺失"
-          }
-        }
-      }
-    },
-    "timeline.evidence.partial.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only %lld of %lld supporting events for this insight exist in the selected period and network."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nur %lld von %lld Belegereignissen für diese Erkenntnis existieren im ausgewählten Zeitraum und Netzwerk."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo %lld de %lld eventos de respaldo de esta conclusión existen en el período y la red seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークに %2$lld 件中 %1$lld 件のみ存在します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.context.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Surrounding events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umgebende Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos circundantes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周辺のイベント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周边事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.context.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events before and after the selected evidence, shown for context."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ereignisse vor und nach den ausgewählten Belegen, zur Einordnung."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos anteriores y posteriores a las pruebas seleccionadas, como contexto."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択した根拠の前後にあるイベントを、前後関係として表示します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选证据前后的事件，供参考上下文。"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.this_mac.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This Mac"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本机环境"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このMac"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.lan.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "LAN"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "局域网连通性"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "LAN"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.internet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internet"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "互联网"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インターネット"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.additional.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Additional Checks"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "附加检测"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加チェック"
-          }
-        }
-      }
-    },
-    "network_diagnostics.check.gateway_reachability.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway Reachability"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关可达性"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ到達性"
-          }
-        }
-      }
-    },
-    "network_diagnostics.diagram.router.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Router"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路由器"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ルーター"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.normal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway reachable"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关可达"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイに到達"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.abnormal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway unreachable"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关不可达"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイに到達できません"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.indeterminate.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway reachability unknown"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关状态未知"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ到達性不明"
-          }
-        }
-      }
-    },
-    "network_diagnostics.proxy.tunnel_routes.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routing through a virtual network interface"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过虚拟网卡路由"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仮想ネットワークインターフェース経由でルーティングしています"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routing über eine virtuelle Netzwerkschnittstelle"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enrutamiento a través de una interfaz de red virtual"
-          }
-        }
-      }
-    },
-    "network_diagnostics.proxy.tunnel_routes_active.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active virtual network interface detected"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクティブな仮想ネットワークインターフェースを検出しました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "检测到活跃的虚拟网络接口"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktive virtuelle Netzwerkschnittstelle erkannt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se detectó una interfaz de red virtual activa"
-          }
-        }
-      }
     }
   }
 }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -2,6 +2,61 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "guidance.invitation.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explore WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "guidance.invitation.message.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        }
+      }
+    },
+    "guidance.invitation.view_pro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "guidance.invitation.later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        }
+      }
+    },
+    "guidance.invitation.dont_show_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not show again"
+          }
+        }
+      }
+    },
     " · %@": {
       "shouldTranslate": false
     },

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -32331,6 +32331,39 @@
           }
         }
       }
+    },
+    "settings.section.support": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support"
+          }
+        }
+      }
+    },
+    "settings.support.rate_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rate WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "settings.support.send_feedback_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        }
+      }
     }
   }
 }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -32712,6 +32712,216 @@
           }
         }
       }
+    },
+    "onboarding.welcome.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to WiFi Lens"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Willkommen bei WiFi Lens"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido a WiFi Lens"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens へようこそ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "欢迎使用 WiFi Lens"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See what’s happening with your Wi-Fi and find less crowded channels."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfahre, was in deinem Wi-Fi vor sich geht, und finde weniger ausgelastete Kanäle."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descubre qué está pasando con tu Wi-Fi y encuentra canales menos congestionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi の状況を確認して、混雑していないチャンネルを見つけましょう。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "了解你的 Wi-Fi 状况，找到不那么拥挤的信道。"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.start": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Analyzing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empezar a analizar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析を開始"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始分析"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.learn_pro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Learn about WiFi Lens Pro"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr über WiFi Lens Pro erfahren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descubre WiFi Lens Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro について"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "了解 WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.skip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überspringen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
     }
   }
 }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -32922,6 +32922,251 @@
           }
         }
       }
+    },
+    "onboarding.welcome.start_recording": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Recording"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar grabación"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録画開始"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始录制"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.live": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See live channel usage"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Kanalauslastung sehen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulta el uso de canales en vivo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チャンネルの利用状況をリアルタイムで確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时查看信道使用情况"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run one-tap diagnostics"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose mit einem Klick"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico con un toque"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワンタップで診断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一键诊断网络"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.export": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Wi-Fi snapshots"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi-Momentaufnahmen exportieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporta instantáneas de Wi-Fi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi スナップショットを書き出す"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出 Wi-Fi 快照"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.record": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record Wi-Fi evidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi-Beweisdaten aufzeichnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graba evidencia de Wi-Fi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi の記録を収集"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制 Wi-Fi 数据"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.timeline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review your timeline"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deinen Zeitverlauf ansehen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisa tu cronología"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムラインで振り返る"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在时间线中回顾"
+          }
+        }
+      }
+    },
+    "onboarding.welcome.highlight.analysis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyze trends and insights"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trends und Erkenntnisse analysieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiza tendencias y perspectivas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "傾向とインサイトを分析"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析趋势与洞察"
+          }
+        }
+      }
     }
   }
 }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -10,6 +10,30 @@
             "state": "translated",
             "value": "Explore WiFi Lens Pro"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro entdecken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descubre WiFi Lens Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro を試してみる"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "探索 WiFi Lens Pro"
+          }
         }
       }
     },
@@ -20,6 +44,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Diagnose spiegelt den aktuellen Netzwerkzustand wider. Mit WiFi Lens Pro kannst du Änderungen über die Zeit nachvollziehen und so intermittierende Probleme und langfristige Trends erkennen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este diagnóstico refleja el estado actual de la red. WiFi Lens Pro puede conservar los cambios a lo largo del tiempo y ayudar a identificar problemas intermitentes y tendencias a largo plazo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この診断は現在のネットワーク状態を反映しています。WiFi Lens Pro は時間の経過に伴う変化を記録し、断続的な問題や長期的な傾向の特定に役立ちます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次诊断反映了当前的网络状态。WiFi Lens Pro 可以保留随时间发生的变化，帮助识别间歇性问题与长期趋势。"
           }
         }
       }
@@ -32,6 +80,30 @@
             "state": "translated",
             "value": "View WiFi Lens Pro"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro ansehen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver WiFi Lens Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro を見る"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看 WiFi Lens Pro"
+          }
         }
       }
     },
@@ -43,6 +115,30 @@
             "state": "translated",
             "value": "Later"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Später"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más tarde"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "後で"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后"
+          }
         }
       }
     },
@@ -53,6 +149,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "Do not show again"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht mehr anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No volver a mostrar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後表示しない"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再显示"
           }
         }
       }
@@ -32053,6 +32173,18 @@
             "state": "translated",
             "value": "このMac"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este Mac"
+          }
         }
       }
     },
@@ -32072,6 +32204,18 @@
           }
         },
         "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "LAN"
@@ -32099,6 +32243,18 @@
             "state": "translated",
             "value": "インターネット"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet"
+          }
         }
       }
     },
@@ -32121,6 +32277,18 @@
           "stringUnit": {
             "state": "translated",
             "value": "追加チェック"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusätzliche Prüfungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobaciones adicionales"
           }
         }
       }
@@ -32145,6 +32313,18 @@
             "state": "translated",
             "value": "ゲートウェイ到達性"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Erreichbarkeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesibilidad de la puerta de enlace"
+          }
         }
       }
     },
@@ -32167,6 +32347,18 @@
           "stringUnit": {
             "state": "translated",
             "value": "ルーター"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Router"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Router"
           }
         }
       }
@@ -32191,6 +32383,18 @@
             "state": "translated",
             "value": "ゲートウェイに到達"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway erreichbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puerta de enlace accesible"
+          }
         }
       }
     },
@@ -32214,6 +32418,18 @@
             "state": "translated",
             "value": "ゲートウェイに到達できません"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway nicht erreichbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puerta de enlace inaccesible"
+          }
         }
       }
     },
@@ -32236,6 +32452,18 @@
           "stringUnit": {
             "state": "translated",
             "value": "ゲートウェイ到達性不明"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Erreichbarkeit unbekannt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesibilidad de la puerta de enlace desconocida"
           }
         }
       }
@@ -32318,6 +32546,30 @@
             "state": "translated",
             "value": "This snapshot captures the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Schnappschuss erfasst den aktuellen Netzwerkzustand. Mit WiFi Lens Pro kannst du Änderungen über die Zeit nachvollziehen und so intermittierende Probleme und langfristige Trends erkennen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta instantánea captura el estado actual de la red. WiFi Lens Pro puede conservar los cambios a lo largo del tiempo y ayudar a identificar problemas intermitentes y tendencias a largo plazo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このスナップショットは現在のネットワーク状態を記録しています。WiFi Lens Pro は時間の経過に伴う変化を記録し、断続的な問題や長期的な傾向の特定に役立ちます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此快照记录了当前的网络状态。WiFi Lens Pro 可以保留随时间发生的变化，帮助识别间歇性问题与长期趋势。"
+          }
         }
       }
     },
@@ -32328,6 +32580,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "Snapshot exported successfully"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnappschuss erfolgreich exportiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantánea exportada correctamente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スナップショットを書き出しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快照已成功导出"
           }
         }
       }
@@ -32340,6 +32616,30 @@
             "state": "translated",
             "value": "Support"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soporte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持"
+          }
         }
       }
     },
@@ -32351,6 +32651,30 @@
             "state": "translated",
             "value": "Rate WiFi Lens Pro"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro bewerten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valorar WiFi Lens Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro を評価"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "评价 WiFi Lens Pro"
+          }
         }
       }
     },
@@ -32361,6 +32685,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "Send Feedback"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback senden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar comentarios"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを送信"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送反馈"
           }
         }
       }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -2,6 +2,61 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "guidance.invitation.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explore WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "guidance.invitation.message.diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        }
+      }
+    },
+    "guidance.invitation.view_pro": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View WiFi Lens Pro"
+          }
+        }
+      }
+    },
+    "guidance.invitation.later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        }
+      }
+    },
+    "guidance.invitation.dont_show_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not show again"
+          }
+        }
+      }
+    },
     " · %@": {
       "shouldTranslate": false
     },
@@ -167,321 +222,6 @@
     },
     "WiFi Lens": {
       "shouldTranslate": false
-    },
-    "analysis.insight.limitation.ambiguous_normal_behavior": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Normal behavior cannot be ruled out"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Normales Verhalten kann nicht ausgeschlossen werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede descartar un comportamiento normal"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正常な動作を除外できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法排除正常行为"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.coverage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura no disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖率不可用"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.cross_network_evidence": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence spans networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege erstrecken sich über mehrere Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La evidencia abarca varias redes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンスが複数ネットワークにわたります"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据跨多个网络"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.incomplete_coverage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage incomplete"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung unvollständig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura incompleta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジが不完全です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖率不完整"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_bssid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el BSSID"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 BSSID"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_gateway_identity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway identity missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway-Identität fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta la identidad de la puerta de enlace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ ID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少网关标识"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.missing_ssid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID fehlt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta el SSID"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSID がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 SSID"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.session_boundary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence crosses a session boundary"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege überschreiten eine Sitzungsgrenze"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La evidencia cruza un límite de sesión"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンスがセッション境界をまたいでいます"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据跨越会话边界"
-          }
-        }
-      }
-    },
-    "analysis.insight.limitation.threshold_not_met": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Threshold not met"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schwelle nicht erreicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umbral no alcanzado"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "しきい値に達していません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未达到阈值"
-          }
-        }
-      }
     },
     "analysis.insight.repeated_disconnection.message": {
       "extractionState": "manual",
@@ -798,321 +538,6 @@
         }
       }
     },
-    "analysis.insights.applicability.applicable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Applicable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anwendbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicable"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "適用"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "适用"
-          }
-        }
-      }
-    },
-    "analysis.insights.applicability.limited": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limited applicability"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingeschränkt anwendbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplicabilidad limitada"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "適用は限定的"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "适用性有限"
-          }
-        }
-      }
-    },
-    "analysis.insights.bssid_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSIDs: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BSSID：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.connectivity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connectivity"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konnektivität"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectividad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続性"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接性"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.performance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Performance"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leistung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendimiento"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パフォーマンス"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "性能"
-          }
-        }
-      }
-    },
-    "analysis.insights.category.stability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stability"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stabilität"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estabilidad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安定性"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "稳定性"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.high": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "High confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hohe Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza alta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 高"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "高置信度"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.low": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Low confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niedrige Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza baja"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 低"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "低置信度"
-          }
-        }
-      }
-    },
-    "analysis.insights.confidence.medium": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medium confidence"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mittlere Zuversicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confianza media"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信頼度: 中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中等置信度"
-          }
-        }
-      }
-    },
     "analysis.insights.evidence_count": {
       "extractionState": "manual",
       "localizations": {
@@ -1148,76 +573,6 @@
         }
       }
     },
-    "analysis.insights.evidence_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence: %d events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belege: %d Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidencia: %d eventos"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エビデンス: %d 件"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据：%d 个事件"
-          }
-        }
-      }
-    },
-    "analysis.insights.evidence_duration_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cluster duration: %d min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clusterdauer: %d Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duración del clúster: %d min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラスターの継続時間: %d 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "聚类持续时长：%d 分钟"
-          }
-        }
-      }
-    },
     "analysis.insights.evidence_kind": {
       "extractionState": "manual",
       "localizations": {
@@ -1249,41 +604,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "证据：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.evidence_range_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ – %@"
           }
         }
       }
@@ -1389,41 +709,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "这些发现描述已记录的观测，并链接回 Timeline 证据。"
-          }
-        }
-      }
-    },
-    "analysis.insights.gateway_identity_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关：%@"
           }
         }
       }
@@ -1564,181 +849,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在评估本地观测…"
-          }
-        }
-      }
-    },
-    "analysis.insights.metadata_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Category %@ · %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kategorie %@ · %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categoría %@ · %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カテゴリ %@ · %@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "类别 %@ · %@ · %@"
-          }
-        }
-      }
-    },
-    "analysis.insights.network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_access_point_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_logical_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：%@"
-          }
-        }
-      }
-    },
-    "analysis.insights.network_unattributed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: unattributed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: nicht zugeordnet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: no atribuida"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク: 未分類"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：无法归属"
           }
         }
       }
@@ -1988,76 +1098,6 @@
         }
       }
     },
-    "analysis.insights.severity.informational": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informational"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informativo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信息"
-          }
-        }
-      }
-    },
-    "analysis.insights.severity.warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warning"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advertencia"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        }
-      }
-    },
     "analysis.insights.shell_description": {
       "comment": "Static Insights page shell description",
       "extractionState": "manual",
@@ -2094,41 +1134,6 @@
         }
       }
     },
-    "analysis.insights.trust_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · %@"
-          }
-        }
-      }
-    },
     "analysis.insights.view_timeline": {
       "extractionState": "manual",
       "localizations": {
@@ -2160,41 +1165,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 Timeline 中查看"
-          }
-        }
-      }
-    },
-    "analysis.readiness.coverage_gap_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage gaps: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckungslücken: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brechas de cobertura: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "範囲の欠落: %lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖缺口：%lld"
           }
         }
       }
@@ -2269,76 +1239,6 @@
         }
       }
     },
-    "analysis.readiness.duration_hours_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld h %lld min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld Std. %lld Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld h %lld min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 時間 %lld 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 小时 %lld 分钟"
-          }
-        }
-      }
-    },
-    "analysis.readiness.duration_minutes_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld min"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld Min."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld min"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 分"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld 分钟"
-          }
-        }
-      }
-    },
     "analysis.readiness.incomplete_coverage": {
       "extractionState": "manual",
       "localizations": {
@@ -2405,41 +1305,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测间隔限制了可得出的结论。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.local_storage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History is stored locally on this Mac."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Historie wird lokal auf diesem Mac gespeichert."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial se almacena localmente en este Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴はこの Mac にローカル保存されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储在本机本地。"
           }
         }
       }
@@ -2514,741 +1379,6 @@
         }
       }
     },
-    "analysis.readiness.not_observing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording local observations is inactive"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Aufzeichnung lokaler Beobachtungen ist inaktiv"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La grabación de observaciones locales está inactiva"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル観測の記録は停止中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未在记录本地观测"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observation_range_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observed %@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtet %@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observado %@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測 %@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测 %@ – %@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observed_duration_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observed duration: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtungsdauer: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duración observada: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測時間: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测时长：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.observing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording local observations is active"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokale Beobachtungen werden aktiv aufgezeichnet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La grabación de observaciones locales está activa"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル観測の記録中"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在记录本地观测"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_limited_basis": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Judgment is based only on recorded events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Bewertung basiert nur auf aufgezeichneten Ereignissen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El juicio se basa solo en los eventos registrados"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記録されたイベントのみに基づく判断です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅根据已经记录的事件进行判断"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_limited_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limited analysis: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eingeschränkte Analyse: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Análisis limitado: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "限定分析：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有限分析：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.all_networks_overview": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The overview scope can only provide informational conclusions"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Überblicksbereich kann nur informative Schlussfolgerungen liefern"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El ámbito de resumen solo puede proporcionar conclusiones informativas"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概要スコープは情報提供のみの結論しか出せません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "概览范围只能提供信息性结论"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.coverage_incomplete": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation coverage is incomplete"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Beobachtungsabdeckung ist unvollständig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La cobertura de observación está incompleta"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測カバレッジが不完全です"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测覆盖不完整"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.coverage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation coverage is unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Beobachtungsabdeckung ist nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La cobertura de observación no está disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測カバレッジを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测覆盖不可用"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.history_too_short": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The recorded history is too short"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die aufgezeichnete Historie ist zu kurz"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial registrado es demasiado corto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記録された履歴が短すぎます"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录太短"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_bssid_metadata": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Access point information is missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Informationen fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta información del AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 情報がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少 AP 信息"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_event_capability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The current data lacks the event type this rule needs"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Den aktuellen Daten fehlt der Ereignistyp, den diese Regel benötigt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los datos actuales no incluyen el tipo de evento que requiere esta regla"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在のデータには、このルールが必要とするイベントタイプがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前数据缺少该规则需要的事件类型"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_router_identity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The gateway identity cannot be confirmed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Gateway-Identität kann nicht bestätigt werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede confirmar la identidad de la puerta de enlace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイの識別情報を確認できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法确认网关身份"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.missing_ssid_attribution": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The required network name information is missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die erforderlichen Netzwerknamen-Informationen fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falta la información del nombre de red necesaria"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "必要なネットワーク名の情報がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "缺少必要的网络名称信息"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.not_single_network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The current analysis scope is not a single network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der aktuelle Analysebereich ist kein einzelnes Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El ámbito de análisis actual no es una única red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在の分析スコープは単一ネットワークではありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前分析范围不是单一网络"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.storage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The storage layer is unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Speicherebene ist nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La capa de almacenamiento no está disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ストレージ層を利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "存储层不可用"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason.unattributed_scope": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events cannot be attributed to a specific network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ereignisse können keinem bestimmten Netzwerk zugeordnet werden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los eventos no pueden atribuirse a una red específica"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イベントを特定のネットワークに帰属できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "事件无法归属到具体网络"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_reason_prefix": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason: "
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grund: "
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Motivo: "
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "理由："
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "原因："
-          }
-        }
-      }
-    },
-    "analysis.readiness.rule_unavailable_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cannot evaluate now: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktuell nicht bewertbar: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se puede evaluar ahora: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在は評価できません：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "当前无法评估：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rules_blocked_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rules unavailable: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regeln nicht verfügbar: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reglas no disponibles: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "実行できないルール: %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法运行的规则：%@"
-          }
-        }
-      }
-    },
-    "analysis.readiness.rules_eligible": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All rules can run for the selected scope."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Regeln können für den ausgewählten Bereich ausgeführt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todas las reglas pueden ejecutarse para el ámbito seleccionado."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したスコープではすべてのルールを実行できます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选作用域可以运行所有规则。"
-          }
-        }
-      }
-    },
     "analysis.readiness.short_history": {
       "extractionState": "manual",
       "localizations": {
@@ -3315,41 +1445,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测历史太短，无法进行完整分析。"
-          }
-        }
-      }
-    },
-    "analysis.readiness.storage_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local history storage is unavailable."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der lokale Historienspeicher ist nicht verfügbar."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El almacenamiento de historial local no está disponible."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴ストレージを利用できません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地历史记录存储不可用。"
           }
         }
       }
@@ -3424,286 +1519,6 @@
         }
       }
     },
-    "analysis.rule.category.gateway_interruption": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repeated gateway-latency observations"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederholte Gateway-Latenz-Beobachtungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observaciones repetidas de latencia de gateway"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ遅延の繰り返し"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重复的网关延迟观测"
-          }
-        }
-      }
-    },
-    "analysis.rule.category.repeated_disconnection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repeated disconnection"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederholte Trennung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconexión repetida"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切断の繰り返し"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重复断开"
-          }
-        }
-      }
-    },
-    "analysis.rule.category.roaming_instability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP switching"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Wechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切り替え"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切换"
-          }
-        }
-      }
-    },
-    "analysis.statistics.ap_switching": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP switching"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP-Wechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de AP"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切り替え"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP 切换"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_percent_change": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relative change: %.1f%%"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relative Änderung: %.1f%%"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambio relativo: %.1f%%"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "相対変化：%.1f%%"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "相对变化：%.1f%%"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compared with previous period"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vergleich mit dem vorherigen Zeitraum"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Comparación con el período anterior"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前の期間との比較"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "与上一周期比较"
-          }
-        }
-      }
-    },
-    "analysis.statistics.comparison_total_change": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Event total change: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Änderung der Ereignisanzahl: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambio total de eventos: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イベント合計の変化：%lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "事件总数变化：%lld"
-          }
-        }
-      }
-    },
-    "analysis.statistics.connection_changes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection changes"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verbindungswechsel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambios de conexión"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続変更"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "连接变化"
-          }
-        }
-      }
-    },
     "analysis.statistics.connections": {
       "extractionState": "manual",
       "localizations": {
@@ -3770,41 +1585,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测范围：%@ 至 %@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.coverage_percent_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coverage: %lld%%"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdeckung: %lld%%"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cobertura: %lld%%"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カバレッジ：%lld%%"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "覆盖：%lld%%"
           }
         }
       }
@@ -3984,76 +1764,6 @@
         }
       }
     },
-    "analysis.statistics.gateway_latency_observations": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway latency observations"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway-Latenzbeobachtungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observaciones de latencia del gateway"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ遅延の観測"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关延迟观测"
-          }
-        }
-      }
-    },
-    "analysis.statistics.latest_notable_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest notable event: %@ · %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Letztes bemerkenswertes Ereignis: %@ · %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Último evento notable: %@ · %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近の注目イベント：%@ · %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近的重要事件：%@ · %@"
-          }
-        }
-      }
-    },
     "analysis.statistics.load_failed": {
       "extractionState": "manual",
       "localizations": {
@@ -4124,461 +1834,6 @@
         }
       }
     },
-    "analysis.statistics.local_history_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History is stored locally on this Mac. You can clear it in Settings → Data."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Historie wird lokal auf diesem Mac gespeichert. Sie können sie unter Einstellungen → Daten löschen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El historial se almacena localmente en este Mac. Puedes borrarlo en Ajustes → Datos."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴はこの Mac にローカル保存されます。設定 → データで消去できます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.local_history_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local history"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lokale Historie"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Historial local"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地历史记录"
-          }
-        }
-      }
-    },
-    "analysis.statistics.most_concentrated_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Most concentrated interval: %@ · %lld events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konzentriertestes Intervall: %@ · %lld Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intervalo más concentrado: %@ · %lld eventos"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最も集中している期間：%@（%lld 件）"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最集中区间：%@（%lld 个事件）"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_access_point_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AP：%@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_all": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Todas las redes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべてのネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全部网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_logical_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network: %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerk: %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Red: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク：%@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络：%@"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_multiple": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selected networks"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausgewählte Netzwerke"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redes seleccionadas"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したネットワーク"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选中的网络"
-          }
-        }
-      }
-    },
-    "analysis.statistics.network_unattributed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unattributed events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nicht zugeordnete Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos sin atribución"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "帰属なしのイベント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未归属事件"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_history_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens has not recorded Timeline history for this period. This is not a statement about network health."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat für diesen Zeitraum keine Timeline-Historie aufgezeichnet. Das ist keine Aussage über die Netzwerkgesundheit."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens no registró historial de línea de tiempo para este período. Esto no es una afirmación sobre la salud de la red."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この期間のタイムライン履歴は WiFi Lens に記録されていません。これはネットワークの健全性を示すものではありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_history_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No local history"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine lokale Historie"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin historial local"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカル履歴がありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有本地历史记录"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_matching_events_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens observed this time range, but no events match the current network and filter."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat diesen Zeitraum beobachtet, aber keine Ereignisse passen zum aktuellen Netzwerk und Filter."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens observó este rango de tiempo, pero ningún evento coincide con la red y el filtro actuales."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens はこの期間を観測しましたが、現在のネットワークとフィルターに一致するイベントはありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.no_matching_events_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matching events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine passenden Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sin eventos coincidentes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するイベントがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有匹配的事件"
-          }
-        }
-      }
-    },
     "analysis.statistics.no_result_message": {
       "extractionState": "manual",
       "localizations": {
@@ -4645,76 +1900,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有分析结果"
-          }
-        }
-      }
-    },
-    "analysis.statistics.observation_state_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens records local Timeline observations while the app is observing. New history appears as observations continue."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens zeichnet lokale Timeline-Beobachtungen auf, während die App beobachtet. Neue Historie erscheint, während die Beobachtungen fortgesetzt werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens registra observaciones locales de la línea de tiempo mientras la app está observando. El historial nuevo aparece a medida que continúan las observaciones."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリが観測している間、WiFi Lens はローカルのタイムライン観測を記録します。観測が続くにつれて新しい履歴が表示されます。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
-          }
-        }
-      }
-    },
-    "analysis.statistics.observation_state_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Observation state"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beobachtungsstatus"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado de observación"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "観測状態"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "观测状态"
           }
         }
       }
@@ -4859,41 +2044,6 @@
         }
       }
     },
-    "analysis.statistics.period_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period: %@ – %@"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zeitraum: %@ – %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Período: %@ – %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "期間：%@ – %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周期：%@ – %@"
-          }
-        }
-      }
-    },
     "analysis.statistics.roaming": {
       "extractionState": "manual",
       "localizations": {
@@ -4925,216 +2075,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "漫游"
-          }
-        }
-      }
-    },
-    "analysis.statistics.scope_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scope"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bereich"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ámbito"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "範囲"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "范围"
-          }
-        }
-      }
-    },
-    "analysis.statistics.session_count_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sessions: %lld"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sessions: %lld"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesiones: %lld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セッション数：%lld"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "会话数：%lld"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_critical": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Critical"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kritisch"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crítico"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重大"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "严重"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_distribution": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Severity distribution"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schweregrad-Verteilung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Distribución por gravedad"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重要度の分布"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "严重度分布"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_info": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Info"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "信息"
-          }
-        }
-      }
-    },
-    "analysis.statistics.severity_warning": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnings"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advertencias"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告"
           }
         }
       }
@@ -11312,17 +8252,6 @@
         }
       }
     },
-    "export.success_banner_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snapshot exported successfully"
-          }
-        }
-      }
-    },
     "format.band_channel_separator": {
       "comment": "Band name and channel number in status bar",
       "extractionState": "manual",
@@ -11829,72 +8758,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 秒前"
-          }
-        }
-      }
-    },
-    "guidance.invitation.dont_show_again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do not show again"
-          }
-        }
-      }
-    },
-    "guidance.invitation.later": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Later"
-          }
-        }
-      }
-    },
-    "guidance.invitation.message.diagnostics": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This diagnostic reflects the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
-          }
-        }
-      }
-    },
-    "guidance.invitation.message.export": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This snapshot captures the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
-          }
-        }
-      }
-    },
-    "guidance.invitation.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Explore WiFi Lens Pro"
-          }
-        }
-      }
-    },
-    "guidance.invitation.view_pro": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View WiFi Lens Pro"
           }
         }
       }
@@ -14773,29 +11636,6 @@
         }
       }
     },
-    "network_diagnostics.check.gateway_reachability.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway Reachability"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关可达性"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ到達性"
-          }
-        }
-      }
-    },
     "network_diagnostics.check.internet.title": {
       "extractionState": "manual",
       "localizations": {
@@ -15286,29 +12126,6 @@
         }
       }
     },
-    "network_diagnostics.diagram.router.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Router"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路由器"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ルーター"
-          }
-        }
-      }
-    },
     "network_diagnostics.dns.abnormal.summary": {
       "extractionState": "manual",
       "localizations": {
@@ -15550,75 +12367,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "La resolución de DNS falló para todos los nombres de prueba"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.abnormal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway unreachable"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关不可达"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイに到達できません"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.indeterminate.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway reachability unknown"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关状态未知"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイ到達性不明"
-          }
-        }
-      }
-    },
-    "network_diagnostics.gateway.normal.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway reachable"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网关可达"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ゲートウェイに到達"
           }
         }
       }
@@ -16599,76 +13347,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las rutas de proxy probadas están disponibles"
-          }
-        }
-      }
-    },
-    "network_diagnostics.proxy.tunnel_routes.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routing through a virtual network interface"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过虚拟网卡路由"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仮想ネットワークインターフェース経由でルーティングしています"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Routing über eine virtuelle Netzwerkschnittstelle"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enrutamiento a través de una interfaz de red virtual"
-          }
-        }
-      }
-    },
-    "network_diagnostics.proxy.tunnel_routes_active.summary": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active virtual network interface detected"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクティブな仮想ネットワークインターフェースを検出しました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "检测到活跃的虚拟网络接口"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktive virtuelle Netzwerkschnittstelle erkannt"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se detectó una interfaz de red virtual activa"
           }
         }
       }
@@ -17719,98 +14397,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "状态"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.additional.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Additional Checks"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "附加检测"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加チェック"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.internet.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internet"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "互联网"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インターネット"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.lan.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "LAN"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "局域网连通性"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "LAN"
-          }
-        }
-      }
-    },
-    "network_diagnostics.stage.this_mac.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This Mac"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本机环境"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このMac"
           }
         }
       }
@@ -29944,426 +26530,6 @@
         }
       }
     },
-    "timeline.evidence.context.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events before and after the selected evidence, shown for context."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ereignisse vor und nach den ausgewählten Belegen, zur Einordnung."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos anteriores y posteriores a las pruebas seleccionadas, como contexto."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択した根拠の前後にあるイベントを、前後関係として表示します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选证据前后的事件，供参考上下文。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.context.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Surrounding events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umgebende Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos circundantes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周辺のイベント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周边事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.no_matching.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens was observing during this period, but no events match the selected network and event type."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens hat in diesem Zeitraum beobachtet, aber keine Ereignisse entsprechen dem ausgewählten Netzwerk und Ereignistyp."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens estaba observando durante este período, pero ningún evento coincide con la red y el tipo de evento seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この期間に WiFi Lens は観測していましたが、選択したネットワークとイベントタイプに一致するイベントはありません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.no_matching.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No matching events"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine passenden Ereignisse"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No hay eventos coincidentes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一致するイベントがありません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "没有匹配的事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.not_found.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "None of the supporting events for this insight exist in the selected period and network."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keines der Belegereignisse für diese Erkenntnis existiert im ausgewählten Zeitraum und Netzwerk."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ninguno de los eventos de respaldo de esta conclusión existe en el período y la red seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークには存在しません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.not_found.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supporting events not found"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belegereignisse nicht gefunden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontraron eventos de respaldo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根拠となるイベントが見つかりません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到支持事件"
-          }
-        }
-      }
-    },
-    "timeline.evidence.partial.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only %lld of %lld supporting events for this insight exist in the selected period and network."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nur %lld von %lld Belegereignissen für diese Erkenntnis existieren im ausgewählten Zeitraum und Netzwerk."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo %lld de %lld eventos de respaldo de esta conclusión existen en el período y la red seleccionados."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークに %2$lld 件中 %1$lld 件のみ存在します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.partial.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Some supporting events are missing"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einige Belegereignisse fehlen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Faltan algunos eventos de respaldo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一部の根拠イベントが見つかりません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "部分支持事件缺失"
-          }
-        }
-      }
-    },
-    "timeline.evidence.query_failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The supporting Timeline history could not be read, so no events are shown instead of incomplete evidence."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die unterstützende Timeline-Historie konnte nicht gelesen werden. Es werden keine Ereignisse angezeigt, statt unvollständiger Belege."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer el historial de la línea de tiempo de respaldo, por lo que no se muestran eventos en lugar de evidencias incompletas."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根拠となるタイムライン履歴を読み取れなかったため、不完全な証拠の代わりにイベントを表示しません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.query_failure.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Evidence query failed"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abfrage der Belege fehlgeschlagen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error al consultar las evidencias"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "証拠のクエリに失敗しました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "证据查询失败"
-          }
-        }
-      }
-    },
-    "timeline.evidence.storage_failure.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local Timeline history could not be read, so the supporting events cannot be verified."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die lokale Timeline-Historie konnte nicht gelesen werden, daher können die Belegereignisse nicht überprüft werden."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se pudo leer el historial local de la línea de tiempo, por lo que no se pueden verificar los eventos de respaldo."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカルのタイムライン履歴を読み取れないため、根拠となるイベントを確認できません。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法读取本地时间线历史，因此无法验证支持事件。"
-          }
-        }
-      }
-    },
-    "timeline.evidence.storage_failure.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History storage unavailable"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Historienspeicher nicht verfügbar"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Almacenamiento de historial no disponible"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴ストレージを利用できません"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "历史记录存储不可用"
-          }
-        }
-      }
-    },
     "timeline.filter.all": {
       "comment": "Timeline filter for all events",
       "extractionState": "manual",
@@ -32331,6 +28497,3840 @@
     },
     "⌘Q": {
       "shouldTranslate": false
+    },
+    "analysis.statistics.scope_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scope"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ámbito"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "範囲"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "范围"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_all": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las redes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_logical_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：%@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_access_point_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_multiple": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redes seleccionadas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中的网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network_unattributed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unattributed events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht zugeordnete Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos sin atribución"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帰属なしのイベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未归属事件"
+          }
+        }
+      }
+    },
+    "analysis.statistics.period_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period: %@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitraum: %@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Período: %@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間：%@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周期：%@ – %@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.coverage_percent_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage: %lld%%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung: %lld%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura: %lld%%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジ：%lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖：%lld%%"
+          }
+        }
+      }
+    },
+    "analysis.statistics.session_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesiones: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション数：%lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "会话数：%lld"
+          }
+        }
+      }
+    },
+    "analysis.statistics.connection_changes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection changes"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindungswechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de conexión"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接变化"
+          }
+        }
+      }
+    },
+    "analysis.statistics.gateway_latency_observations": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Latenzbeobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones de latencia del gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の観測"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关延迟观测"
+          }
+        }
+      }
+    },
+    "analysis.statistics.ap_switching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP switching"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Wechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切り替え"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切换"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_distribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Severity distribution"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schweregrad-Verteilung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distribución por gravedad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要度の分布"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "严重度分布"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencias"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
+    "analysis.statistics.severity_critical": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Critical"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kritisch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crítico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "严重"
+          }
+        }
+      }
+    },
+    "analysis.statistics.most_concentrated_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Most concentrated interval: %@ · %lld events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konzentriertestes Intervall: %@ · %lld Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalo más concentrado: %@ · %lld eventos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最も集中している期間：%@（%lld 件）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最集中区间：%@（%lld 个事件）"
+          }
+        }
+      }
+    },
+    "analysis.statistics.latest_notable_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest notable event: %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letztes bemerkenswertes Ereignis: %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Último evento notable: %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近の注目イベント：%@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近的重要事件：%@ · %@"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compared with previous period"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vergleich mit dem vorherigen Zeitraum"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comparación con el período anterior"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前の期間との比較"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与上一周期比较"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_total_change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event total change: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderung der Ereignisanzahl: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio total de eventos: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント合計の変化：%lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件总数变化：%lld"
+          }
+        }
+      }
+    },
+    "analysis.statistics.comparison_percent_change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative change: %.1f%%"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative Änderung: %.1f%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambio relativo: %.1f%%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相対変化：%.1f%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相对变化：%.1f%%"
+          }
+        }
+      }
+    },
+    "analysis.insights.metadata_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Category %@ · %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie %@ · %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categoría %@ · %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カテゴリ %@ · %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类别 %@ · %@ · %@"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence: %d events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege: %d Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidencia: %d eventos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンス: %d 件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据：%d 个事件"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_range_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        }
+      }
+    },
+    "analysis.insights.evidence_duration_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cluster duration: %d min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clusterdauer: %d Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración del clúster: %d min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラスターの継続時間: %d 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚类持续时长：%d 分钟"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.connectivity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectivity"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnektivität"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectividad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続性"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接性"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.performance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performance"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leistung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendimiento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パフォーマンス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "性能"
+          }
+        }
+      }
+    },
+    "analysis.insights.category.stability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stability"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stabilität"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estabilidad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安定性"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稳定性"
+          }
+        }
+      }
+    },
+    "analysis.insights.severity.informational": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informational"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informativo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
+        }
+      }
+    },
+    "analysis.insights.severity.warning": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.high": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hohe Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza alta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 高"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高置信度"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittlere Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza media"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中等置信度"
+          }
+        }
+      }
+    },
+    "analysis.insights.confidence.low": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low confidence"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niedrige Zuversicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confianza baja"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼度: 低"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低置信度"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.coverage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura no disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖率不可用"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.incomplete_coverage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage incomplete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckung unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cobertura incompleta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カバレッジが不完全です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖率不完整"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.session_boundary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence crosses a session boundary"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege überschreiten eine Sitzungsgrenze"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La evidencia cruza un límite de sesión"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンスがセッション境界をまたいでいます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据跨越会话边界"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_ssid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el SSID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 SSID"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_bssid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta el BSSID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 BSSID"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.missing_gateway_identity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway identity missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway-Identität fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta la identidad de la puerta de enlace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ ID がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少网关标识"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.ambiguous_normal_behavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal behavior cannot be ruled out"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normales Verhalten kann nicht ausgeschlossen werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede descartar un comportamiento normal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正常な動作を除外できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法排除正常行为"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.cross_network_evidence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence spans networks"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belege erstrecken sich über mehrere Netzwerke"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La evidencia abarca varias redes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エビデンスが複数ネットワークにわたります"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据跨多个网络"
+          }
+        }
+      }
+    },
+    "analysis.insight.limitation.threshold_not_met": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Threshold not met"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwelle nicht erreicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral no alcanzado"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "しきい値に達していません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未达到阈值"
+          }
+        }
+      }
+    },
+    "analysis.statistics.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_history_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No local history"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine lokale Historie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin historial local"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有本地历史记录"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens has not recorded Timeline history for this period. This is not a statement about network health."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat für diesen Zeitraum keine Timeline-Historie aufgezeichnet. Das ist keine Aussage über die Netzwerkgesundheit."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens no registró historial de línea de tiempo para este período. Esto no es una afirmación sobre la salud de la red."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間のタイムライン履歴は WiFi Lens に記録されていません。これはネットワークの健全性を示すものではありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.observation_state_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation state"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungsstatus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de observación"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測状態"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测状态"
+          }
+        }
+      }
+    },
+    "analysis.statistics.observation_state_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens records local Timeline observations while the app is observing. New history appears as observations continue."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens zeichnet lokale Timeline-Beobachtungen auf, während die App beobachtet. Neue Historie erscheint, während die Beobachtungen fortgesetzt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens registra observaciones locales de la línea de tiempo mientras la app está observando. El historial nuevo aparece a medida que continúan las observaciones."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリが観測している間、WiFi Lens はローカルのタイムライン観測を記録します。観測が続くにつれて新しい履歴が表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.local_history_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local history"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Historie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial local"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地历史记录"
+          }
+        }
+      }
+    },
+    "analysis.statistics.local_history_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is stored locally on this Mac. You can clear it in Settings → Data."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert. Sie können sie unter Einstellungen → Daten löschen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial se almacena localmente en este Mac. Puedes borrarlo en Ajustes → Datos."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴はこの Mac にローカル保存されます。設定 → データで消去できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_matching_events_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin eventos coincidentes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するイベントがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的事件"
+          }
+        }
+      }
+    },
+    "analysis.statistics.no_matching_events_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens observed this time range, but no events match the current network and filter."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat diesen Zeitraum beobachtet, aber keine Ereignisse passen zum aktuellen Netzwerk und Filter."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens observó este rango de tiempo, pero ningún evento coincide con la red y el filtro actuales."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens はこの期間を観測しましたが、現在のネットワークとフィルターに一致するイベントはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording local observations is active"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Beobachtungen werden aktiv aufgezeichnet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación de observaciones locales está activa"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測の記録中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在记录本地观测"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observation_range_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed %@ – %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtet %@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observado %@ – %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測 %@ – %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测 %@ – %@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.observed_duration_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed duration: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtungsdauer: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración observada: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測時間: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测时长：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.coverage_gap_count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coverage gaps: %lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdeckungslücken: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brechas de cobertura: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "範囲の欠落: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖缺口：%lld"
+          }
+        }
+      }
+    },
+    "analysis.readiness.local_storage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History is stored locally on this Mac."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Historie wird lokal auf diesem Mac gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial se almacena localmente en este Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴はこの Mac にローカル保存されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储在本机本地。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.storage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local history storage is unavailable."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der lokale Historienspeicher ist nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El almacenamiento de historial local no está disponible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル履歴ストレージを利用できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地历史记录存储不可用。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rules_eligible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All rules can run for the selected scope."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Regeln können für den ausgewählten Bereich ausgeführt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las reglas pueden ejecutarse para el ámbito seleccionado."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したスコープではすべてのルールを実行できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选作用域可以运行所有规则。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rules_blocked_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rules unavailable: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regeln nicht verfügbar: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reglas no disponibles: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行できないルール: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法运行的规则：%@"
+          }
+        }
+      }
+    },
+    "analysis.rule.category.repeated_disconnection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated disconnection"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Trennung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconexión repetida"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断の繰り返し"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重复断开"
+          }
+        }
+      }
+    },
+    "analysis.rule.category.gateway_interruption": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repeated gateway-latency observations"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederholte Gateway-Latenz-Beobachtungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observaciones repetidas de latencia de gateway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ遅延の繰り返し"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重复的网关延迟观测"
+          }
+        }
+      }
+    },
+    "analysis.rule.category.roaming_instability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP switching"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Wechsel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios de AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切り替え"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 切换"
+          }
+        }
+      }
+    },
+    "analysis.readiness.duration_minutes_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分钟"
+          }
+        }
+      }
+    },
+    "analysis.readiness.duration_hours_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld h %lld min"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Std. %lld Min."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld h %lld min"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 時間 %lld 分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小时 %lld 分钟"
+          }
+        }
+      }
+    },
+    "analysis.insights.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_logical_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_access_point_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.network_unattributed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network: unattributed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk: nicht zugeordnet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red: no atribuida"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク: 未分類"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络：无法归属"
+          }
+        }
+      }
+    },
+    "analysis.insights.gateway_identity_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.bssid_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSIDs: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID：%@"
+          }
+        }
+      }
+    },
+    "analysis.insights.trust_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        }
+      }
+    },
+    "analysis.insights.applicability.applicable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwendbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用"
+          }
+        }
+      }
+    },
+    "analysis.insights.applicability.limited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limited applicability"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkt anwendbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicabilidad limitada"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用は限定的"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用性有限"
+          }
+        }
+      }
+    },
+    "timeline.evidence.query_failure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence query failed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abfrage der Belege fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al consultar las evidencias"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠のクエリに失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据查询失败"
+          }
+        }
+      }
+    },
+    "timeline.evidence.query_failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The supporting Timeline history could not be read, so no events are shown instead of incomplete evidence."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die unterstützende Timeline-Historie konnte nicht gelesen werden. Es werden keine Ereignisse angezeigt, statt unvollständiger Belege."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el historial de la línea de tiempo de respaldo, por lo que no se muestran eventos en lugar de evidencias incompletas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根拠となるタイムライン履歴を読み取れなかったため、不完全な証拠の代わりにイベントを表示しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.storage_failure.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History storage unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historienspeicher nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento de historial no disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴ストレージを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录存储不可用"
+          }
+        }
+      }
+    },
+    "timeline.evidence.storage_failure.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Timeline history could not be read, so the supporting events cannot be verified."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die lokale Timeline-Historie konnte nicht gelesen werden, daher können die Belegereignisse nicht überprüft werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el historial local de la línea de tiempo, por lo que no se pueden verificar los eventos de respaldo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルのタイムライン履歴を読み取れないため、根拠となるイベントを確認できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取本地时间线历史，因此无法验证支持事件。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.not_found.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supporting events not found"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belegereignisse nicht gefunden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron eventos de respaldo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根拠となるイベントが見つかりません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到支持事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.not_found.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None of the supporting events for this insight exist in the selected period and network."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keines der Belegereignisse für diese Erkenntnis existiert im ausgewählten Zeitraum und Netzwerk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguno de los eventos de respaldo de esta conclusión existe en el período y la red seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークには存在しません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.no_matching.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay eventos coincidentes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するイベントがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.no_matching.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens was observing during this period, but no events match the selected network and event type."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens hat in diesem Zeitraum beobachtet, aber keine Ereignisse entsprechen dem ausgewählten Netzwerk und Ereignistyp."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens estaba observando durante este período, pero ningún evento coincide con la red y el tipo de evento seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この期間に WiFi Lens は観測していましたが、選択したネットワークとイベントタイプに一致するイベントはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_unavailable_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot evaluate now: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuell nicht bewertbar: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede evaluar ahora: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在は評価できません：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前无法评估：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_limited_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limited analysis: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschränkte Analyse: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análisis limitado: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "限定分析：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有限分析：%@"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_limited_basis": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Judgment is based only on recorded events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Bewertung basiert nur auf aufgezeichneten Ereignissen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El juicio se basa solo en los eventos registrados"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録されたイベントのみに基づく判断です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅根据已经记录的事件进行判断"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason_prefix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reason: "
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grund: "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motivo: "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "理由："
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原因："
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.not_single_network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current analysis scope is not a single network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der aktuelle Analysebereich ist kein einzelnes Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El ámbito de análisis actual no es una única red"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の分析スコープは単一ネットワークではありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前分析范围不是单一网络"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.unattributed_scope": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Events cannot be attributed to a specific network"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse können keinem bestimmten Netzwerk zugeordnet werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los eventos no pueden atribuirse a una red específica"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントを特定のネットワークに帰属できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件无法归属到具体网络"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_ssid_attribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The required network name information is missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die erforderlichen Netzwerknamen-Informationen fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta la información del nombre de red necesaria"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必要なネットワーク名の情報がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少必要的网络名称信息"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_event_capability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The current data lacks the event type this rule needs"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den aktuellen Daten fehlt der Ereignistyp, den diese Regel benötigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los datos actuales no incluyen el tipo de evento que requiere esta regla"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のデータには、このルールが必要とするイベントタイプがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前数据缺少该规则需要的事件类型"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_router_identity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The gateway identity cannot be confirmed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Gateway-Identität kann nicht bestätigt werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede confirmar la identidad de la puerta de enlace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイの識別情報を確認できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法确认网关身份"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.coverage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage is unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Beobachtungsabdeckung ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura de observación no está disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測カバレッジを利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测覆盖不可用"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.coverage_incomplete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observation coverage is incomplete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Beobachtungsabdeckung ist unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cobertura de observación está incompleta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測カバレッジが不完全です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "观测覆盖不完整"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.history_too_short": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The recorded history is too short"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die aufgezeichnete Historie ist zu kurz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El historial registrado es demasiado corto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録された履歴が短すぎます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录太短"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.missing_bssid_metadata": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access point information is missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP-Informationen fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta información del AP"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP 情報がありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少 AP 信息"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.all_networks_overview": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The overview scope can only provide informational conclusions"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Überblicksbereich kann nur informative Schlussfolgerungen liefern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El ámbito de resumen solo puede proporcionar conclusiones informativas"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要スコープは情報提供のみの結論しか出せません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概览范围只能提供信息性结论"
+          }
+        }
+      }
+    },
+    "analysis.readiness.rule_reason.storage_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The storage layer is unavailable"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Speicherebene ist nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capa de almacenamiento no está disponible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ層を利用できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储层不可用"
+          }
+        }
+      }
+    },
+    "analysis.readiness.not_observing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording local observations is inactive"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Aufzeichnung lokaler Beobachtungen ist inaktiv"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación de observaciones locales está inactiva"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカル観測の記録は停止中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未在记录本地观测"
+          }
+        }
+      }
+    },
+    "timeline.evidence.partial.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some supporting events are missing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige Belegereignisse fehlen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faltan algunos eventos de respaldo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部の根拠イベントが見つかりません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分支持事件缺失"
+          }
+        }
+      }
+    },
+    "timeline.evidence.partial.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only %lld of %lld supporting events for this insight exist in the selected period and network."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur %lld von %lld Belegereignissen für diese Erkenntnis existieren im ausgewählten Zeitraum und Netzwerk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo %lld de %lld eventos de respaldo de esta conclusión existen en el período y la red seleccionados."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このインサイトの根拠となるイベントは、選択した期間とネットワークに %2$lld 件中 %1$lld 件のみ存在します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
+          }
+        }
+      }
+    },
+    "timeline.evidence.context.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surrounding events"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umgebende Ereignisse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos circundantes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周辺のイベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周边事件"
+          }
+        }
+      }
+    },
+    "timeline.evidence.context.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Events before and after the selected evidence, shown for context."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ereignisse vor und nach den ausgewählten Belegen, zur Einordnung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eventos anteriores y posteriores a las pruebas seleccionadas, como contexto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した根拠の前後にあるイベントを、前後関係として表示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选证据前后的事件，供参考上下文。"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.this_mac.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机环境"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMac"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.lan.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "局域网连通性"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.internet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "互联网"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インターネット"
+          }
+        }
+      }
+    },
+    "network_diagnostics.stage.additional.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Additional Checks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附加检测"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加チェック"
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.gateway_reachability.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway Reachability"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关可达性"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ到達性"
+          }
+        }
+      }
+    },
+    "network_diagnostics.diagram.router.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Router"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路由器"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ルーター"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.normal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway reachable"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关可达"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイに到達"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.abnormal.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway unreachable"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关不可达"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイに到達できません"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.indeterminate.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway reachability unknown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关状态未知"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイ到達性不明"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.tunnel_routes.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routing through a virtual network interface"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过虚拟网卡路由"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仮想ネットワークインターフェース経由でルーティングしています"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routing über eine virtuelle Netzwerkschnittstelle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enrutamiento a través de una interfaz de red virtual"
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.tunnel_routes_active.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active virtual network interface detected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブな仮想ネットワークインターフェースを検出しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到活跃的虚拟网络接口"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktive virtuelle Netzwerkschnittstelle erkannt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó una interfaz de red virtual activa"
+          }
+        }
+      }
+    },
+    "guidance.invitation.message.export": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This snapshot captures the current network state. WiFi Lens Pro can retain changes over time and help identify intermittent problems and long-term trends."
+          }
+        }
+      }
+    },
+    "export.success_banner_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot exported successfully"
+          }
+        }
+      }
     }
   }
 }

--- a/WiFiLens/Sources/WiFiLens/Roaming/RoamingTestViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Roaming/RoamingTestViewModel.swift
@@ -21,10 +21,12 @@ final class RoamingTestViewModel {
 
     init(
         roamingProvider: RoamingProbeProviding = RoamingProbeProvider(),
-        latencyProvider: GatewayLatencyProviding = GatewayLatencyProvider()
+        latencyProvider: GatewayLatencyProviding = GatewayLatencyProvider(),
+        guidance: GuidanceCoordinator = .shared
     ) {
         self.roamingProvider = roamingProvider
         self.latencyProvider = latencyProvider
+        self.guidance = guidance
     }
 
     // MARK: - State
@@ -54,6 +56,10 @@ final class RoamingTestViewModel {
 
     let roamingProvider: RoamingProbeProviding
     let latencyProvider: GatewayLatencyProviding
+
+    // MARK: - Guidance
+
+    @ObservationIgnored private let guidance: GuidanceCoordinator
 
     // MARK: - Private
 
@@ -106,7 +112,9 @@ final class RoamingTestViewModel {
             }
 
         case .poweredOff, .interfaceUnavailable:
-            stopTest()
+            // Power-off and interface-loss interruptions are never recorded as
+            // useful roaming completions.
+            stopTest(userInitiated: false)
             self.state = .idle
             errorMessage = nil
         }
@@ -145,7 +153,8 @@ final class RoamingTestViewModel {
         }
     }
 
-    func stopTest() {
+    func stopTest(userInitiated: Bool = true) {
+        let wasRunning = state == .running
         timer?.invalidate()
         timer = nil
 
@@ -156,6 +165,12 @@ final class RoamingTestViewModel {
 
         refreshConnectionInfo()
         state = .stopped
+
+        // A normal user-initiated stop of a live test is a useful roaming
+        // completion; idle stops and power-off interruptions are not.
+        if userInitiated, wasRunning {
+            guidance.record(.roamingCompleted)
+        }
     }
 
     // MARK: - Tick

--- a/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
+++ b/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
@@ -9,7 +9,7 @@ enum ExportSuccessPresentation: Equatable, Sendable {
     case preserveExisting  // Pro: keep the existing success alert
 }
 
-/// Snapshot export service for the OSS target.
+/// Shared PNG snapshot export service used by both editions.
 /// Composites all visible band charts into a single high-resolution PNG image.
 @MainActor
 enum ExportService {

--- a/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
+++ b/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
@@ -82,7 +82,17 @@ enum ExportService {
                 do {
                     try png.write(to: url)
                     await MainActor.run {
-                        showSuccess(String(localized: "export.image_saved_message", comment: "Chart image exported successfully"))
+                        // Presentation is an explicit edition strategy: OSS shows the
+                        // non-modal banner (which records the moment), Pro keeps its
+                        // existing success alert and records the moment for rating
+                        // eligibility only.
+                        switch EditionComposition.exportSuccessPresentation {
+                        case .banner:
+                            GuidanceCoordinator.shared.handleExportSucceeded()
+                        case .preserveExisting:
+                            GuidanceCoordinator.shared.record(.exportSucceeded)
+                            showSuccess(String(localized: "export.image_saved_message", comment: "Chart image exported successfully"))
+                        }
                     }
                 } catch {
                     await MainActor.run {

--- a/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
+++ b/WiFiLens/Sources/WiFiLens/SnapshotExport/ExportService.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import AppKit
 import UniformTypeIdentifiers
 
+/// How export success feedback is presented. A presentation concern only —
+/// the guidance policy never reads it.
+enum ExportSuccessPresentation: Equatable, Sendable {
+    case banner            // OSS: non-modal success banner + invitation
+    case preserveExisting  // Pro: keep the existing success alert
+}
+
 /// Snapshot export service for the OSS target.
 /// Composites all visible band charts into a single high-resolution PNG image.
 @MainActor

--- a/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
+++ b/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ExternalDestination {
     case privacyPolicy
     case appStore
+    case appStoreWriteReview
     case appStoreCampaign
     case website
     case github
@@ -20,6 +21,8 @@ enum ExternalLinks {
             "https://wifi-lens.shiinalabs.com/privacy"
         case .appStore:
             "https://apps.apple.com/app/wifi-lens-pro/id6776590746"
+        case .appStoreWriteReview:
+            "https://apps.apple.com/app/wifi-lens-pro/id6776590746?action=write-review"
         case .appStoreCampaign:
             // Official App Store Connect "oss_invite" Campaign Link. Regenerate
             // from App Analytics -> Campaigns if the campaign changes; never

--- a/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
+++ b/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ExternalDestination {
     case privacyPolicy
     case appStore
+    case appStoreCampaign
     case website
     case github
     case xAccount
@@ -19,6 +20,11 @@ enum ExternalLinks {
             "https://wifi-lens.shiinalabs.com/privacy"
         case .appStore:
             "https://apps.apple.com/app/wifi-lens-pro/id6776590746"
+        case .appStoreCampaign:
+            // Official App Store Connect "oss_invite" Campaign Link. Regenerate
+            // from App Analytics -> Campaigns if the campaign changes; never
+            // handcraft the pt/ct parameters.
+            "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_invite&mt=8"
         case .website:
             "https://wifi-lens.shiinalabs.com"
         case .github:

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -321,6 +321,13 @@ private struct AppRootView: View {
             installMainWindowOpenAction {
                 openWindow(id: WiFiLensApp.mainWindowSceneID)
             }
+#if DEBUG
+            // Debug-only: lets the Debug menu render the production
+            // diagnostics result host without running a real diagnostic.
+            GuidanceDebugOverrides.installDiagnosticsStaging {
+                networkDiagnosticsViewModel.debugStageCompletedResult()
+            }
+#endif
             // Under `xcodebuild test` the app process hosts the unit test
             // bundle, so the real scanner must not start: CoreWLAN and
             // NetworkInfoService are synchronous XPC calls that can stall the
@@ -1146,6 +1153,12 @@ struct WiFiLensApp: App {
                     sparkleUpdater.checkForUpdates()
                 }
             }
+#endif
+
+#if DEBUG
+            EditionComposition.debugCommands(
+                showMainWindow: { showMainWindow(route: $0) }
+            )
 #endif
 
         }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -327,7 +327,8 @@ private struct AppRootView: View {
             // NetworkInfoService are synchronous XPC calls that can stall the
             // test process. Unit tests inject their own stores and fakes.
             if !ProcessInfo.processInfo.isRunningUnderTestHost {
-                if !UITestMode.isActive {
+                if !UITestMode.isActive,
+                   EditionComposition.onboardingConfiguration.welcomeEnabled {
                     _ = onboardingCoordinator.claimWelcome(hostID: sceneState.id)
                 }
                 EditionComposition.startLifecycle(observationRuntime: viewModel.observationRuntime)
@@ -361,6 +362,7 @@ private struct AppRootView: View {
         .onChange(of: onboardingCoordinator.debugShowRequested) { _, requested in
             guard requested,
                   onboardingCoordinator.consumeDebugShowRequest(),
+                  EditionComposition.onboardingConfiguration.welcomeEnabled,
                   !UITestMode.isActive,
                   !ProcessInfo.processInfo.isRunningUnderTestHost else {
                 return

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -349,8 +349,11 @@ private struct AppRootView: View {
                 configuration: EditionComposition.onboardingConfiguration,
                 coordinator: onboardingCoordinator,
                 hostID: sceneState.id,
-                onStart: { route in
+                onStart: { route, selection in
                     sceneState.route(to: route)
+                    if let selection {
+                        secondaryToolbarSelections.setSelection(selection, for: route)
+                    }
                 }
             )
         }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -321,6 +321,7 @@ private struct AppRootView: View {
             // test process. Unit tests inject their own stores and fakes.
             if !ProcessInfo.processInfo.isRunningUnderTestHost {
                 EditionComposition.startLifecycle(observationRuntime: viewModel.observationRuntime)
+                GuidanceCoordinator.shared.recordAppActive()
                 await viewModel.start()
                 roamingViewModel.handleWiFiPowerStateChange(viewModel.wifiPowerState)
             }
@@ -328,6 +329,7 @@ private struct AppRootView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active, !ProcessInfo.processInfo.isRunningUnderTestHost {
+                GuidanceCoordinator.shared.recordAppActive()
                 Task { await viewModel.handleSceneDidBecomeActive() }
             }
         }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -249,6 +249,12 @@ private struct AppRootView: View {
     #endif
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .overlay(alignment: .bottom) {
+                    // OSS `.banner` export strategy only: renders while the
+                    // coordinator publishes export feedback; no-op in Pro
+                    // (`.preserveExisting` never publishes feedback).
+                    ExportSuccessBanner(guidance: GuidanceCoordinator.shared)
+                }
             }
         }
     }

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -44,6 +44,7 @@ private struct AppRootView: View {
     var bleViewModel: BLEViewModel?
     @Binding var showCrashLog: Bool
     @Binding var crashLogText: String
+    let onboardingCoordinator: OnboardingCoordinator
     let sparkleUpdater: SparkleUpdater
     let updateMCPServer: @MainActor () -> Void
     let installMainWindowOpenAction: (@escaping () -> Void) -> Void
@@ -321,24 +322,51 @@ private struct AppRootView: View {
             installMainWindowOpenAction {
                 openWindow(id: WiFiLensApp.mainWindowSceneID)
             }
-#if DEBUG
-            // Debug-only: lets the Debug menu render the production
-            // diagnostics result host without running a real diagnostic.
-            GuidanceDebugOverrides.installDiagnosticsStaging {
-                networkDiagnosticsViewModel.debugStageCompletedResult()
-            }
-#endif
             // Under `xcodebuild test` the app process hosts the unit test
             // bundle, so the real scanner must not start: CoreWLAN and
             // NetworkInfoService are synchronous XPC calls that can stall the
             // test process. Unit tests inject their own stores and fakes.
             if !ProcessInfo.processInfo.isRunningUnderTestHost {
+                if !UITestMode.isActive {
+                    _ = onboardingCoordinator.claimWelcome(hostID: sceneState.id)
+                }
                 EditionComposition.startLifecycle(observationRuntime: viewModel.observationRuntime)
                 GuidanceCoordinator.shared.recordAppActive()
                 await viewModel.start()
                 roamingViewModel.handleWiFiPowerStateChange(viewModel.wifiPowerState)
             }
             updateMCPServer()
+        }
+        .sheet(isPresented: Binding(
+            get: { onboardingCoordinator.welcomeHostID == sceneState.id },
+            set: { isPresented in
+                if !isPresented, onboardingCoordinator.welcomeHostID == sceneState.id {
+                    onboardingCoordinator.releaseWelcome(hostID: sceneState.id)
+                }
+            }
+        )) {
+            WelcomeView(
+                configuration: EditionComposition.onboardingConfiguration,
+                coordinator: onboardingCoordinator,
+                hostID: sceneState.id,
+                onStart: { route in
+                    sceneState.route(to: route)
+                }
+            )
+        }
+#if DEBUG
+        .onChange(of: onboardingCoordinator.debugShowRequested) { _, requested in
+            guard requested,
+                  onboardingCoordinator.consumeDebugShowRequest(),
+                  !UITestMode.isActive,
+                  !ProcessInfo.processInfo.isRunningUnderTestHost else {
+                return
+            }
+            _ = onboardingCoordinator.claimWelcome(hostID: sceneState.id)
+        }
+#endif
+        .onDisappear {
+            onboardingCoordinator.releaseWelcome(hostID: sceneState.id)
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active, !ProcessInfo.processInfo.isRunningUnderTestHost {
@@ -944,6 +972,17 @@ struct WiFiLensApp: App {
     private let macVendorDatabaseSummary: MACVendorBundledDatabaseSummary?
     @State private var roamingViewModel = RoamingTestViewModel()
     @State private var bleViewModel: BLEViewModel?
+    /// Declared before `sparkleUpdater` so the existing-install migration
+    /// observes `SUEnableAutomaticChecks` before Sparkle writes it on a
+    /// brand-new install (Swift storage properties initialize in declaration
+    /// order).
+    private let onboardingCoordinator: OnboardingCoordinator = {
+        let coordinator = OnboardingCoordinator.shared
+        if !UITestMode.isActive, ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+            coordinator.migrateExistingInstallationIfNeeded()
+        }
+        return coordinator
+    }()
     @State private var sparkleUpdater = SparkleUpdater()
     @State private var showCrashLog: Bool = false
     @State private var mainWindowLifecycle = MainWindowLifecycleCoordinator()
@@ -1001,6 +1040,7 @@ struct WiFiLensApp: App {
                     bleViewModel: bleViewModel,
                     showCrashLog: $showCrashLog,
                     crashLogText: $crashLogText,
+                    onboardingCoordinator: onboardingCoordinator,
                     sparkleUpdater: sparkleUpdater,
                     updateMCPServer: updateMCPServer,
                     installMainWindowOpenAction: mainWindowLifecycle.installOpenSceneAction,

--- a/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
@@ -13,6 +13,14 @@ struct ExternalLinksTests {
         #expect(ExternalLinks.url(for: .appStore)?.absoluteString == "https://apps.apple.com/app/wifi-lens-pro/id6776590746")
     }
 
+    @Test("app store campaign maps to the official oss_invite campaign link")
+    func appStoreCampaignURL() {
+        #expect(
+            ExternalLinks.url(for: .appStoreCampaign)?.absoluteString
+                == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_invite&mt=8"
+        )
+    }
+
     @Test("dependency repositories keep their current public locations")
     func dependencyRepositoryURLs() {
         #expect(ExternalLinks.url(for: .chartLensRepository)?.absoluteString == "https://github.com/SHIINASAMA/chart-lens")

--- a/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
@@ -13,6 +13,14 @@ struct ExternalLinksTests {
         #expect(ExternalLinks.url(for: .appStore)?.absoluteString == "https://apps.apple.com/app/wifi-lens-pro/id6776590746")
     }
 
+    @Test("app store write-review maps to the manual rating destination")
+    func appStoreWriteReviewURL() {
+        #expect(
+            ExternalLinks.url(for: .appStoreWriteReview)?.absoluteString
+                == "https://apps.apple.com/app/wifi-lens-pro/id6776590746?action=write-review"
+        )
+    }
+
     @Test("app store campaign maps to the official oss_invite campaign link")
     func appStoreCampaignURL() {
         #expect(

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
@@ -347,6 +347,37 @@ final class GuidanceCoordinatorTests {
         #expect(events(named: "guidance.invitation.disabled").count == 1)
     }
 
+    // MARK: - Invitation card copy
+
+    @Test func invitationCardCopySelectsPerMoment() {
+        #expect(ProInvitationCard.messageKey(for: .diagnosticsCompleted) == "guidance.invitation.message.diagnostics")
+        #expect(ProInvitationCard.messageKey(for: .exportSucceeded) == "guidance.invitation.message.export")
+        #expect(ProInvitationCard.messageKey(for: .analysisLoaded) == "guidance.invitation.message.diagnostics")
+        #expect(ProInvitationCard.messageKey(for: .roamingCompleted) == "guidance.invitation.message.diagnostics")
+    }
+
+    @Test func diagnosticsCompletionsCrossThresholdOnThirdUsefulCompletion() {
+        let coordinator = makeCoordinator(state: GuidanceState(
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: 0
+        ))
+
+        #expect(coordinator.record(.diagnosticsCompleted) == .none(.completionThresholdNotMet))
+        #expect(coordinator.record(.diagnosticsCompleted) == .none(.completionThresholdNotMet))
+        #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
+
+        let invitation = coordinator.pendingInvitation
+        #expect(invitation?.moment == .diagnosticsCompleted)
+        let loaded = store.load()
+        #expect(loaded.meaningfulCompletionCount == 3)
+        #expect(loaded.invitationPresentationCount == 0)
+
+        if let id = invitation?.id {
+            coordinator.invitationPresented(id: id)
+        }
+        #expect(store.load().invitationPresentationCount == 1)
+    }
+
     // MARK: - Events
 
     @Test func eventSinkCapturesValueMomentScheduledPresentedDismissed() {

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
@@ -415,6 +415,17 @@ final class GuidanceCoordinatorTests {
         #expect(coordinator.pendingInvitation == nil)
     }
 
+    @Test func roamingCompletionsDoNotAdvanceInvitationEligibility() {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 0))
+        _ = coordinator.record(.roamingCompleted)
+        _ = coordinator.record(.roamingCompleted)
+
+        #expect(store.load().meaningfulCompletionCount == 0)
+        #expect(coordinator.record(.diagnosticsCompleted) == .none(.completionThresholdNotMet))
+        #expect(coordinator.record(.diagnosticsCompleted) == .none(.completionThresholdNotMet))
+        #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
+    }
+
     @Test func reviewEventsOncePerToken() {
         let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
         _ = coordinator.record(.analysisLoaded)

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import WiFi_Lens
 
@@ -423,6 +425,71 @@ final class GuidanceCoordinatorTests {
         #expect(events(named: "guidance.review.request_invoked").count == 1)
     }
 
+    // MARK: - Export banner view
+
+    @Test func exportBannerHostsInvitationAndConfirmsPresentation() throws {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 3))
+        coordinator.handleExportSucceeded()
+        let invitation = try #require(coordinator.pendingInvitation)
+        #expect(invitation.moment == .exportSucceeded)
+
+        let host = BannerHost(content: ExportSuccessBanner(guidance: coordinator))
+        host.flushLayout()
+
+        #expect(store.load().invitationPresentationCount == 1)
+        #expect(events(named: "guidance.invitation.presented").count == 1)
+    }
+
+    @Test func exportBannerWithoutInvitationShowsFeedbackOnly() throws {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 0))
+        coordinator.handleExportSucceeded()
+        #expect(coordinator.pendingInvitation == nil)
+
+        let host = BannerHost(content: ExportSuccessBanner(guidance: coordinator))
+        host.flushLayout()
+
+        #expect(events(named: "guidance.invitation.presented").isEmpty)
+        #expect(store.load().invitationPresentationCount == 0)
+    }
+
+    @Test func exportBannerDisappearAfterPresentationConsumesAsLater() throws {
+        let coordinator = makeCoordinator(state: invitationState())
+        coordinator.handleExportSucceeded()
+        let invitation = try #require(coordinator.pendingInvitation)
+
+        let host = BannerHost(content: ExportSuccessBanner(guidance: coordinator))
+        host.flushLayout()
+        #expect(store.load().invitationPresentationCount == 1)
+        #expect(invitation.id == coordinator.pendingInvitation?.id)
+
+        host.replace(with: EmptyView())
+
+        #expect(coordinator.pendingInvitation == nil)
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 1)
+        #expect(loaded.invitationDismissalCount == 1)
+        #expect(events(named: "guidance.invitation.dismissed").count == 1)
+        #expect(events(named: "guidance.invitation.cancelled").isEmpty)
+    }
+
+    @Test func exportBannerNeverTouchesNonExportInvitation() throws {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = try #require(coordinator.pendingInvitation)
+        coordinator.handleExportSucceeded()
+        #expect(coordinator.pendingInvitation?.id == invitation.id)
+
+        let host = BannerHost(content: ExportSuccessBanner(guidance: coordinator))
+        host.flushLayout()
+        #expect(store.load().invitationPresentationCount == 0)
+
+        host.replace(with: EmptyView())
+
+        #expect(coordinator.pendingInvitation?.id == invitation.id)
+        #expect(store.load().invitationDismissalCount == 0)
+        #expect(events(named: "guidance.invitation.presented").isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeCoordinator(
@@ -484,5 +551,29 @@ final class GuidanceCoordinatorTests {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
         return calendar
+    }
+}
+
+/// Hosts a SwiftUI view in a real window so `onAppear`/`onDisappear` fire the
+/// way they do in the shipping app.
+@MainActor
+private final class BannerHost {
+    private let window: NSWindow
+    private let controller: NSHostingController<AnyView>
+
+    init<Content: View>(content: Content) {
+        controller = NSHostingController(rootView: AnyView(content))
+        window = NSWindow(contentViewController: controller)
+    }
+
+    func flushLayout() {
+        window.layoutIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.02))
+    }
+
+    func replace<Content: View>(with content: Content) {
+        controller.rootView = AnyView(content)
+        window.layoutIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.02))
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
@@ -1,0 +1,432 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+final class GuidanceCoordinatorTests {
+    private var store: InMemoryGuidanceStateStore!
+    private var collectedEvents: [GuidanceEvent] = []
+    private var coordinator: GuidanceCoordinator!
+    private var calendar: Calendar { Self.makeCalendar() }
+
+    private var now: Date {
+        calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 12))!
+    }
+
+    // MARK: - Scheduling vs consumption
+
+    @Test func schedulingInvitationPersistsOnlyCompletionCount() {
+        let coordinator = makeCoordinator(state: invitationState())
+
+        let decision = coordinator.record(.diagnosticsCompleted)
+
+        #expect(decision == .showProInvitation)
+        #expect(coordinator.pendingInvitation != nil)
+        let loaded = store.load()
+        #expect(loaded.meaningfulCompletionCount == 3)
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+    }
+
+    @Test func presentationConsumesCountAndDateIdempotently() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+
+        coordinator.invitationPresented(id: invitation.id)
+        coordinator.invitationPresented(id: invitation.id)
+
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 1)
+        #expect(loaded.lastInvitationDate == now)
+        #expect(events(named: "guidance.invitation.presented").count == 1)
+    }
+
+    // MARK: - Token gates (reachable state sequences)
+
+    @Test func staleInvitationTokenCannotAffectNewerInvitation() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let a = coordinator.pendingInvitation!
+
+        coordinator.openInvitation(id: a.id)
+        #expect(coordinator.pendingInvitation == nil)
+
+        // The next eligible moment schedules B — the only real path to a new
+        // pending invitation while a host may still hold a stale rendered token.
+        _ = coordinator.record(.diagnosticsCompleted)
+        let b = coordinator.pendingInvitation!
+        #expect(b.id != a.id)
+
+        coordinator.invitationPresented(id: a.id)
+        coordinator.dismissInvitation(id: a.id)
+        coordinator.disableInvitations(id: a.id)
+        coordinator.openInvitation(id: a.id)
+        coordinator.endInvitationPresentation(id: a.id)
+
+        #expect(coordinator.pendingInvitation?.id == b.id)
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.invitationDismissalCount == 0)
+        #expect(loaded.invitationsDisabled == false)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(events(named: "guidance.invitation.view_selected").map(\.tokenID) == [a.id])
+
+        coordinator.dismissInvitation(id: b.id)
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(store.load().invitationDismissalCount == 1)
+    }
+
+    @Test func dismissWithStaleOrNilPendingNeverCounts() {
+        let coordinator = makeCoordinator(state: invitationState())
+
+        coordinator.dismissInvitation(id: UUID())
+
+        #expect(store.load().invitationDismissalCount == 0)
+        #expect(events(named: "guidance.invitation.dismissed").isEmpty)
+    }
+
+    // MARK: - Host lifecycle
+
+    @Test func unpresentedInvitationCancelsWithoutTrace() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+
+        coordinator.endInvitationPresentation(id: invitation.id)
+
+        #expect(coordinator.pendingInvitation == nil)
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.invitationDismissalCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(events(named: "guidance.invitation.cancelled").count == 1)
+    }
+
+    @Test func presentedInvitationWithoutChoiceConsumesAsLater() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+        coordinator.invitationPresented(id: invitation.id)
+
+        coordinator.endInvitationPresentation(id: invitation.id)
+
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(store.load().invitationDismissalCount == 1)
+        #expect(events(named: "guidance.invitation.dismissed").count == 1)
+        #expect(events(named: "guidance.invitation.cancelled").isEmpty)
+    }
+
+    // MARK: - Pending gates
+
+    @Test func pendingInvitationBlocksNewInvitationScheduling() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+
+        let decision = coordinator.record(.diagnosticsCompleted)
+
+        #expect(decision == .none(.invitationAlreadyPending))
+        #expect(store.load().meaningfulCompletionCount == 4)
+        #expect(coordinator.pendingInvitation != nil)
+    }
+
+    @Test func pendingReviewRequestBlocksNewReviewScheduling() {
+        let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
+        _ = coordinator.record(.analysisLoaded)
+
+        let decision = coordinator.record(.analysisLoaded)
+
+        #expect(decision == .none(.reviewRequestPending))
+        #expect(store.load().meaningfulCompletionCount == 6)
+        #expect(coordinator.pendingReviewRequest != nil)
+    }
+
+    // MARK: - Review persistence timing and token
+
+    @Test func reviewPersistenceHappensOnlyOnInvocation() {
+        let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
+        _ = coordinator.record(.analysisLoaded)
+        let request = coordinator.pendingReviewRequest!
+
+        var loaded = store.load()
+        #expect(loaded.lastReviewRequestDate == nil)
+        #expect(loaded.lastReviewRequestVersion == nil)
+
+        coordinator.reviewRequestPresented(id: request.id)
+        coordinator.reviewRequestPresented(id: request.id)
+
+        loaded = store.load()
+        #expect(loaded.lastReviewRequestDate == now)
+        #expect(loaded.lastReviewRequestVersion == "2.1.0")
+        #expect(events(named: "guidance.review.request_invoked").count == 1)
+
+        let decision = coordinator.record(.analysisLoaded)
+        #expect(decision == .none(.reviewAlreadyRequestedForVersion))
+        #expect(coordinator.pendingReviewRequest == nil)
+    }
+
+    @Test func staleReviewTokenIsNoOp() {
+        let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
+        _ = coordinator.record(.analysisLoaded)
+        let request = coordinator.pendingReviewRequest!
+
+        coordinator.reviewRequestPresented(id: UUID())
+
+        #expect(coordinator.pendingReviewRequest?.id == request.id)
+        let loaded = store.load()
+        #expect(loaded.lastReviewRequestDate == nil)
+        #expect(loaded.lastReviewRequestVersion == nil)
+    }
+
+    // MARK: - Quit before consumption
+
+    @Test func quitBeforeConsumptionLeavesNoPersistedTrace() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+
+        let fresh = GuidanceCoordinator(
+            configuration: invitationConfig(),
+            stateStore: store,
+            now: { self.now },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { _ in }
+        )
+
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+
+        let decision = fresh.record(.diagnosticsCompleted)
+        #expect(decision == .showProInvitation)
+        #expect(fresh.pendingInvitation != nil)
+    }
+
+    // MARK: - Export feedback
+
+    @Test func recordAppActiveIsIdempotentPerLocalDay() {
+        let dayStart = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 8, minute: 30))!
+        let dayEnd = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 23, minute: 30))!
+        var current = dayStart
+        store = InMemoryGuidanceStateStore()
+        collectedEvents = []
+        let coordinator = GuidanceCoordinator(
+            configuration: invitationConfig(),
+            stateStore: store,
+            now: { current },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { self.collectedEvents.append($0) }
+        )
+
+        coordinator.recordAppActive()
+        current = dayEnd
+        coordinator.recordAppActive()
+
+        let loaded = store.load()
+        #expect(loaded.activeDays == ["2026-08-05"])
+        #expect(loaded.firstLaunchDate == dayStart)
+    }
+
+    @Test func recordAppActiveDayBoundaryFollowsInjectedCalendar() {
+        let dayOneLate = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 23, minute: 59))!
+        let dayTwoEarly = calendar.date(from: DateComponents(year: 2026, month: 8, day: 6, hour: 0, minute: 1))!
+        var current = dayOneLate
+        store = InMemoryGuidanceStateStore()
+        collectedEvents = []
+        let coordinator = GuidanceCoordinator(
+            configuration: invitationConfig(),
+            stateStore: store,
+            now: { current },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { self.collectedEvents.append($0) }
+        )
+
+        coordinator.recordAppActive()
+        current = dayTwoEarly
+        coordinator.recordAppActive()
+
+        #expect(store.load().activeDays == ["2026-08-05", "2026-08-06"])
+    }
+
+    @Test func handleExportSucceededPublishesFeedbackAndRecordsMoment() {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 3))
+
+        coordinator.handleExportSucceeded()
+
+        #expect(coordinator.exportFeedback != nil)
+        #expect(store.load().meaningfulCompletionCount == 4)
+        #expect(coordinator.pendingInvitation != nil)
+    }
+
+    @Test func recordExportSucceededAloneNeverPublishesFeedback() {
+        let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
+
+        _ = coordinator.record(.exportSucceeded)
+
+        #expect(coordinator.exportFeedback == nil)
+        #expect(store.load().meaningfulCompletionCount == 5)
+    }
+
+    @Test func dismissExportFeedbackConsumesAttachedInvitationAsLater() {
+        let coordinator = makeCoordinator(state: invitationState())
+        coordinator.handleExportSucceeded()
+        #expect(coordinator.pendingInvitation != nil)
+
+        coordinator.dismissExportFeedback()
+
+        #expect(coordinator.exportFeedback == nil)
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(store.load().invitationDismissalCount == 1)
+    }
+
+    @Test func dismissExportFeedbackWithoutInvitationClearsFeedbackOnly() {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 0))
+        coordinator.handleExportSucceeded()
+        #expect(coordinator.exportFeedback != nil)
+        #expect(coordinator.pendingInvitation == nil)
+
+        coordinator.dismissExportFeedback()
+
+        #expect(coordinator.exportFeedback == nil)
+        #expect(store.load().invitationDismissalCount == 0)
+    }
+
+    // MARK: - Invitation actions
+
+    @Test func openInvitationEmitsViewSelectedAndClearsWithoutCount() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+
+        coordinator.openInvitation(id: invitation.id)
+
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(store.load().invitationDismissalCount == 0)
+        #expect(events(named: "guidance.invitation.view_selected").count == 1)
+    }
+
+    @Test func disableInvitationsPersistsAndClears() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+
+        coordinator.disableInvitations(id: invitation.id)
+
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(store.load().invitationsDisabled == true)
+        #expect(events(named: "guidance.invitation.disabled").count == 1)
+    }
+
+    // MARK: - Events
+
+    @Test func eventSinkCapturesValueMomentScheduledPresentedDismissed() {
+        let coordinator = makeCoordinator(state: invitationState())
+        _ = coordinator.record(.diagnosticsCompleted)
+        let invitation = coordinator.pendingInvitation!
+        coordinator.invitationPresented(id: invitation.id)
+        coordinator.dismissInvitation(id: invitation.id)
+
+        #expect(events(named: "guidance.value_moment").count == 1)
+        #expect(events(named: "guidance.invitation.scheduled").count == 1)
+        #expect(events(named: "guidance.invitation.presented").count == 1)
+        #expect(events(named: "guidance.invitation.dismissed").count == 1)
+    }
+
+    @Test func eventSinkEmitsNoActionWithSuppressionReason() {
+        let coordinator = makeCoordinator(state: invitationState(completionCount: 0))
+
+        _ = coordinator.record(.diagnosticsCompleted)
+
+        let noAction = events(named: "guidance.no_action").first
+        #expect(noAction?.suppressionReason == .completionThresholdNotMet)
+        #expect(noAction?.moment == .diagnosticsCompleted)
+    }
+
+    @Test func roamingRecordsValueMomentWithoutCompletion() {
+        let coordinator = makeCoordinator(state: invitationState())
+
+        _ = coordinator.record(.roamingCompleted)
+
+        #expect(store.load().meaningfulCompletionCount == 2)
+        #expect(events(named: "guidance.no_action").first?.suppressionReason == .roamingPolicyNotEnabled)
+        #expect(coordinator.pendingInvitation == nil)
+    }
+
+    @Test func reviewEventsOncePerToken() {
+        let coordinator = makeCoordinator(configuration: reviewConfig(), state: reviewState())
+        _ = coordinator.record(.analysisLoaded)
+        let request = coordinator.pendingReviewRequest!
+        coordinator.reviewRequestPresented(id: request.id)
+
+        #expect(events(named: "guidance.review.scheduled").count == 1)
+        #expect(events(named: "guidance.review.request_invoked").count == 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator(
+        configuration: GuidanceConfiguration? = nil,
+        state: GuidanceState = GuidanceState(),
+        appVersion: String = "2.1.0"
+    ) -> GuidanceCoordinator {
+        store = InMemoryGuidanceStateStore(initial: state)
+        collectedEvents = []
+        let coordinator = GuidanceCoordinator(
+            configuration: configuration ?? invitationConfig(),
+            stateStore: store,
+            now: { self.now },
+            calendar: calendar,
+            appVersion: { appVersion },
+            isProAppInstalled: { false },
+            eventSink: { self.collectedEvents.append($0) }
+        )
+        self.coordinator = coordinator
+        return coordinator
+    }
+
+    private func events(named name: String) -> [GuidanceEvent] {
+        collectedEvents.filter { $0.name == name }
+    }
+
+    private func invitationConfig() -> GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.invitationEnabled = true
+        return config
+    }
+
+    private func reviewConfig() -> GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.reviewEnabled = true
+        return config
+    }
+
+    private func invitationState(completionCount: Int = 2) -> GuidanceState {
+        GuidanceState(
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: completionCount
+        )
+    }
+
+    private func reviewState(completionCount: Int = 4) -> GuidanceState {
+        GuidanceState(
+            firstLaunchDate: daysAgo(7),
+            activeDays: ["2026-07-01", "2026-07-02", "2026-07-03"],
+            meaningfulCompletionCount: completionCount
+        )
+    }
+
+    private func daysAgo(_ days: Int) -> Date {
+        calendar.date(byAdding: .day, value: -days, to: now)!
+    }
+
+    private static func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceCoordinatorTests.swift
@@ -272,16 +272,41 @@ final class GuidanceCoordinatorTests {
         #expect(store.load().meaningfulCompletionCount == 5)
     }
 
-    @Test func dismissExportFeedbackConsumesAttachedInvitationAsLater() {
+    @Test func dismissExportFeedbackConsumesAttachedInvitationAsLater() throws {
         let coordinator = makeCoordinator(state: invitationState())
         coordinator.handleExportSucceeded()
-        #expect(coordinator.pendingInvitation != nil)
+        let invitation = try #require(coordinator.pendingInvitation)
+        coordinator.invitationPresented(id: invitation.id)
 
         coordinator.dismissExportFeedback()
 
         #expect(coordinator.exportFeedback == nil)
         #expect(coordinator.pendingInvitation == nil)
-        #expect(store.load().invitationDismissalCount == 1)
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 1)
+        #expect(loaded.invitationDismissalCount == 1)
+        #expect(loaded.lastInvitationDate == now)
+
+        // The presented-then-dismissed invitation starts the 30-day cooldown.
+        let decision = coordinator.record(.diagnosticsCompleted)
+        #expect(decision == .none(.invitationCooldown))
+    }
+
+    @Test func dismissExportFeedbackBeforePresentationCancelsWithoutTrace() throws {
+        let coordinator = makeCoordinator(state: invitationState())
+        coordinator.handleExportSucceeded()
+        _ = try #require(coordinator.pendingInvitation)
+
+        coordinator.dismissExportFeedback()
+
+        #expect(coordinator.exportFeedback == nil)
+        #expect(coordinator.pendingInvitation == nil)
+        let loaded = store.load()
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.invitationDismissalCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(events(named: "guidance.invitation.cancelled").count == 1)
+        #expect(events(named: "guidance.invitation.dismissed").isEmpty)
     }
 
     @Test func dismissExportFeedbackWithoutInvitationClearsFeedbackOnly() {

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceDebugTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceDebugTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+final class GuidanceDebugTests {
+    private var store: InMemoryGuidanceStateStore!
+    private var collectedEvents: [GuidanceEvent] = []
+    private var coordinator: GuidanceCoordinator!
+    private var calendar: Calendar { Self.makeCalendar() }
+
+    private var now: Date {
+        calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 12))!
+    }
+
+    // MARK: - Reset
+
+    @Test func debugResetStateClearsPersistedStateAndPendingTokens() throws {
+        let coordinator = makeCoordinator(state: GuidanceState(
+            firstLaunchDate: now,
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: 4,
+            invitationPresentationCount: 2,
+            invitationDismissalCount: 1,
+            invitationsDisabled: true,
+            lastReviewRequestDate: now,
+            lastReviewRequestVersion: "2.1.0"
+        ))
+        // The disabled flag suppresses the policy path, so schedule through
+        // the debug API to get a real pending token to reset.
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+        #expect(coordinator.pendingInvitation != nil)
+
+        coordinator.debugResetState()
+
+        #expect(coordinator.pendingInvitation == nil)
+        #expect(coordinator.pendingReviewRequest == nil)
+        #expect(coordinator.exportFeedback == nil)
+        let loaded = store.load()
+        #expect(loaded.firstLaunchDate == nil)
+        #expect(loaded.activeDays.isEmpty)
+        #expect(loaded.meaningfulCompletionCount == 0)
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.invitationDismissalCount == 0)
+        #expect(loaded.invitationsDisabled == false)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(loaded.lastReviewRequestDate == nil)
+        #expect(loaded.lastReviewRequestVersion == nil)
+        #expect(events(named: "guidance.debug.state_reset").count == 1)
+    }
+
+    // MARK: - Eligibility seeding
+
+    @Test func debugPrepareInvitationEligibilitySatisfiesPolicy() {
+        let coordinator = makeCoordinator(state: GuidanceState())
+
+        coordinator.debugPrepareInvitationEligibility()
+
+        let loaded = store.load()
+        #expect(loaded.meaningfulCompletionCount == 3)
+        #expect(loaded.activeDays.count == 2)
+        #expect(loaded.invitationsDisabled == false)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(events(named: "guidance.debug.invitation_eligibility_prepared").count == 1)
+
+        // The next real value moment goes through the production policy.
+        #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
+    }
+
+    // MARK: - Invitation scheduling (policy bypass, lifecycle intact)
+
+    @Test func debugScheduleInvitationCreatesDiagnosticsToken() throws {
+        let coordinator = makeCoordinator(state: GuidanceState())
+
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+
+        let invitation = try #require(coordinator.pendingInvitation)
+        #expect(invitation.moment == .diagnosticsCompleted)
+        // No completion count is written by the debug trigger.
+        #expect(store.load().meaningfulCompletionCount == 0)
+        #expect(events(named: "guidance.invitation.scheduled").count == 1)
+        #expect(events(named: "guidance.debug.invitation_triggered").count == 1)
+
+        // The card still confirms presentation through the production API.
+        coordinator.invitationPresented(id: invitation.id)
+        #expect(store.load().invitationPresentationCount == 1)
+    }
+
+    @Test func debugScheduleInvitationCreatesExportToken() throws {
+        let coordinator = makeCoordinator(state: GuidanceState())
+
+        coordinator.debugScheduleInvitation(for: .exportSucceeded)
+        coordinator.debugPublishExportFeedback()
+
+        let invitation = try #require(coordinator.pendingInvitation)
+        #expect(invitation.moment == .exportSucceeded)
+        #expect(coordinator.exportFeedback != nil)
+    }
+
+    @Test func debugScheduleRefusesWhenInvitationPending() throws {
+        let coordinator = makeCoordinator(state: GuidanceState())
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+        let first = try #require(coordinator.pendingInvitation)
+
+        coordinator.debugScheduleInvitation(for: .exportSucceeded)
+
+        #expect(coordinator.pendingInvitation?.id == first.id)
+        #expect(events(named: "guidance.debug.refused").first?.metadata["reason"] == "pending_invitation")
+    }
+
+    @Test func staleDebugTokenCannotConsumeNewerInvitation() throws {
+        let coordinator = makeCoordinator(state: GuidanceState())
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+        let first = try #require(coordinator.pendingInvitation)
+
+        coordinator.openInvitation(id: first.id)
+        #expect(coordinator.pendingInvitation == nil)
+
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+        let second = try #require(coordinator.pendingInvitation)
+        #expect(second.id != first.id)
+
+        coordinator.invitationPresented(id: first.id)
+        coordinator.dismissInvitation(id: first.id)
+        coordinator.endInvitationPresentation(id: first.id)
+
+        #expect(coordinator.pendingInvitation?.id == second.id)
+        #expect(store.load().invitationPresentationCount == 0)
+        #expect(store.load().invitationDismissalCount == 0)
+    }
+
+    // MARK: - Pro installation override
+
+    @Test func proInstallationOverrideControlsPolicyAndIsNotPersisted() throws {
+        defer { GuidanceDebugOverrides.setProInstallationOverride(.useRealDetection) }
+        #expect(GuidanceDebugOverrides.proInstallationOverride == .useRealDetection)
+
+        // Coordinator with the production default detection closure.
+        let coordinator = makeCoordinatorWithDefaultDetection(state: GuidanceState(
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: 2
+        ))
+
+        GuidanceDebugOverrides.setProInstallationOverride(.treatAsInstalled)
+        #expect(coordinator.record(.diagnosticsCompleted) == .none(.proAppInstalled))
+        #expect(coordinator.pendingInvitation == nil)
+
+        GuidanceDebugOverrides.setProInstallationOverride(.treatAsNotInstalled)
+        #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
+        #expect(coordinator.pendingInvitation != nil)
+
+        // The override never touches persisted state.
+        let loaded = store.load()
+        #expect(loaded.meaningfulCompletionCount == 4)
+        #expect(loaded.activeDays == ["2026-07-01", "2026-07-02"])
+        #expect(loaded.invitationPresentationCount == 0)
+    }
+
+    // MARK: - State logging
+
+    @Test func debugLogStateEmitsSanitizedSummary() throws {
+        let coordinator = makeCoordinator(state: GuidanceState(
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: 2
+        ))
+        coordinator.debugScheduleInvitation(for: .diagnosticsCompleted)
+
+        coordinator.debugLogState(edition: "OSS")
+
+        let summary = try #require(events(named: "guidance.debug.state_summary").first)
+        let metadata = summary.metadata
+        #expect(metadata["edition"] == "OSS")
+        #expect(metadata["completionCount"] == "2")
+        #expect(metadata["activeDayCount"] == "2")
+        #expect(metadata["invitationPresentationCount"] == "0")
+        #expect(metadata["invitationDismissalCount"] == "0")
+        #expect(metadata["invitationsDisabled"] == "false")
+        #expect(metadata["invitationCooldownActive"] == "false")
+        #expect(metadata["hasReviewRequestHistory"] == "false")
+        #expect(metadata["reviewConsumedForCurrentVersion"] == "false")
+        #expect(metadata["hasPendingInvitation"] == "true")
+        #expect(metadata["hasPendingReviewRequest"] == "false")
+        #expect(metadata["proInstallationOverride"] == "useRealDetection")
+        #expect(summary.tokenID == nil)
+
+        // No sensitive or token data anywhere in the summary.
+        let serialized = (Array(metadata.keys) + Array(metadata.values)).joined(separator: " ").lowercased()
+        for forbidden in ["ssid", "bssid", "ip", "dns", "diagnostic", "uuid", "token"] {
+            #expect(!serialized.contains(forbidden), "summary must not contain \(forbidden)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator(
+        configuration: GuidanceConfiguration? = nil,
+        state: GuidanceState = GuidanceState()
+    ) -> GuidanceCoordinator {
+        store = InMemoryGuidanceStateStore(initial: state)
+        collectedEvents = []
+        var config = configuration ?? Self.invitationConfig()
+        if configuration == nil { config.invitationEnabled = true }
+        let coordinator = GuidanceCoordinator(
+            configuration: config,
+            stateStore: store,
+            now: { self.now },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { self.collectedEvents.append($0) }
+        )
+        self.coordinator = coordinator
+        return coordinator
+    }
+
+    private func makeCoordinatorWithDefaultDetection(
+        configuration: GuidanceConfiguration? = nil,
+        state: GuidanceState = GuidanceState()
+    ) -> GuidanceCoordinator {
+        store = InMemoryGuidanceStateStore(initial: state)
+        collectedEvents = []
+        var config = configuration ?? Self.invitationConfig()
+        if configuration == nil { config.invitationEnabled = true }
+        let coordinator = GuidanceCoordinator(
+            configuration: config,
+            stateStore: store,
+            now: { self.now },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            eventSink: { self.collectedEvents.append($0) }
+        )
+        self.coordinator = coordinator
+        return coordinator
+    }
+
+    private func events(named name: String) -> [GuidanceEvent] {
+        collectedEvents.filter { $0.name == name }
+    }
+
+    private static func invitationConfig() -> GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.invitationEnabled = true
+        return config
+    }
+
+    private static func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceDebugTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceDebugTests.swift
@@ -67,6 +67,39 @@ final class GuidanceDebugTests {
         #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
     }
 
+    @Test func debugPrepareInvitationEligibilityUsesConfiguration() {
+        var config = Self.invitationConfig()
+        config.minimumInvitationActiveDays = 5
+        let coordinator = makeCoordinator(configuration: config, state: GuidanceState())
+
+        coordinator.debugPrepareInvitationEligibility()
+
+        let loaded = store.load()
+        #expect(loaded.activeDays.count == 5)
+        #expect(loaded.meaningfulCompletionCount == config.minimumInvitationCompletions)
+        #expect(coordinator.record(.diagnosticsCompleted) == .showProInvitation)
+    }
+
+    @Test func diagnosticsStagingIsConsumedAtomically() {
+        defer { GuidanceDebugOverrides.clearDiagnosticsStaging() }
+        #expect(GuidanceDebugOverrides.consumeDiagnosticsStaging() == false)
+
+        GuidanceDebugOverrides.requestDiagnosticsStaging()
+
+        #expect(GuidanceDebugOverrides.consumeDiagnosticsStaging() == true)
+        #expect(GuidanceDebugOverrides.consumeDiagnosticsStaging() == false)
+    }
+
+    @Test func debugResetClearsPendingDiagnosticsStaging() {
+        defer { GuidanceDebugOverrides.clearDiagnosticsStaging() }
+        GuidanceDebugOverrides.requestDiagnosticsStaging()
+        let coordinator = makeCoordinator(state: GuidanceState())
+
+        coordinator.debugResetState()
+
+        #expect(GuidanceDebugOverrides.consumeDiagnosticsStaging() == false)
+    }
+
     // MARK: - Invitation scheduling (policy bypass, lifecycle intact)
 
     @Test func debugScheduleInvitationCreatesDiagnosticsToken() throws {
@@ -80,6 +113,11 @@ final class GuidanceDebugTests {
         #expect(store.load().meaningfulCompletionCount == 0)
         #expect(events(named: "guidance.invitation.scheduled").count == 1)
         #expect(events(named: "guidance.debug.invitation_triggered").count == 1)
+        // The injected sink still sees the token for lifecycle tests, but the
+        // production metadata never carries it.
+        let scheduled = try #require(events(named: "guidance.invitation.scheduled").first)
+        #expect(scheduled.tokenID == invitation.id)
+        #expect(scheduled.metadata["token"] == nil)
 
         // The card still confirms presentation through the production API.
         coordinator.invitationPresented(id: invitation.id)

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceEditionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceEditionTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import WiFi_Lens
+
+struct GuidanceEditionTests {
+    @Test func ossGuidanceConfigurationEnablesInvitationsOnly() {
+        let config = EditionComposition.guidanceConfiguration
+
+        #expect(config.invitationEnabled == true)
+        #expect(config.reviewEnabled == false)
+    }
+
+    @Test func ossExportSuccessPresentationIsBanner() {
+        #expect(EditionComposition.exportSuccessPresentation == .banner)
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidancePolicyTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidancePolicyTests.swift
@@ -1,0 +1,409 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+struct GuidancePolicyTests {
+    private let calendar = Self.makeCalendar()
+    private let appVersion = "2.1.0"
+    private var now: Date { date(2026, 8, 5, hour: 12, calendar: calendar) }
+
+    // MARK: - Invitation flow
+
+    @Test func diagnosticsCompletionInvitesWhenEligible() {
+        let decision = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(),
+            config: invitationConfig()
+        )
+
+        #expect(decision == .showProInvitation)
+    }
+
+    @Test func exportSuccessInvitesWhenEligible() {
+        let decision = decide(
+            for: .exportSucceeded,
+            state: invitationState(),
+            config: invitationConfig()
+        )
+
+        #expect(decision == .showProInvitation)
+    }
+
+    @Test func roamingNeverAppliesPolicy() {
+        let decision = decide(
+            for: .roamingCompleted,
+            state: invitationState(completionCount: 100, presentationCount: 0),
+            config: invitationConfig()
+        )
+
+        #expect(decision == .none(.roamingPolicyNotEnabled))
+    }
+
+    @Test func analysisNeverInvitesEvenWhenInvitationEnabled() {
+        let decision = decide(
+            for: .analysisLoaded,
+            state: invitationState(),
+            config: invitationConfig()
+        )
+
+        #expect(decision == .none(.editionReviewDisabled))
+    }
+
+    @Test func invitationDisabledByUserSuppresses() {
+        let decision = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(invitationsDisabled: true),
+            config: invitationConfig()
+        )
+
+        #expect(decision == .none(.invitationsDisabledByUser))
+    }
+
+    @Test func proAppInstalledSuppressesInvitation() {
+        let decision = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(),
+            config: invitationConfig(),
+            isProAppInstalled: true
+        )
+
+        #expect(decision == .none(.proAppInstalled))
+    }
+
+    @Test func invitationCompletionThresholdBoundary() {
+        let below = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(completionCount: 2),
+            config: invitationConfig()
+        )
+        let at = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(completionCount: 3),
+            config: invitationConfig()
+        )
+
+        #expect(below == .none(.completionThresholdNotMet))
+        #expect(at == .showProInvitation)
+    }
+
+    @Test func invitationActiveDaysThresholdBoundary() {
+        let below = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(activeDays: ["2026-07-01"]),
+            config: invitationConfig()
+        )
+        let at = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(activeDays: ["2026-07-01", "2026-07-02"]),
+            config: invitationConfig()
+        )
+
+        #expect(below == .none(.activeDaysThresholdNotMet))
+        #expect(at == .showProInvitation)
+    }
+
+    @Test func invitationPresentationLimitBoundary() {
+        let atLimit = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(presentationCount: 3),
+            config: invitationConfig()
+        )
+        let underLimit = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(presentationCount: 2),
+            config: invitationConfig()
+        )
+
+        #expect(atLimit == .none(.invitationPresentationLimit))
+        #expect(underLimit == .showProInvitation)
+    }
+
+    @Test func invitationCooldownBoundary() {
+        let inCooldown = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(lastInvitationDate: daysAgo(29)),
+            config: invitationConfig()
+        )
+        let atBoundary = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(lastInvitationDate: daysAgo(30)),
+            config: invitationConfig()
+        )
+
+        #expect(inCooldown == .none(.invitationCooldown))
+        #expect(atBoundary == .showProInvitation)
+    }
+
+    @Test func diagnosticsWithBothFlowsDisabled() {
+        let decision = decide(
+            for: .diagnosticsCompleted,
+            state: invitationState(),
+            config: GuidanceConfiguration()
+        )
+
+        #expect(decision == .none(.editionInvitationDisabled))
+    }
+
+    // MARK: - Review flow
+
+    @Test func analysisRequestsReviewWhenEligible() {
+        let decision = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+
+        #expect(decision == .requestReview)
+    }
+
+    @Test func diagnosticsUsesReviewFlowWhenInvitationDisabled() {
+        let decision = decide(
+            for: .diagnosticsCompleted,
+            state: reviewState(firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+
+        #expect(decision == .requestReview)
+    }
+
+    @Test func exportUsesReviewFlowWhenInvitationDisabled() {
+        let decision = decide(
+            for: .exportSucceeded,
+            state: reviewState(firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+
+        #expect(decision == .requestReview)
+    }
+
+    @Test func analysisWithReviewDisabled() {
+        let decision = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: nil),
+            config: GuidanceConfiguration()
+        )
+
+        #expect(decision == .none(.editionReviewDisabled))
+    }
+
+    @Test func reviewFirstLaunchAgeBoundary() {
+        let noLaunch = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: nil),
+            config: reviewConfig()
+        )
+        let tooYoung = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(6)),
+            config: reviewConfig()
+        )
+        let atBoundary = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+
+        #expect(noLaunch == .none(.firstLaunchAgeNotMet))
+        #expect(tooYoung == .none(.firstLaunchAgeNotMet))
+        #expect(atBoundary == .requestReview)
+    }
+
+    @Test func reviewActiveDaysThresholdBoundary() {
+        let below = decide(
+            for: .analysisLoaded,
+            state: reviewState(activeDays: ["2026-07-01", "2026-07-02"], firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+        let at = decide(
+            for: .analysisLoaded,
+            state: reviewState(
+                activeDays: ["2026-07-01", "2026-07-02", "2026-07-03"],
+                firstLaunchDate: daysAgo(7)
+            ),
+            config: reviewConfig()
+        )
+
+        #expect(below == .none(.activeDaysThresholdNotMet))
+        #expect(at == .requestReview)
+    }
+
+    @Test func reviewCompletionThresholdBoundary() {
+        let below = decide(
+            for: .analysisLoaded,
+            state: reviewState(completionCount: 4, firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+        let at = decide(
+            for: .analysisLoaded,
+            state: reviewState(completionCount: 5, firstLaunchDate: daysAgo(7)),
+            config: reviewConfig()
+        )
+
+        #expect(below == .none(.completionThresholdNotMet))
+        #expect(at == .requestReview)
+    }
+
+    @Test func reviewVersionGating() {
+        let sameVersion = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(7), lastReviewRequestVersion: appVersion),
+            config: reviewConfig()
+        )
+        let nilVersion = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(7), lastReviewRequestVersion: nil),
+            config: reviewConfig()
+        )
+        let newVersion = decide(
+            for: .analysisLoaded,
+            state: reviewState(firstLaunchDate: daysAgo(7), lastReviewRequestVersion: "2.0.9"),
+            config: reviewConfig()
+        )
+
+        #expect(sameVersion == .none(.reviewAlreadyRequestedForVersion))
+        #expect(nilVersion == .requestReview)
+        #expect(newVersion == .requestReview)
+    }
+
+    @Test func reviewCooldownBoundary() {
+        let inCooldown = decide(
+            for: .analysisLoaded,
+            state: reviewState(
+                firstLaunchDate: daysAgo(7),
+                lastReviewRequestDate: daysAgo(119),
+                lastReviewRequestVersion: "2.0.9"
+            ),
+            config: reviewConfig()
+        )
+        let atBoundary = decide(
+            for: .analysisLoaded,
+            state: reviewState(
+                firstLaunchDate: daysAgo(7),
+                lastReviewRequestDate: daysAgo(120),
+                lastReviewRequestVersion: "2.0.9"
+            ),
+            config: reviewConfig()
+        )
+
+        #expect(inCooldown == .none(.reviewCooldown))
+        #expect(atBoundary == .requestReview)
+    }
+
+    // MARK: - Pending-gate reasons are coordinator-only
+
+    @Test func policyNeverReturnsPendingGateReasons() {
+        let scenarios: [GuidanceDecision] = [
+            decide(for: .diagnosticsCompleted, state: invitationState(), config: invitationConfig()),
+            decide(for: .exportSucceeded, state: reviewState(firstLaunchDate: daysAgo(7)), config: reviewConfig()),
+            decide(for: .analysisLoaded, state: reviewState(firstLaunchDate: daysAgo(7)), config: reviewConfig()),
+            decide(for: .roamingCompleted, state: invitationState(), config: invitationConfig()),
+            decide(
+                for: .diagnosticsCompleted,
+                state: invitationState(invitationsDisabled: true),
+                config: invitationConfig()
+            ),
+            decide(
+                for: .analysisLoaded,
+                state: reviewState(firstLaunchDate: daysAgo(7), lastReviewRequestVersion: appVersion),
+                config: reviewConfig()
+            ),
+            decide(for: .diagnosticsCompleted, state: invitationState(), config: GuidanceConfiguration())
+        ]
+
+        for decision in scenarios {
+            if case let .none(reason) = decision {
+                #expect(reason != .invitationAlreadyPending)
+                #expect(reason != .reviewRequestPending)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func decide(
+        for moment: GuidanceValueMoment,
+        state: GuidanceState,
+        config: GuidanceConfiguration,
+        isProAppInstalled: Bool = false
+    ) -> GuidanceDecision {
+        GuidancePolicy.decide(
+            for: moment,
+            state: state,
+            config: config,
+            now: now,
+            calendar: calendar,
+            appVersion: appVersion,
+            isProAppInstalled: isProAppInstalled
+        )
+    }
+
+    private func invitationConfig() -> GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.invitationEnabled = true
+        return config
+    }
+
+    private func reviewConfig() -> GuidanceConfiguration {
+        var config = GuidanceConfiguration()
+        config.reviewEnabled = true
+        return config
+    }
+
+    private func invitationState(
+        completionCount: Int = 3,
+        activeDays: [String] = ["2026-07-01", "2026-07-02"],
+        invitationsDisabled: Bool = false,
+        presentationCount: Int = 0,
+        lastInvitationDate: Date? = nil
+    ) -> GuidanceState {
+        GuidanceState(
+            activeDays: activeDays,
+            meaningfulCompletionCount: completionCount,
+            lastInvitationDate: lastInvitationDate,
+            invitationPresentationCount: presentationCount,
+            invitationDismissalCount: 0,
+            invitationsDisabled: invitationsDisabled
+        )
+    }
+
+    private func reviewState(
+        completionCount: Int = 5,
+        activeDays: [String] = ["2026-07-01", "2026-07-02", "2026-07-03"],
+        firstLaunchDate: Date? = nil,
+        lastReviewRequestDate: Date? = nil,
+        lastReviewRequestVersion: String? = nil
+    ) -> GuidanceState {
+        GuidanceState(
+            firstLaunchDate: firstLaunchDate,
+            activeDays: activeDays,
+            meaningfulCompletionCount: completionCount,
+            lastReviewRequestDate: lastReviewRequestDate,
+            lastReviewRequestVersion: lastReviewRequestVersion
+        )
+    }
+
+    private func daysAgo(_ days: Int) -> Date {
+        calendar.date(byAdding: .day, value: -days, to: now)!
+    }
+
+    private static func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        hour: Int = 12,
+        calendar: Calendar
+    ) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return calendar.date(from: components)!
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceStateStoreTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Guidance/GuidanceStateStoreTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+struct GuidanceStateStoreTests {
+    // MARK: - Store behavior
+
+    @Test func emptyLoadReturnsZeroValues() {
+        let defaults = makeDefaults(suite: "GuidanceStateStoreTests.empty")
+
+        let state = UserDefaultsGuidanceStateStore(defaults: defaults).load()
+
+        #expect(state.firstLaunchDate == nil)
+        #expect(state.activeDays.isEmpty)
+        #expect(state.meaningfulCompletionCount == 0)
+        #expect(state.lastInvitationDate == nil)
+        #expect(state.invitationPresentationCount == 0)
+        #expect(state.invitationDismissalCount == 0)
+        #expect(state.invitationsDisabled == false)
+        #expect(state.lastReviewRequestDate == nil)
+        #expect(state.lastReviewRequestVersion == nil)
+    }
+
+    @Test func fullRoundTripOfEveryField() {
+        let defaults = makeDefaults(suite: "GuidanceStateStoreTests.roundTrip")
+        let store = UserDefaultsGuidanceStateStore(defaults: defaults)
+        let original = GuidanceState(
+            firstLaunchDate: date(2026, 7, 1, hour: 9, calendar: utcCalendar),
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: 7,
+            lastInvitationDate: date(2026, 7, 15, hour: 9, calendar: utcCalendar),
+            invitationPresentationCount: 2,
+            invitationDismissalCount: 1,
+            invitationsDisabled: true,
+            lastReviewRequestDate: date(2026, 8, 1, hour: 9, calendar: utcCalendar),
+            lastReviewRequestVersion: "2.1.0"
+        )
+
+        store.save(original)
+
+        #expect(store.load() == original)
+    }
+
+    @Test func savingNilOptionalsClearsThem() {
+        let defaults = makeDefaults(suite: "GuidanceStateStoreTests.missingOptionals")
+        let store = UserDefaultsGuidanceStateStore(defaults: defaults)
+        store.save(
+            GuidanceState(
+                firstLaunchDate: date(2026, 7, 1, calendar: utcCalendar),
+                lastInvitationDate: date(2026, 7, 15, calendar: utcCalendar),
+                lastReviewRequestDate: date(2026, 8, 1, calendar: utcCalendar),
+                lastReviewRequestVersion: "2.1.0"
+            )
+        )
+
+        store.save(GuidanceState(meaningfulCompletionCount: 3))
+
+        let loaded = store.load()
+        #expect(loaded.firstLaunchDate == nil)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(loaded.lastReviewRequestDate == nil)
+        #expect(loaded.lastReviewRequestVersion == nil)
+        #expect(loaded.meaningfulCompletionCount == 3)
+    }
+
+    @Test func saveReplacesPreviousValues() {
+        let defaults = makeDefaults(suite: "GuidanceStateStoreTests.replace")
+        let store = UserDefaultsGuidanceStateStore(defaults: defaults)
+
+        store.save(GuidanceState(meaningfulCompletionCount: 1))
+        store.save(GuidanceState(meaningfulCompletionCount: 9, invitationsDisabled: true))
+
+        let loaded = store.load()
+        #expect(loaded.meaningfulCompletionCount == 9)
+        #expect(loaded.invitationsDisabled == true)
+    }
+
+    @Test func userDefaultsSuitesAreIsolated() {
+        let storeA = UserDefaultsGuidanceStateStore(
+            defaults: makeDefaults(suite: "GuidanceStateStoreTests.isolationA")
+        )
+        let storeB = UserDefaultsGuidanceStateStore(
+            defaults: makeDefaults(suite: "GuidanceStateStoreTests.isolationB")
+        )
+
+        storeA.save(GuidanceState(meaningfulCompletionCount: 5))
+
+        #expect(storeB.load().meaningfulCompletionCount == 0)
+        #expect(storeA.load().meaningfulCompletionCount == 5)
+    }
+
+    @Test func inMemoryStoreReturnsInitialStateAndReplacesOnSave() {
+        let initial = GuidanceState(meaningfulCompletionCount: 2)
+        let store = InMemoryGuidanceStateStore(initial: initial)
+
+        #expect(store.load() == initial)
+
+        let replacement = GuidanceState(meaningfulCompletionCount: 8)
+        store.save(replacement)
+
+        #expect(store.load() == replacement)
+    }
+
+    // MARK: - State invariants
+
+    @Test func sameLocalDayRecordsOnce() {
+        var state = GuidanceState()
+
+        state.recordActiveDay(at: date(2026, 8, 5, hour: 8, minute: 30, calendar: utcCalendar), calendar: utcCalendar)
+        state.recordActiveDay(at: date(2026, 8, 5, hour: 23, minute: 30, calendar: utcCalendar), calendar: utcCalendar)
+
+        #expect(state.activeDays == ["2026-08-05"])
+    }
+
+    @Test func consecutiveLocalDaysRecordTwoDays() {
+        var state = GuidanceState()
+
+        state.recordActiveDay(at: date(2026, 8, 5, hour: 23, minute: 59, calendar: utcCalendar), calendar: utcCalendar)
+        state.recordActiveDay(at: date(2026, 8, 6, hour: 0, minute: 1, calendar: utcCalendar), calendar: utcCalendar)
+
+        #expect(state.activeDays == ["2026-08-05", "2026-08-06"])
+    }
+
+    @Test func localCalendarDecidesTheDayBoundary() {
+        // 2026-08-05T16:30Z is 2026-08-06T01:30 in Asia/Tokyo.
+        let instant = date(2026, 8, 5, hour: 16, minute: 30, calendar: utcCalendar)
+
+        var utcState = GuidanceState()
+        utcState.recordActiveDay(at: instant, calendar: utcCalendar)
+        #expect(utcState.activeDays == ["2026-08-05"])
+
+        var tokyoState = GuidanceState()
+        tokyoState.recordActiveDay(at: instant, calendar: tokyoCalendar)
+        #expect(tokyoState.activeDays == ["2026-08-06"])
+    }
+
+    @Test func activeDayHistoryIsCappedAt120KeepingNewest() {
+        let base = date(2026, 1, 1, calendar: utcCalendar)
+        var state = GuidanceState()
+
+        for day in 0..<130 {
+            let d = utcCalendar.date(byAdding: .day, value: day, to: base)!
+            state.recordActiveDay(at: d, calendar: utcCalendar)
+        }
+
+        #expect(state.activeDays.count == 120)
+        #expect(state.activeDays.first == "2026-01-11")
+        #expect(state.activeDays.last == "2026-05-10")
+    }
+
+    // MARK: - Restore normalization
+
+    @Test func restoreNormalizesDuplicatesOrderAndCap() {
+        let base = date(2026, 1, 1, calendar: utcCalendar)
+        var keys: [String] = []
+        for day in (0..<130).reversed() {
+            let d = utcCalendar.date(byAdding: .day, value: day, to: base)!
+            keys.append(dayKey(for: d, calendar: utcCalendar))
+        }
+
+        let state = GuidanceState(activeDays: keys + keys)
+
+        #expect(state.activeDays.count == 120)
+        #expect(state.activeDays.first == "2026-01-11")
+        #expect(state.activeDays.last == "2026-05-10")
+        #expect(state.activeDays == Array(Set(state.activeDays)).sorted())
+    }
+
+    @Test func restoreFiltersInvalidDayKeys() {
+        let state = GuidanceState(
+            activeDays: ["2026-07-01", "foo", "2026-02-30", "2026-13-01", "26-8-5", "2026-07-02"]
+        )
+
+        #expect(state.activeDays == ["2026-07-01", "2026-07-02"])
+    }
+
+    @Test func storeLoadRepairsDamagedActiveDays() {
+        let defaults = makeDefaults(suite: "GuidanceStateStoreTests.damagedLoad")
+        defaults.set(["2026-07-03", "garbage", "2026-07-01", "2026-07-01", "2026-02-30"], forKey: "guidance.activeDays")
+        defaults.set(999, forKey: "guidance.completionCount")
+
+        let state = UserDefaultsGuidanceStateStore(defaults: defaults).load()
+
+        #expect(state.activeDays == ["2026-07-01", "2026-07-03"])
+        #expect(state.meaningfulCompletionCount == 999)
+    }
+
+    // MARK: - Helpers
+
+    private var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private var tokyoCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        return calendar
+    }
+
+    private func makeDefaults(suite: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        hour: Int = 12,
+        minute: Int = 0,
+        calendar: Calendar
+    ) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return calendar.date(from: components)!
+    }
+
+    private func dayKey(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", components.year!, components.month!, components.day!)
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -2181,10 +2181,12 @@ struct NetworkDiagnosticsTests {
     @MainActor
     func viewModelManualStart() async {
         let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: recorder),
             minimumStepDuration: .zero,
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
         )
 
         #expect(viewModel.phase == .idle)
@@ -2205,10 +2207,12 @@ struct NetworkDiagnosticsTests {
     @MainActor
     func viewModelRerun() async {
         let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: recorder),
             minimumStepDuration: .zero,
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
         )
 
         #expect(viewModel.start())
@@ -2226,6 +2230,7 @@ struct NetworkDiagnosticsTests {
     func fingerprintChangeRestartsOnce() async {
         let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
         let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
+        let guidance = IsolatedGuidance()
         let configurationProbe = RestartableDiagnosticProbe()
         let networkProbe = RestartableDiagnosticProbe(blockFirstInvocation: true)
         let checks: [any DiagnosticCheck] = [
@@ -2245,7 +2250,8 @@ struct NetworkDiagnosticsTests {
         let viewModel = NetworkDiagnosticsViewModel(
             checks: checks,
             minimumStepDuration: .zero,
-            fingerprintMonitor: fingerprintMonitor
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
         )
 
         #expect(viewModel.start())
@@ -2268,6 +2274,7 @@ struct NetworkDiagnosticsTests {
     func unchangedFingerprintDoesNotRestart() async {
         let fingerprint = makeFingerprint(interfaceName: "en0", dnsHash: 1)
         let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: fingerprint)
+        let guidance = IsolatedGuidance()
         let probe = RestartableDiagnosticProbe(blockFirstInvocation: true)
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [
@@ -2279,7 +2286,8 @@ struct NetworkDiagnosticsTests {
                 ),
             ],
             minimumStepDuration: .zero,
-            fingerprintMonitor: fingerprintMonitor
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
         )
 
         #expect(viewModel.start())
@@ -2298,10 +2306,12 @@ struct NetworkDiagnosticsTests {
         let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
         let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
         let probe = BlockingDiagnosticProbe()
+        let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
             minimumStepDuration: .zero,
-            fingerprintMonitor: fingerprintMonitor
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
         )
 
         #expect(viewModel.start())
@@ -2416,6 +2426,52 @@ struct NetworkDiagnosticsTests {
 
         #expect(viewModel.phase == .idle)
         #expect(viewModel.conclusion == nil)
+    }
+
+    @Test("a successful diagnostics run reports the completion moment exactly once")
+    @MainActor
+    func successfulRunReportsDiagnosticsMomentOnce() async {
+        let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: recorder),
+            minimumStepDuration: .zero,
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        let loaded = guidance.store.load()
+        #expect(loaded.meaningfulCompletionCount == 1)
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(guidance.events.filter { $0.name == "guidance.value_moment" }.count == 1)
+    }
+
+    @Test("a run that never reaches completion never reports the diagnostics moment")
+    @MainActor
+    func failingRunNeverReportsDiagnosticsMoment() async {
+        let probe = BlockingDiagnosticProbe()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
+            minimumStepDuration: .zero,
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        viewModel.cancel()
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .idle)
+        #expect(viewModel.conclusion == nil)
+        #expect(guidance.store.load().meaningfulCompletionCount == 0)
+        #expect(guidance.events.isEmpty)
     }
 
     @Test("system fingerprint monitor detects DNS settings changes without a path update")
@@ -3615,6 +3671,53 @@ private actor DiagnosticTestRecorder {
     func record(_ value: NetworkDiagnosticCheckID) {
         values.append(value)
     }
+}
+
+/// Isolated guidance harness: in-memory store, fixed clock, collecting event
+/// sink. Keeps diagnostics view-model tests hermetic (no real UserDefaults,
+/// no Launch Services queries).
+@MainActor
+private final class IsolatedGuidance {
+    let store: InMemoryGuidanceStateStore
+    let coordinator: GuidanceCoordinator
+    private let eventBox: EventBox
+
+    var events: [GuidanceEvent] { eventBox.events }
+
+    init(completionCount: Int = 0) {
+        let calendar = Self.makeCalendar()
+        let now = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 12))!
+        let box = EventBox()
+        store = InMemoryGuidanceStateStore(initial: GuidanceState(
+            activeDays: ["2026-07-01", "2026-07-02"],
+            meaningfulCompletionCount: completionCount
+        ))
+        var configuration = GuidanceConfiguration()
+        configuration.invitationEnabled = true
+        coordinator = GuidanceCoordinator(
+            configuration: configuration,
+            stateStore: store,
+            now: { now },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { event in
+                box.events.append(event)
+            }
+        )
+        eventBox = box
+    }
+
+    private static func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+}
+
+@MainActor
+private final class EventBox {
+    var events: [GuidanceEvent] = []
 }
 
 private struct StubDiagnosticCheck: DiagnosticCheck {

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingCoordinatorTests.swift
@@ -156,13 +156,45 @@ final class OnboardingCoordinatorTests {
         #expect(store.saveCount == 1)
     }
 
-    @Test func migrationLeavesCleanInstallIncomplete() {
+    @Test func migrationWritesFalseForCleanInstall() {
         let coordinator = makeCoordinator(existingInstallation: false)
 
         coordinator.migrateExistingInstallationIfNeeded()
 
         #expect(coordinator.hasCompletedWelcome == false)
+        #expect(store.hasStoredState() == true)
+        #expect(store.saveCount == 1)
+    }
+
+    @Test func migrationDoesNotRunWhenKeyPresentWithExplicitFalse() {
+        let coordinator = makeCoordinator(
+            initial: OnboardingState(hasCompletedWelcome: false),
+            hasStoredState: true,
+            existingInstallation: true
+        )
+
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(coordinator.hasCompletedWelcome == false)
         #expect(store.saveCount == 0)
+    }
+
+    @Test func cleanInstallWriteFalseThenSparkleMarkerAppearsKeepsWelcome() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+
+        // First launch: clean install writes an explicit false.
+        coordinator.migrateExistingInstallationIfNeeded()
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(store.saveCount == 1)
+
+        // Sparkle writes SUEnableAutomaticChecks after first launch. A later
+        // launch must not re-classify this install as an existing user.
+        detector.evidence = true
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(store.saveCount == 1)
+        #expect(coordinator.claimWelcome(hostID: UUID()) == true)
     }
 
     @Test func migrationRunsOnlyOnce() {
@@ -189,6 +221,29 @@ final class OnboardingCoordinatorTests {
         let guidance = guidanceStore.load()
         #expect(guidance.meaningfulCompletionCount == 7)
         #expect(guidance.invitationPresentationCount == 2)
+    }
+
+    // MARK: - welcomeEnabled gating
+
+    @Test func welcomeDisabledNeverClaims() {
+        let coordinator = makeCoordinator(
+            existingInstallation: false,
+            welcomeEnabled: false
+        )
+
+        #expect(coordinator.claimWelcome(hostID: UUID()) == false)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func welcomeDisabledDebugShowDoesNotRequest() {
+        let coordinator = makeCoordinator(
+            existingInstallation: false,
+            welcomeEnabled: false
+        )
+
+        coordinator.debugRequestShowWelcome()
+
+        #expect(coordinator.consumeDebugShowRequest() == false)
     }
 
     // MARK: - Debug-only
@@ -221,20 +276,27 @@ final class OnboardingCoordinatorTests {
 
     private func makeCoordinator(
         initial: OnboardingState = OnboardingState(),
-        existingInstallation: Bool
+        hasStoredState: Bool? = nil,
+        existingInstallation: Bool,
+        welcomeEnabled: Bool = true
     ) -> OnboardingCoordinator {
-        store = CountingOnboardingStateStore(initial: initial)
+        store = CountingOnboardingStateStore(
+            initial: initial,
+            hasStoredState: hasStoredState
+        )
         detector = StubExistingInstallationDetector(evidence: existingInstallation)
         coordinator = OnboardingCoordinator(
             store: store,
-            existingInstallationDetector: detector
+            existingInstallationDetector: detector,
+            welcomeEnabled: welcomeEnabled
         )
         return coordinator
     }
 }
 
 private final class StubExistingInstallationDetector: ExistingInstallationDetecting, @unchecked Sendable {
-    let evidence: Bool
+    var evidence: Bool
+
     init(evidence: Bool) {
         self.evidence = evidence
     }
@@ -247,18 +309,25 @@ private final class StubExistingInstallationDetector: ExistingInstallationDetect
 @MainActor
 private final class CountingOnboardingStateStore: OnboardingStateStoring {
     private var state: OnboardingState
+    private var stored: Bool
     private(set) var saveCount = 0
 
-    init(initial: OnboardingState = OnboardingState()) {
+    init(initial: OnboardingState = OnboardingState(), hasStoredState: Bool? = nil) {
         state = initial
+        stored = hasStoredState ?? initial.hasCompletedWelcome
     }
 
     func load() -> OnboardingState {
         state
     }
 
+    func hasStoredState() -> Bool {
+        stored
+    }
+
     func save(_ state: OnboardingState) {
         saveCount += 1
         self.state = state
+        stored = true
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingCoordinatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingCoordinatorTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+final class OnboardingCoordinatorTests {
+    private var store: CountingOnboardingStateStore!
+    private var detector: StubExistingInstallationDetector!
+    private var coordinator: OnboardingCoordinator!
+
+    // MARK: - Clean install and completion gating
+
+    @Test func cleanInstallCanClaimWelcome() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let hostA = UUID()
+
+        #expect(coordinator.claimWelcome(hostID: hostA) == true)
+        #expect(coordinator.welcomeHostID == hostA)
+    }
+
+    @Test func completedUserCannotClaim() {
+        let coordinator = makeCoordinator(
+            initial: OnboardingState(hasCompletedWelcome: true),
+            existingInstallation: false
+        )
+
+        #expect(coordinator.claimWelcome(hostID: UUID()) == false)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    // MARK: - Multi-window exclusivity
+
+    @Test func onlyOneHostClaimsAtATime() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let hostA = UUID()
+        let hostB = UUID()
+
+        #expect(coordinator.claimWelcome(hostID: hostA) == true)
+        #expect(coordinator.claimWelcome(hostID: hostB) == false)
+        #expect(coordinator.welcomeHostID == hostA)
+    }
+
+    @Test func hostDisappearingWithoutUserActionDoesNotComplete() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.releaseWelcome(hostID: host)
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func newHostCanClaimAfterRelease() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let hostA = UUID()
+        let hostB = UUID()
+        coordinator.claimWelcome(hostID: hostA)
+        coordinator.releaseWelcome(hostID: hostA)
+
+        #expect(coordinator.claimWelcome(hostID: hostB) == true)
+        #expect(coordinator.welcomeHostID == hostB)
+    }
+
+    // MARK: - Completion semantics
+
+    @Test func startMarksCompletedAndRoutesOnce() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        let first = coordinator.completeWelcomeStart(hostID: host, startRoute: .spectrum)
+        let second = coordinator.completeWelcomeStart(hostID: host, startRoute: .overview)
+
+        #expect(first == .spectrum)
+        #expect(second == nil)
+        #expect(coordinator.hasCompletedWelcome == true)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func skipMarksCompleted() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.completeWelcomeWithoutRouting(hostID: host)
+
+        #expect(coordinator.hasCompletedWelcome == true)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func closeMarksCompleted() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.completeWelcomeWithoutRouting(hostID: host)
+
+        #expect(coordinator.hasCompletedWelcome == true)
+    }
+
+    @Test func proURLOpenedSuccessfullyCompletes() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.completeWelcomeAfterOpeningProURL(hostID: host, openedSuccessfully: true)
+
+        #expect(coordinator.hasCompletedWelcome == true)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func proURLOpenFailureDoesNotComplete() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.completeWelcomeAfterOpeningProURL(hostID: host, openedSuccessfully: false)
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(coordinator.welcomeHostID == host)
+    }
+
+    @Test func staleHostCannotComplete() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let hostA = UUID()
+        let hostB = UUID()
+        coordinator.claimWelcome(hostID: hostA)
+
+        coordinator.completeWelcomeWithoutRouting(hostID: hostB)
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(coordinator.welcomeHostID == hostA)
+    }
+
+    // MARK: - Existing-install migration
+
+    @Test func migrationSkipsWhenKeyAlreadyPresent() {
+        let coordinator = makeCoordinator(
+            initial: OnboardingState(hasCompletedWelcome: true),
+            existingInstallation: true
+        )
+
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(coordinator.hasCompletedWelcome == true)
+        #expect(store.saveCount == 0)
+    }
+
+    @Test func migrationCompletesForExistingInstall() {
+        let coordinator = makeCoordinator(existingInstallation: true)
+
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(coordinator.hasCompletedWelcome == true)
+        #expect(store.saveCount == 1)
+    }
+
+    @Test func migrationLeavesCleanInstallIncomplete() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(store.saveCount == 0)
+    }
+
+    @Test func migrationRunsOnlyOnce() {
+        let coordinator = makeCoordinator(existingInstallation: true)
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        coordinator.migrateExistingInstallationIfNeeded()
+
+        #expect(store.saveCount == 1)
+    }
+
+    @Test func onboardingDoesNotTouchGuidanceState() {
+        let coordinator = makeCoordinator(existingInstallation: true)
+        let guidanceStore = InMemoryGuidanceStateStore(initial: GuidanceState(
+            meaningfulCompletionCount: 7,
+            invitationPresentationCount: 2
+        ))
+
+        coordinator.migrateExistingInstallationIfNeeded()
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+        coordinator.completeWelcomeWithoutRouting(hostID: host)
+
+        let guidance = guidanceStore.load()
+        #expect(guidance.meaningfulCompletionCount == 7)
+        #expect(guidance.invitationPresentationCount == 2)
+    }
+
+    // MARK: - Debug-only
+
+    @Test func debugResetClearsOnlyOnboarding() {
+        let coordinator = makeCoordinator(existingInstallation: false)
+        let host = UUID()
+        coordinator.claimWelcome(hostID: host)
+
+        coordinator.debugReset()
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(coordinator.welcomeHostID == nil)
+    }
+
+    @Test func debugShowWelcomeBypassesCompletionAndMigration() {
+        let coordinator = makeCoordinator(
+            initial: OnboardingState(hasCompletedWelcome: true),
+            existingInstallation: true
+        )
+
+        coordinator.debugRequestShowWelcome()
+
+        #expect(coordinator.hasCompletedWelcome == false)
+        #expect(coordinator.consumeDebugShowRequest() == true)
+        #expect(coordinator.consumeDebugShowRequest() == false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator(
+        initial: OnboardingState = OnboardingState(),
+        existingInstallation: Bool
+    ) -> OnboardingCoordinator {
+        store = CountingOnboardingStateStore(initial: initial)
+        detector = StubExistingInstallationDetector(evidence: existingInstallation)
+        coordinator = OnboardingCoordinator(
+            store: store,
+            existingInstallationDetector: detector
+        )
+        return coordinator
+    }
+}
+
+private final class StubExistingInstallationDetector: ExistingInstallationDetecting, @unchecked Sendable {
+    let evidence: Bool
+    init(evidence: Bool) {
+        self.evidence = evidence
+    }
+
+    func hasExistingInstallationEvidence() -> Bool {
+        evidence
+    }
+}
+
+@MainActor
+private final class CountingOnboardingStateStore: OnboardingStateStoring {
+    private var state: OnboardingState
+    private(set) var saveCount = 0
+
+    init(initial: OnboardingState = OnboardingState()) {
+        state = initial
+    }
+
+    func load() -> OnboardingState {
+        state
+    }
+
+    func save(_ state: OnboardingState) {
+        saveCount += 1
+        self.state = state
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
@@ -19,4 +19,17 @@ final class OnboardingEditionTests {
         ])
         #expect(config.proURL?.absoluteString == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_invite&mt=8")
     }
+
+    @Test func ossMigrationUsesSparkleMarker() {
+        let suiteName = "OSSOnboardingEdition.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let detector = SparkleAutomaticCheckExistingInstallationDetector(defaults: defaults)
+
+        #expect(detector.hasExistingInstallationEvidence() == false)
+
+        defaults.set(true, forKey: SparkleAutomaticCheckExistingInstallationDetector.defaultsKey)
+
+        #expect(detector.hasExistingInstallationEvidence() == true)
+    }
 }

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
@@ -10,6 +10,13 @@ final class OnboardingEditionTests {
         #expect(config.welcomeEnabled == true)
         #expect(config.showsProLink == true)
         #expect(config.startRoute == .overview)
+        #expect(config.startToolbarSelection == nil)
+        #expect(config.primaryActionKey == "onboarding.welcome.start")
+        #expect(config.highlights.map(\.titleKey) == [
+            "onboarding.welcome.highlight.live",
+            "onboarding.welcome.highlight.diagnostics",
+            "onboarding.welcome.highlight.export"
+        ])
         #expect(config.proURL?.absoluteString == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_invite&mt=8")
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingEditionTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+final class OnboardingEditionTests {
+    @Test func ossEnablesWelcomeWithProLink() {
+        let config = EditionComposition.onboardingConfiguration
+
+        #expect(config.welcomeEnabled == true)
+        #expect(config.showsProLink == true)
+        #expect(config.startRoute == .overview)
+        #expect(config.proURL?.absoluteString == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_invite&mt=8")
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingStateStoreTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingStateStoreTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import WiFi_Lens
+
+@MainActor
+final class OnboardingStateStoreTests {
+    @Test func cleanInstallDefaultsToIncomplete() {
+        let store = UserDefaultsOnboardingStateStore(defaults: suiteDefaults())
+        defer { clearSuite() }
+
+        #expect(store.load().hasCompletedWelcome == false)
+    }
+
+    @Test func completedStateRestores() {
+        let defaults = suiteDefaults()
+        defer { clearSuite() }
+        let store = UserDefaultsOnboardingStateStore(defaults: defaults)
+
+        store.save(OnboardingState(hasCompletedWelcome: true))
+
+        #expect(UserDefaultsOnboardingStateStore(defaults: defaults).load().hasCompletedWelcome == true)
+    }
+
+    @Test func resetReturnsToIncomplete() {
+        let defaults = suiteDefaults()
+        defer { clearSuite() }
+        let store = UserDefaultsOnboardingStateStore(defaults: defaults)
+        store.save(OnboardingState(hasCompletedWelcome: true))
+
+        store.save(OnboardingState())
+
+        #expect(store.load().hasCompletedWelcome == false)
+    }
+
+    @Test func corruptDataFallsBackSafely() {
+        let defaults = suiteDefaults()
+        defer { clearSuite() }
+        defaults.set("not-a-bool", forKey: "onboarding.welcome.completed.v1")
+
+        let loaded = UserDefaultsOnboardingStateStore(defaults: defaults).load()
+
+        #expect(loaded.hasCompletedWelcome == false)
+    }
+
+    @Test func versionedKeyDoesNotAffectOtherDefaults() {
+        let defaults = suiteDefaults()
+        defer { clearSuite() }
+        defaults.set("kept", forKey: "unrelated.key")
+
+        UserDefaultsOnboardingStateStore(defaults: defaults)
+            .save(OnboardingState(hasCompletedWelcome: true))
+
+        #expect(defaults.string(forKey: "unrelated.key") == "kept")
+    }
+
+    private func suiteDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "OnboardingStateStoreTests.\(UUID().uuidString)")!
+    }
+
+    private func clearSuite() {
+        // Each test uses its own suite; nothing to clear across tests.
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingStateStoreTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Onboarding/OnboardingStateStoreTests.swift
@@ -4,10 +4,24 @@ import Testing
 
 @MainActor
 final class OnboardingStateStoreTests {
-    @Test func cleanInstallDefaultsToIncomplete() {
+    @Test func cleanInstallDefaultsToIncompleteWithoutStoredKey() {
         let store = UserDefaultsOnboardingStateStore(defaults: suiteDefaults())
         defer { clearSuite() }
 
+        #expect(store.load().hasCompletedWelcome == false)
+        #expect(store.hasStoredState() == false)
+    }
+
+    @Test func absentKeyDistinctFromExplicitFalse() {
+        let defaults = suiteDefaults()
+        defer { clearSuite() }
+        let store = UserDefaultsOnboardingStateStore(defaults: defaults)
+
+        #expect(store.hasStoredState() == false)
+
+        store.save(OnboardingState())
+
+        #expect(store.hasStoredState() == true)
         #expect(store.load().hasCompletedWelcome == false)
     }
 
@@ -18,7 +32,9 @@ final class OnboardingStateStoreTests {
 
         store.save(OnboardingState(hasCompletedWelcome: true))
 
-        #expect(UserDefaultsOnboardingStateStore(defaults: defaults).load().hasCompletedWelcome == true)
+        let reloaded = UserDefaultsOnboardingStateStore(defaults: defaults)
+        #expect(reloaded.load().hasCompletedWelcome == true)
+        #expect(reloaded.hasStoredState() == true)
     }
 
     @Test func resetReturnsToIncomplete() {
@@ -30,6 +46,7 @@ final class OnboardingStateStoreTests {
         store.save(OnboardingState())
 
         #expect(store.load().hasCompletedWelcome == false)
+        #expect(store.hasStoredState() == true)
     }
 
     @Test func corruptDataFallsBackSafely() {
@@ -37,9 +54,11 @@ final class OnboardingStateStoreTests {
         defer { clearSuite() }
         defaults.set("not-a-bool", forKey: "onboarding.welcome.completed.v1")
 
-        let loaded = UserDefaultsOnboardingStateStore(defaults: defaults).load()
+        let store = UserDefaultsOnboardingStateStore(defaults: defaults)
+        let loaded = store.load()
 
         #expect(loaded.hasCompletedWelcome == false)
+        #expect(store.hasStoredState() == true)
     }
 
     @Test func versionedKeyDoesNotAffectOtherDefaults() {

--- a/WiFiLens/Tests/WiFiLensTests/RoamingTestViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/RoamingTestViewModelTests.swift
@@ -55,4 +55,114 @@ import Testing
         // Just verify the VM is in a consistent state
         #expect(vm.state == .idle)
     }
+
+    // MARK: - Guidance Wiring
+
+    @Test func userInitiatedStopOfLiveTestRecordsRoamingMoment() async {
+        let guidance = RoamingGuidanceHarness()
+        let vm = makeConnectedViewModel(guidance: guidance.coordinator)
+
+        await vm.checkReadiness()
+        await waitUntil { vm.state == .ready }
+        vm.startTest()
+        await waitUntil { vm.state == .running }
+        vm.stopTest()
+
+        #expect(vm.state == .stopped)
+        #expect(guidance.store.load().meaningfulCompletionCount == 0)
+        #expect(guidance.events.filter { $0.name == "guidance.value_moment" }.count == 1)
+        #expect(guidance.events.filter { $0.name == "guidance.no_action" }.first?.suppressionReason == .roamingPolicyNotEnabled)
+    }
+
+    @Test func powerOffInterruptionNeverRecordsRoamingMoment() async {
+        let guidance = RoamingGuidanceHarness()
+        let vm = makeConnectedViewModel(guidance: guidance.coordinator)
+
+        await vm.checkReadiness()
+        await waitUntil { vm.state == .ready }
+        vm.startTest()
+        await waitUntil { vm.state == .running }
+
+        vm.handleWiFiPowerStateChange(.poweredOff)
+
+        #expect(vm.state == .idle)
+        #expect(guidance.events.isEmpty)
+        #expect(guidance.store.load().meaningfulCompletionCount == 0)
+    }
+
+    @Test func idleStopNeverRecordsRoamingMoment() {
+        let guidance = RoamingGuidanceHarness()
+        let vm = RoamingTestViewModel(guidance: guidance.coordinator)
+
+        vm.stopTest()
+
+        #expect(vm.state == .stopped)
+        #expect(guidance.events.isEmpty)
+        #expect(guidance.store.load().meaningfulCompletionCount == 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeConnectedViewModel(guidance: GuidanceCoordinator) -> RoamingTestViewModel {
+        let status = WiFiCurrentStatus(
+            timestamp: Date(),
+            ssid: "TestNet",
+            bssid: "AA:BB:CC:DD:EE:FF",
+            channel: 6,
+            rssi: -45,
+            txRate: 300,
+            isConnected: true,
+            isWiFiPowerOn: true
+        )
+        return RoamingTestViewModel(
+            roamingProvider: MockRoamingProbeProvider(result: status),
+            latencyProvider: MockGatewayLatencyProvider(result: .init(timestamp: Date(), latencyMs: 3)),
+            guidance: guidance
+        )
+    }
+
+    @MainActor
+    private func waitUntil(_ condition: () -> Bool) async {
+        var spins = 0
+        while !condition(), spins < 500 {
+            spins += 1
+            await Task.yield()
+        }
+    }
+}
+
+/// Isolated guidance harness for roaming tests: in-memory store, fixed clock,
+/// collecting event sink — no real UserDefaults or Launch Services queries.
+@MainActor
+private final class RoamingGuidanceHarness {
+    let store: InMemoryGuidanceStateStore
+    let coordinator: GuidanceCoordinator
+    private let eventBox: EventBox
+
+    var events: [GuidanceEvent] { eventBox.events }
+
+    init() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let now = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 12))!
+        let box = EventBox()
+        store = InMemoryGuidanceStateStore()
+        var configuration = GuidanceConfiguration()
+        configuration.invitationEnabled = true
+        coordinator = GuidanceCoordinator(
+            configuration: configuration,
+            stateStore: store,
+            now: { now },
+            calendar: calendar,
+            appVersion: { "2.1.0" },
+            isProAppInstalled: { false },
+            eventSink: { event in box.events.append(event) }
+        )
+        eventBox = box
+    }
+}
+
+@MainActor
+private final class EventBox {
+    var events: [GuidanceEvent] = []
 }

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		EC2000000000000000000001C /* InsightRuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001D /* InsightRuleEngine.swift */; };
 		EC2000000000000000000001E /* InitialInsightRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001F /* InitialInsightRules.swift */; };
 		EC20000000000000000000020 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000021 /* InsightsViewModel.swift */; };
+		EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000023 /* ProReviewRequestBridge.swift */; };
 		EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000001 /* EditionCompositionTests.swift */; };
 		E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */; };
 		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
@@ -665,6 +666,7 @@
 		EC2000000000000000000001D /* InsightRuleEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRuleEngine.swift; sourceTree = "<group>"; };
 		EC2000000000000000000001F /* InitialInsightRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialInsightRules.swift; sourceTree = "<group>"; };
 		EC20000000000000000000021 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
+		EC20000000000000000000023 /* ProReviewRequestBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProReviewRequestBridge.swift; sourceTree = "<group>"; };
 		EC20000000000000000000001 /* EditionCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionTests.swift; sourceTree = "<group>"; };
 		E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiObservationEventSQLiteStoreTests.swift; sourceTree = "<group>"; };
 		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
@@ -1270,6 +1272,7 @@
 				EC20000000000000000000019 /* StatisticsViewModel.swift */,
 				EC20000000000000000000011 /* InsightsView.swift */,
 				EC20000000000000000000021 /* InsightsViewModel.swift */,
+				EC20000000000000000000023 /* ProReviewRequestBridge.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2009,6 +2012,7 @@
 				EC2000000000000000000001C /* InsightRuleEngine.swift in Sources */,
 				EC2000000000000000000001E /* InitialInsightRules.swift in Sources */,
 				EC20000000000000000000020 /* InsightsViewModel.swift in Sources */,
+				EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */,
 				FB1E32482FC7316C009D1BDC /* BluetoothPermissionManager.swift in Sources */,
 				FB1E32492FC7316C009D1BDC /* BLEChannel.swift in Sources */,
 				FB1E324A2FC7316C009D1BDC /* BLEAdvertisementEvent.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		G900000000000000000000D5 /* GuidanceCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */; };
 		G900000000000000000000D7 /* GuidanceEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D6 /* GuidanceEditionTests.swift */; };
 		G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D8 /* GuidanceEditionTests.swift */; };
+		G900000000000000000000EB /* GuidanceDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000EC /* GuidanceDebugTests.swift */; };
+		G900000000000000000000EF /* GuidanceDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000EE /* GuidanceDebugTests.swift */; };
 		MV0000000000000000000018 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
 		MV0000000000000000000019 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
 		G900000000000000000000BA /* GuidanceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AA /* GuidanceState.swift */; };
@@ -78,6 +80,8 @@
 		G900000000000000000000E3 /* ProInvitationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E1 /* ProInvitationCard.swift */; };
 		G900000000000000000000E5 /* ExportSuccessBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E4 /* ExportSuccessBanner.swift */; };
 		G900000000000000000000E6 /* ExportSuccessBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E4 /* ExportSuccessBanner.swift */; };
+		G900000000000000000000E8 /* GuidanceDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E7 /* GuidanceDebug.swift */; };
+		G900000000000000000000E9 /* GuidanceDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E7 /* GuidanceDebug.swift */; };
 		MV0000000000000000000022 /* MACVendorDatabaseDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */; };
 		MV0000000000000000000024 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
 		MV0000000000000000000025 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
@@ -538,6 +542,7 @@
 		G900000000000000000000D1 /* GuidanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinator.swift; sourceTree = "<group>"; };
 		G900000000000000000000E1 /* ProInvitationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProInvitationCard.swift; sourceTree = "<group>"; };
 		G900000000000000000000E4 /* ExportSuccessBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportSuccessBanner.swift; sourceTree = "<group>"; };
+		G900000000000000000000E7 /* GuidanceDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceDebug.swift; sourceTree = "<group>"; };
 		MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloaderTests.swift; sourceTree = "<group>"; };
 		MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloader.swift; sourceTree = "<group>"; };
 		MV0000000000000000000028 /* MACVendorDatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseManagerTests.swift; sourceTree = "<group>"; };
@@ -569,6 +574,8 @@
 		G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinatorTests.swift; sourceTree = "<group>"; };
 		G900000000000000000000D6 /* GuidanceEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceEditionTests.swift; sourceTree = "<group>"; };
 		G900000000000000000000D8 /* GuidanceEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceEditionTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000EC /* GuidanceDebugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceDebugTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000EE /* GuidanceDebugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceDebugTests.swift; sourceTree = "<group>"; };
 		EC10000000000000000000005 /* EditionCompositionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionContext.swift; sourceTree = "<group>"; };
 		EC10000000000000000000006 /* OSSEditionComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSEditionComposition.swift; sourceTree = "<group>"; };
 		A10000000000000000000017 /* App/MenuBarWindowBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarWindowBehaviorTests.swift; sourceTree = "<group>"; };
@@ -1070,6 +1077,7 @@
 				G900000000000000000000D1 /* GuidanceCoordinator.swift */,
 				G900000000000000000000E1 /* ProInvitationCard.swift */,
 				G900000000000000000000E4 /* ExportSuccessBanner.swift */,
+				G900000000000000000000E7 /* GuidanceDebug.swift */,
 			);
 			path = Guidance;
 			sourceTree = "<group>";
@@ -1163,6 +1171,7 @@
 				EB2000000000000000000005 /* Fixtures */,
 				EC20000000000000000000001 /* EditionCompositionTests.swift */,
 				G900000000000000000000D8 /* GuidanceEditionTests.swift */,
+				G900000000000000000000EE /* GuidanceDebugTests.swift */,
 				E10000000000000000000001 /* EventJournalTests.swift */,
 				E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */,
 				FB8FCB182FF6C4E300BB2929 /* MenuBarMigrationTests.swift */,
@@ -1404,6 +1413,7 @@
 				G900000000000000000000AD /* GuidancePolicyTests.swift */,
 				G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */,
 				G900000000000000000000D6 /* GuidanceEditionTests.swift */,
+				G900000000000000000000EC /* GuidanceDebugTests.swift */,
 			);
 			path = Guidance;
 			sourceTree = "<group>";
@@ -1773,6 +1783,7 @@
 				G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */,
 				G900000000000000000000E2 /* ProInvitationCard.swift in Sources */,
 				G900000000000000000000E5 /* ExportSuccessBanner.swift in Sources */,
+				G900000000000000000000E8 /* GuidanceDebug.swift in Sources */,
 				ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */,
 				ND0000000000000000000014 /* NetworkConnectivityCheck.swift in Sources */,
 				ND0000000000000000000015 /* DNSResolutionCheck.swift in Sources */,
@@ -1915,6 +1926,7 @@
 				G900000000000000000000BF /* GuidancePolicyTests.swift in Sources */,
 				G900000000000000000000D5 /* GuidanceCoordinatorTests.swift in Sources */,
 				G900000000000000000000D7 /* GuidanceEditionTests.swift in Sources */,
+				G900000000000000000000EB /* GuidanceDebugTests.swift in Sources */,
 				ND0000000000000000000001 /* NetworkDiagnosticsTests.swift in Sources */,
 				67B6475699ADED9C42E8F7CC /* BLEModelTests.swift in Sources */,
 				2A8E470AAD8FCE2CC1D14305 /* BandChartViewModelTests.swift in Sources */,
@@ -1984,6 +1996,7 @@
 				G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */,
 				G900000000000000000000E3 /* ProInvitationCard.swift in Sources */,
 				G900000000000000000000E6 /* ExportSuccessBanner.swift in Sources */,
+				G900000000000000000000E9 /* GuidanceDebug.swift in Sources */,
 				MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */,
 				MV0000000000000000000014 /* MACVendorDatabaseModels.swift in Sources */,
 				MV0000000000000000000004 /* MACVendorResolver.swift in Sources */,
@@ -2166,6 +2179,7 @@
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,
 				G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */,
+				G900000000000000000000EF /* GuidanceDebugTests.swift in Sources */,
 				E10000000000000000000002 /* EventJournalTests.swift in Sources */,
 				E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */,
 				FB8FCB282FF6CAC800BB2929 /* SecondaryToolbarProTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -57,8 +57,23 @@
 		MV0000000000000000000015 /* MACVendorCSVParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000012 /* MACVendorCSVParser.swift */; };
 		MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000012 /* MACVendorCSVParser.swift */; };
 		MV0000000000000000000017 /* MACVendorDatabaseStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000020 /* MACVendorDatabaseStoreTests.swift */; };
+		G900000000000000000000BC /* GuidanceStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AC /* GuidanceStateStoreTests.swift */; };
+		G900000000000000000000BF /* GuidancePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AD /* GuidancePolicyTests.swift */; };
+		G900000000000000000000D5 /* GuidanceCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */; };
+		G900000000000000000000D7 /* GuidanceEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D6 /* GuidanceEditionTests.swift */; };
+		G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D8 /* GuidanceEditionTests.swift */; };
 		MV0000000000000000000018 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
 		MV0000000000000000000019 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
+		G900000000000000000000BA /* GuidanceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AA /* GuidanceState.swift */; };
+		G900000000000000000000BB /* GuidanceStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AB /* GuidanceStateStore.swift */; };
+		G900000000000000000000BD /* GuidanceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AA /* GuidanceState.swift */; };
+		G900000000000000000000BE /* GuidanceStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AB /* GuidanceStateStore.swift */; };
+		G900000000000000000000C1 /* GuidanceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AE /* GuidanceConfiguration.swift */; };
+		G900000000000000000000C2 /* GuidancePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AF /* GuidancePolicy.swift */; };
+		G900000000000000000000C3 /* GuidanceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AE /* GuidanceConfiguration.swift */; };
+		G900000000000000000000C4 /* GuidancePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AF /* GuidancePolicy.swift */; };
+		G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D1 /* GuidanceCoordinator.swift */; };
+		G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D1 /* GuidanceCoordinator.swift */; };
 		MV0000000000000000000022 /* MACVendorDatabaseDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */; };
 		MV0000000000000000000024 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
 		MV0000000000000000000025 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
@@ -510,6 +525,11 @@
 		MV0000000000000000000012 /* MACVendorCSVParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorCSVParser.swift; sourceTree = "<group>"; };
 		MV0000000000000000000020 /* MACVendorDatabaseStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseStoreTests.swift; sourceTree = "<group>"; };
 		MV0000000000000000000021 /* MACVendorDatabaseStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseStore.swift; sourceTree = "<group>"; };
+		G900000000000000000000AA /* GuidanceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceState.swift; sourceTree = "<group>"; };
+		G900000000000000000000AB /* GuidanceStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceStateStore.swift; sourceTree = "<group>"; };
+		G900000000000000000000AE /* GuidanceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceConfiguration.swift; sourceTree = "<group>"; };
+		G900000000000000000000AF /* GuidancePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidancePolicy.swift; sourceTree = "<group>"; };
+		G900000000000000000000D1 /* GuidanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinator.swift; sourceTree = "<group>"; };
 		MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloaderTests.swift; sourceTree = "<group>"; };
 		MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloader.swift; sourceTree = "<group>"; };
 		MV0000000000000000000028 /* MACVendorDatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseManagerTests.swift; sourceTree = "<group>"; };
@@ -536,6 +556,11 @@
 		A10000000000000000000008 /* SecondaryToolbarCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarCapsule.swift; sourceTree = "<group>"; };
 		A10000000000000000000009 /* SecondaryToolbarDescriptorExpansionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryToolbarDescriptorExpansionTests.swift; sourceTree = "<group>"; };
 		EC10000000000000000000002 /* EditionCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000AC /* GuidanceStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceStateStoreTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000AD /* GuidancePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidancePolicyTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinatorTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000D6 /* GuidanceEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceEditionTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000D8 /* GuidanceEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceEditionTests.swift; sourceTree = "<group>"; };
 		EC10000000000000000000005 /* EditionCompositionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionContext.swift; sourceTree = "<group>"; };
 		EC10000000000000000000006 /* OSSEditionComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSEditionComposition.swift; sourceTree = "<group>"; };
 		A10000000000000000000017 /* App/MenuBarWindowBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarWindowBehaviorTests.swift; sourceTree = "<group>"; };
@@ -1007,6 +1032,7 @@
 				D3E6587CCEDEC199C00591B2 /* Channels */,
 				49FEC4F42675BFAD1316DDEC /* Debug */,
 				C1D2E3F4A5B6123456789AC0 /* Filter */,
+				G900000000000000000000CA /* Guidance */,
 				8FFEB5302BE8674E56110FAE /* Interfaces */,
 				786696F9D6046171197C0641 /* MCP */,
 				ND0000000000000000000030 /* NetworkDiagnostics */,
@@ -1022,6 +1048,18 @@
 				DD6657406F0FB50F2D9B7FB4 /* Utilities */,
 			);
 			path = WiFiLens;
+			sourceTree = "<group>";
+		};
+		G900000000000000000000CA /* Guidance */ = {
+			isa = PBXGroup;
+			children = (
+				G900000000000000000000AA /* GuidanceState.swift */,
+				G900000000000000000000AB /* GuidanceStateStore.swift */,
+				G900000000000000000000AE /* GuidanceConfiguration.swift */,
+				G900000000000000000000AF /* GuidancePolicy.swift */,
+				G900000000000000000000D1 /* GuidanceCoordinator.swift */,
+			);
+			path = Guidance;
 			sourceTree = "<group>";
 		};
 		ND0000000000000000000030 /* NetworkDiagnostics */ = {
@@ -1112,6 +1150,7 @@
 				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
 				EB2000000000000000000005 /* Fixtures */,
 				EC20000000000000000000001 /* EditionCompositionTests.swift */,
+				G900000000000000000000D8 /* GuidanceEditionTests.swift */,
 				E10000000000000000000001 /* EventJournalTests.swift */,
 				E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */,
 				FB8FCB182FF6C4E300BB2929 /* MenuBarMigrationTests.swift */,
@@ -1298,6 +1337,7 @@
 				ADB001000000000000000001 /* DebugMultiAPScenarioTests.swift */,
 				3053495094BB40125310557F /* DeviceCompatibilityFilterTests.swift */,
 				90CF4B22A68C668A58043392 /* ExternalLinksTests.swift */,
+				G900000000000000000000CB /* Guidance */,
 				39A94372ADF30D10E0F015CD /* IEParserTests.swift */,
 				A5024CBB8BFCAFF56FEF0756 /* MCPServerTests.swift */,
 				MV0000000000000000000010 /* MACVendorCSVParserTests.swift */,
@@ -1341,6 +1381,17 @@
 				ND0000000000000000000002 /* NetworkDiagnosticsTests.swift */,
 			);
 			path = NetworkDiagnostics;
+			sourceTree = "<group>";
+		};
+		G900000000000000000000CB /* Guidance */ = {
+			isa = PBXGroup;
+			children = (
+				G900000000000000000000AC /* GuidanceStateStoreTests.swift */,
+				G900000000000000000000AD /* GuidancePolicyTests.swift */,
+				G900000000000000000000D4 /* GuidanceCoordinatorTests.swift */,
+				G900000000000000000000D6 /* GuidanceEditionTests.swift */,
+			);
+			path = Guidance;
 			sourceTree = "<group>";
 		};
 		FBD329492FBF0E2F00D01613 /* Tests */ = {
@@ -1701,6 +1752,11 @@
 				MV0000000000000000000003 /* MACVendorResolver.swift in Sources */,
 				MV0000000000000000000046 /* MACVendorBundledDatabase.swift in Sources */,
 				ND0000000000000000000010 /* NetworkDiagnosticModels.swift in Sources */,
+				G900000000000000000000BA /* GuidanceState.swift in Sources */,
+				G900000000000000000000BB /* GuidanceStateStore.swift in Sources */,
+				G900000000000000000000C1 /* GuidanceConfiguration.swift in Sources */,
+				G900000000000000000000C2 /* GuidancePolicy.swift in Sources */,
+				G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */,
 				ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */,
 				ND0000000000000000000014 /* NetworkConnectivityCheck.swift in Sources */,
 				ND0000000000000000000015 /* DNSResolutionCheck.swift in Sources */,
@@ -1839,6 +1895,10 @@
 				MV0000000000000000000041 /* MACVendorDatabaseReminderTests.swift in Sources */,
 				MV0000000000000000000017 /* MACVendorDatabaseStoreTests.swift in Sources */,
 				MV0000000000000000000009 /* MACVendorCSVParserTests.swift in Sources */,
+				G900000000000000000000BC /* GuidanceStateStoreTests.swift in Sources */,
+				G900000000000000000000BF /* GuidancePolicyTests.swift in Sources */,
+				G900000000000000000000D5 /* GuidanceCoordinatorTests.swift in Sources */,
+				G900000000000000000000D7 /* GuidanceEditionTests.swift in Sources */,
 				ND0000000000000000000001 /* NetworkDiagnosticsTests.swift in Sources */,
 				67B6475699ADED9C42E8F7CC /* BLEModelTests.swift in Sources */,
 				2A8E470AAD8FCE2CC1D14305 /* BandChartViewModelTests.swift in Sources */,
@@ -1901,6 +1961,11 @@
 				MV0000000000000000000030 /* MACVendorDatabaseService.swift in Sources */,
 				MV0000000000000000000025 /* MACVendorDatabaseDownloader.swift in Sources */,
 				MV0000000000000000000019 /* MACVendorDatabaseStore.swift in Sources */,
+				G900000000000000000000BD /* GuidanceState.swift in Sources */,
+				G900000000000000000000BE /* GuidanceStateStore.swift in Sources */,
+				G900000000000000000000C3 /* GuidanceConfiguration.swift in Sources */,
+				G900000000000000000000C4 /* GuidancePolicy.swift in Sources */,
+				G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */,
 				MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */,
 				MV0000000000000000000014 /* MACVendorDatabaseModels.swift in Sources */,
 				MV0000000000000000000004 /* MACVendorResolver.swift in Sources */,
@@ -2080,6 +2145,7 @@
 				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,
+				G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */,
 				E10000000000000000000002 /* EventJournalTests.swift in Sources */,
 				E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */,
 				FB8FCB282FF6CAC800BB2929 /* SecondaryToolbarProTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 		EC2000000000000000000001E /* InitialInsightRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2000000000000000000001F /* InitialInsightRules.swift */; };
 		EC20000000000000000000020 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000021 /* InsightsViewModel.swift */; };
 		EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000023 /* ProReviewRequestBridge.swift */; };
+		EC20000000000000000000026 /* FeedbackContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000025 /* FeedbackContact.swift */; };
 		EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000001 /* EditionCompositionTests.swift */; };
 		E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */; };
 		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
@@ -667,6 +668,7 @@
 		EC2000000000000000000001F /* InitialInsightRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialInsightRules.swift; sourceTree = "<group>"; };
 		EC20000000000000000000021 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
 		EC20000000000000000000023 /* ProReviewRequestBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProReviewRequestBridge.swift; sourceTree = "<group>"; };
+		EC20000000000000000000025 /* FeedbackContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContact.swift; sourceTree = "<group>"; };
 		EC20000000000000000000001 /* EditionCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionTests.swift; sourceTree = "<group>"; };
 		E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiObservationEventSQLiteStoreTests.swift; sourceTree = "<group>"; };
 		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
@@ -1273,6 +1275,7 @@
 				EC20000000000000000000011 /* InsightsView.swift */,
 				EC20000000000000000000021 /* InsightsViewModel.swift */,
 				EC20000000000000000000023 /* ProReviewRequestBridge.swift */,
+				EC20000000000000000000025 /* FeedbackContact.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2013,6 +2016,7 @@
 				EC2000000000000000000001E /* InitialInsightRules.swift in Sources */,
 				EC20000000000000000000020 /* InsightsViewModel.swift in Sources */,
 				EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */,
+				EC20000000000000000000026 /* FeedbackContact.swift in Sources */,
 				FB1E32482FC7316C009D1BDC /* BluetoothPermissionManager.swift in Sources */,
 				FB1E32492FC7316C009D1BDC /* BLEChannel.swift in Sources */,
 				FB1E324A2FC7316C009D1BDC /* BLEAdvertisementEvent.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		G900000000000000000000C4 /* GuidancePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AF /* GuidancePolicy.swift */; };
 		G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D1 /* GuidanceCoordinator.swift */; };
 		G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D1 /* GuidanceCoordinator.swift */; };
+		G900000000000000000000E2 /* ProInvitationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E1 /* ProInvitationCard.swift */; };
+		G900000000000000000000E3 /* ProInvitationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E1 /* ProInvitationCard.swift */; };
 		MV0000000000000000000022 /* MACVendorDatabaseDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */; };
 		MV0000000000000000000024 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
 		MV0000000000000000000025 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
@@ -530,6 +532,7 @@
 		G900000000000000000000AE /* GuidanceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceConfiguration.swift; sourceTree = "<group>"; };
 		G900000000000000000000AF /* GuidancePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidancePolicy.swift; sourceTree = "<group>"; };
 		G900000000000000000000D1 /* GuidanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinator.swift; sourceTree = "<group>"; };
+		G900000000000000000000E1 /* ProInvitationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProInvitationCard.swift; sourceTree = "<group>"; };
 		MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloaderTests.swift; sourceTree = "<group>"; };
 		MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloader.swift; sourceTree = "<group>"; };
 		MV0000000000000000000028 /* MACVendorDatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseManagerTests.swift; sourceTree = "<group>"; };
@@ -1058,6 +1061,7 @@
 				G900000000000000000000AE /* GuidanceConfiguration.swift */,
 				G900000000000000000000AF /* GuidancePolicy.swift */,
 				G900000000000000000000D1 /* GuidanceCoordinator.swift */,
+				G900000000000000000000E1 /* ProInvitationCard.swift */,
 			);
 			path = Guidance;
 			sourceTree = "<group>";
@@ -1757,6 +1761,7 @@
 				G900000000000000000000C1 /* GuidanceConfiguration.swift in Sources */,
 				G900000000000000000000C2 /* GuidancePolicy.swift in Sources */,
 				G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */,
+				G900000000000000000000E2 /* ProInvitationCard.swift in Sources */,
 				ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */,
 				ND0000000000000000000014 /* NetworkConnectivityCheck.swift in Sources */,
 				ND0000000000000000000015 /* DNSResolutionCheck.swift in Sources */,
@@ -1966,6 +1971,7 @@
 				G900000000000000000000C3 /* GuidanceConfiguration.swift in Sources */,
 				G900000000000000000000C4 /* GuidancePolicy.swift in Sources */,
 				G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */,
+				G900000000000000000000E3 /* ProInvitationCard.swift in Sources */,
 				MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */,
 				MV0000000000000000000014 /* MACVendorDatabaseModels.swift in Sources */,
 				MV0000000000000000000004 /* MACVendorResolver.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D1 /* GuidanceCoordinator.swift */; };
 		G900000000000000000000E2 /* ProInvitationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E1 /* ProInvitationCard.swift */; };
 		G900000000000000000000E3 /* ProInvitationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E1 /* ProInvitationCard.swift */; };
+		G900000000000000000000E5 /* ExportSuccessBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E4 /* ExportSuccessBanner.swift */; };
+		G900000000000000000000E6 /* ExportSuccessBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000E4 /* ExportSuccessBanner.swift */; };
 		MV0000000000000000000022 /* MACVendorDatabaseDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */; };
 		MV0000000000000000000024 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
 		MV0000000000000000000025 /* MACVendorDatabaseDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */; };
@@ -533,6 +535,7 @@
 		G900000000000000000000AF /* GuidancePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidancePolicy.swift; sourceTree = "<group>"; };
 		G900000000000000000000D1 /* GuidanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCoordinator.swift; sourceTree = "<group>"; };
 		G900000000000000000000E1 /* ProInvitationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProInvitationCard.swift; sourceTree = "<group>"; };
+		G900000000000000000000E4 /* ExportSuccessBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportSuccessBanner.swift; sourceTree = "<group>"; };
 		MV0000000000000000000023 /* MACVendorDatabaseDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloaderTests.swift; sourceTree = "<group>"; };
 		MV0000000000000000000026 /* MACVendorDatabaseDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseDownloader.swift; sourceTree = "<group>"; };
 		MV0000000000000000000028 /* MACVendorDatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorDatabaseManagerTests.swift; sourceTree = "<group>"; };
@@ -1062,6 +1065,7 @@
 				G900000000000000000000AF /* GuidancePolicy.swift */,
 				G900000000000000000000D1 /* GuidanceCoordinator.swift */,
 				G900000000000000000000E1 /* ProInvitationCard.swift */,
+				G900000000000000000000E4 /* ExportSuccessBanner.swift */,
 			);
 			path = Guidance;
 			sourceTree = "<group>";
@@ -1762,6 +1766,7 @@
 				G900000000000000000000C2 /* GuidancePolicy.swift in Sources */,
 				G900000000000000000000D2 /* GuidanceCoordinator.swift in Sources */,
 				G900000000000000000000E2 /* ProInvitationCard.swift in Sources */,
+				G900000000000000000000E5 /* ExportSuccessBanner.swift in Sources */,
 				ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */,
 				ND0000000000000000000014 /* NetworkConnectivityCheck.swift in Sources */,
 				ND0000000000000000000015 /* DNSResolutionCheck.swift in Sources */,
@@ -1972,6 +1977,7 @@
 				G900000000000000000000C4 /* GuidancePolicy.swift in Sources */,
 				G900000000000000000000D3 /* GuidanceCoordinator.swift in Sources */,
 				G900000000000000000000E3 /* ProInvitationCard.swift in Sources */,
+				G900000000000000000000E6 /* ExportSuccessBanner.swift in Sources */,
 				MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */,
 				MV0000000000000000000014 /* MACVendorDatabaseModels.swift in Sources */,
 				MV0000000000000000000004 /* MACVendorResolver.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -64,6 +64,22 @@
 		G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000D8 /* GuidanceEditionTests.swift */; };
 		G900000000000000000000EB /* GuidanceDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000EC /* GuidanceDebugTests.swift */; };
 		G900000000000000000000EF /* GuidanceDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000EE /* GuidanceDebugTests.swift */; };
+		G900000000000000000000A1 /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A0 /* OnboardingState.swift */; };
+		G900000000000000000000A2 /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A0 /* OnboardingState.swift */; };
+		G900000000000000000000A4 /* OnboardingStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A3 /* OnboardingStateStore.swift */; };
+		G900000000000000000000A5 /* OnboardingStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A3 /* OnboardingStateStore.swift */; };
+		G900000000000000000000A7 /* ExistingInstallationDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A6 /* ExistingInstallationDetector.swift */; };
+		G900000000000000000000A8 /* ExistingInstallationDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A6 /* ExistingInstallationDetector.swift */; };
+		G900000000000000000000B0 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A9 /* OnboardingCoordinator.swift */; };
+		G900000000000000000000B1 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000A9 /* OnboardingCoordinator.swift */; };
+		G900000000000000000000B3 /* OnboardingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000B2 /* OnboardingConfiguration.swift */; };
+		G900000000000000000000B4 /* OnboardingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000B2 /* OnboardingConfiguration.swift */; };
+		G900000000000000000000B6 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000B5 /* WelcomeView.swift */; };
+		G900000000000000000000B7 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000B5 /* WelcomeView.swift */; };
+		G900000000000000000000B9 /* OnboardingStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000B8 /* OnboardingStateStoreTests.swift */; };
+		G900000000000000000000C5 /* OnboardingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000C0 /* OnboardingCoordinatorTests.swift */; };
+		G900000000000000000000C7 /* OnboardingEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000C6 /* OnboardingEditionTests.swift */; };
+		G900000000000000000000C9 /* OnboardingEditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000C8 /* OnboardingEditionTests.swift */; };
 		MV0000000000000000000018 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
 		MV0000000000000000000019 /* MACVendorDatabaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000021 /* MACVendorDatabaseStore.swift */; };
 		G900000000000000000000BA /* GuidanceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = G900000000000000000000AA /* GuidanceState.swift */; };
@@ -576,6 +592,16 @@
 		G900000000000000000000D8 /* GuidanceEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceEditionTests.swift; sourceTree = "<group>"; };
 		G900000000000000000000EC /* GuidanceDebugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceDebugTests.swift; sourceTree = "<group>"; };
 		G900000000000000000000EE /* GuidanceDebugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceDebugTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000A0 /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
+		G900000000000000000000A3 /* OnboardingStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStateStore.swift; sourceTree = "<group>"; };
+		G900000000000000000000A6 /* ExistingInstallationDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingInstallationDetector.swift; sourceTree = "<group>"; };
+		G900000000000000000000A9 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
+		G900000000000000000000B2 /* OnboardingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConfiguration.swift; sourceTree = "<group>"; };
+		G900000000000000000000B5 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
+		G900000000000000000000B8 /* OnboardingStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStateStoreTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000C0 /* OnboardingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinatorTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000C6 /* OnboardingEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEditionTests.swift; sourceTree = "<group>"; };
+		G900000000000000000000C8 /* OnboardingEditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEditionTests.swift; sourceTree = "<group>"; };
 		EC10000000000000000000005 /* EditionCompositionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditionCompositionContext.swift; sourceTree = "<group>"; };
 		EC10000000000000000000006 /* OSSEditionComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSSEditionComposition.swift; sourceTree = "<group>"; };
 		A10000000000000000000017 /* App/MenuBarWindowBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarWindowBehaviorTests.swift; sourceTree = "<group>"; };
@@ -1050,6 +1076,7 @@
 				49FEC4F42675BFAD1316DDEC /* Debug */,
 				C1D2E3F4A5B6123456789AC0 /* Filter */,
 				G900000000000000000000CA /* Guidance */,
+				G900000000000000000000D0 /* Onboarding */,
 				8FFEB5302BE8674E56110FAE /* Interfaces */,
 				786696F9D6046171197C0641 /* MCP */,
 				ND0000000000000000000030 /* NetworkDiagnostics */,
@@ -1065,6 +1092,19 @@
 				DD6657406F0FB50F2D9B7FB4 /* Utilities */,
 			);
 			path = WiFiLens;
+			sourceTree = "<group>";
+		};
+		G900000000000000000000D0 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				G900000000000000000000A0 /* OnboardingState.swift */,
+				G900000000000000000000A3 /* OnboardingStateStore.swift */,
+				G900000000000000000000A6 /* ExistingInstallationDetector.swift */,
+				G900000000000000000000A9 /* OnboardingCoordinator.swift */,
+				G900000000000000000000B2 /* OnboardingConfiguration.swift */,
+				G900000000000000000000B5 /* WelcomeView.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		G900000000000000000000CA /* Guidance */ = {
@@ -1172,6 +1212,7 @@
 				EC20000000000000000000001 /* EditionCompositionTests.swift */,
 				G900000000000000000000D8 /* GuidanceEditionTests.swift */,
 				G900000000000000000000EE /* GuidanceDebugTests.swift */,
+				G900000000000000000000C8 /* OnboardingEditionTests.swift */,
 				E10000000000000000000001 /* EventJournalTests.swift */,
 				E30000000000000000000001 /* WiFiObservationEventSQLiteStoreTests.swift */,
 				FB8FCB182FF6C4E300BB2929 /* MenuBarMigrationTests.swift */,
@@ -1361,6 +1402,7 @@
 				3053495094BB40125310557F /* DeviceCompatibilityFilterTests.swift */,
 				90CF4B22A68C668A58043392 /* ExternalLinksTests.swift */,
 				G900000000000000000000CB /* Guidance */,
+				G900000000000000000000F0 /* Onboarding */,
 				39A94372ADF30D10E0F015CD /* IEParserTests.swift */,
 				A5024CBB8BFCAFF56FEF0756 /* MCPServerTests.swift */,
 				MV0000000000000000000010 /* MACVendorCSVParserTests.swift */,
@@ -1404,6 +1446,16 @@
 				ND0000000000000000000002 /* NetworkDiagnosticsTests.swift */,
 			);
 			path = NetworkDiagnostics;
+			sourceTree = "<group>";
+		};
+		G900000000000000000000F0 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				G900000000000000000000B8 /* OnboardingStateStoreTests.swift */,
+				G900000000000000000000C0 /* OnboardingCoordinatorTests.swift */,
+				G900000000000000000000C6 /* OnboardingEditionTests.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		G900000000000000000000CB /* Guidance */ = {
@@ -1784,6 +1836,12 @@
 				G900000000000000000000E2 /* ProInvitationCard.swift in Sources */,
 				G900000000000000000000E5 /* ExportSuccessBanner.swift in Sources */,
 				G900000000000000000000E8 /* GuidanceDebug.swift in Sources */,
+				G900000000000000000000A1 /* OnboardingState.swift in Sources */,
+				G900000000000000000000A4 /* OnboardingStateStore.swift in Sources */,
+				G900000000000000000000A7 /* ExistingInstallationDetector.swift in Sources */,
+				G900000000000000000000B0 /* OnboardingCoordinator.swift in Sources */,
+				G900000000000000000000B3 /* OnboardingConfiguration.swift in Sources */,
+				G900000000000000000000B6 /* WelcomeView.swift in Sources */,
 				ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */,
 				ND0000000000000000000014 /* NetworkConnectivityCheck.swift in Sources */,
 				ND0000000000000000000015 /* DNSResolutionCheck.swift in Sources */,
@@ -1927,6 +1985,9 @@
 				G900000000000000000000D5 /* GuidanceCoordinatorTests.swift in Sources */,
 				G900000000000000000000D7 /* GuidanceEditionTests.swift in Sources */,
 				G900000000000000000000EB /* GuidanceDebugTests.swift in Sources */,
+				G900000000000000000000B9 /* OnboardingStateStoreTests.swift in Sources */,
+				G900000000000000000000C5 /* OnboardingCoordinatorTests.swift in Sources */,
+				G900000000000000000000C7 /* OnboardingEditionTests.swift in Sources */,
 				ND0000000000000000000001 /* NetworkDiagnosticsTests.swift in Sources */,
 				67B6475699ADED9C42E8F7CC /* BLEModelTests.swift in Sources */,
 				2A8E470AAD8FCE2CC1D14305 /* BandChartViewModelTests.swift in Sources */,
@@ -1997,6 +2058,12 @@
 				G900000000000000000000E3 /* ProInvitationCard.swift in Sources */,
 				G900000000000000000000E6 /* ExportSuccessBanner.swift in Sources */,
 				G900000000000000000000E9 /* GuidanceDebug.swift in Sources */,
+				G900000000000000000000A2 /* OnboardingState.swift in Sources */,
+				G900000000000000000000A5 /* OnboardingStateStore.swift in Sources */,
+				G900000000000000000000A8 /* ExistingInstallationDetector.swift in Sources */,
+				G900000000000000000000B1 /* OnboardingCoordinator.swift in Sources */,
+				G900000000000000000000B4 /* OnboardingConfiguration.swift in Sources */,
+				G900000000000000000000B7 /* WelcomeView.swift in Sources */,
 				MV0000000000000000000016 /* MACVendorCSVParser.swift in Sources */,
 				MV0000000000000000000014 /* MACVendorDatabaseModels.swift in Sources */,
 				MV0000000000000000000004 /* MACVendorResolver.swift in Sources */,
@@ -2180,6 +2247,7 @@
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,
 				G900000000000000000000D9 /* GuidanceEditionTests.swift in Sources */,
 				G900000000000000000000EF /* GuidanceDebugTests.swift in Sources */,
+				G900000000000000000000C9 /* OnboardingEditionTests.swift in Sources */,
 				E10000000000000000000002 /* EventJournalTests.swift in Sources */,
 				E30000000000000000000002 /* WiFiObservationEventSQLiteStoreTests.swift in Sources */,
 				FB8FCB282FF6CAC800BB2929 /* SecondaryToolbarProTests.swift in Sources */,


### PR DESCRIPTION
Implements the complete lifecycle-guidance flow for SHIINASAMA/wifi-lens-pro#17: shared core (Milestone 1), diagnostics invitation (Task 5), export banner + edition strategy (Task 6), roaming event (Task 7), and localization/release readiness (Task 10), plus the first-run onboarding experience. The Pro-only review flow (Tasks 8–9) lives in the pinned `wifi-lens-pro` submodule.

**Included (shared/OSS)**
- `GuidanceState` — persisted state; restore-time invalid-day-key filtering, dedupe/sort/cap at 120, local-calendar active days
- `GuidanceStateStore` — `UserDefaults` + in-memory stores (main-actor protocol)
- `GuidanceConfiguration` / `GuidancePolicy` — pure eligibility, thresholds, cooldowns, version gating, roaming policy-off
- `GuidanceCoordinator` — main-actor, observable; in-memory scheduling only, token-gated consumption, lifecycle-aware host dismissal (`endInvitationPresentation(id:)`), injected event sink (production forwards to `AppLogger.guidance`)
- `ProInvitationCard` — dumb card receiving an explicit `InvitationPresentation`; moment-specific copy; View Pro opens the official `oss_invite` Campaign Link then confirms
- `ExportSuccessBanner` — OSS bottom-anchored banner hosting the export invitation; X with invitation = Later, without = feedback only
- `ExportService` strategy switch — `.banner` (OSS) / `.preserveExisting` (Pro keeps its PNG alert); both record `exportSucceeded`
- `RoamingTestViewModel.stopTest(userInitiated:)` — user stops record `roamingCompleted`; power-off/idle never record
- Launch + scene-phase active-day wiring in `WiFiLensApp`
- OSS seam uses the confirmed official App Store Connect `oss_invite` Campaign Link through `ExternalLinks.appStoreCampaign`
- Full translations (en/de/es/ja/zh-Hans) for guidance, diagnostics, export, onboarding, and Settings support keys

**First-run onboarding**
- Independent from Lifecycle Guidance: onboarding never touches `GuidanceState`, invitation/review counts, cooldowns, or tokens.
- `OnboardingState` / `OnboardingStateStore` — versioned key `onboarding.welcome.completed.v1`; separate from guidance state; the store distinguishes "key absent" from "key present with `false`".
- `ExistingInstallationDetector` — OSS uses the pre-existing Sparkle `SUEnableAutomaticChecks` marker; the one-time migration only runs while the onboarding key is absent and always writes a result (`true` for existing installs, `false` for clean installs), so a marker that appears later (Sparkle writes after first launch) can never re-classify a clean install into "completed".
- All welcome display is gated by the edition `welcomeEnabled` flag (automatic claim and Debug "Show Welcome Now"); when disabled the coordinator refuses to claim.
- `OnboardingCoordinator` — main-actor single-host claim (at most one window shows the welcome); completion only on explicit user action; host disappearance never completes.
- `WelcomeView` — compact sheet with the real app icon as the visual anchor and three short edition-specific highlights; OSS `Start Analyzing` routes to Overview, Pro `Start Recording` routes to the Spectrum recording page (the honest first step before any data exists); OSS-only "Learn about WiFi Lens Pro" opens the official `oss_invite` Campaign Link and completes only when the system accepts the URL; Skip/Close complete.
- Edition-provided `OnboardingConfiguration`: OSS shows welcome + Pro link (highlights: live channel usage / one-tap diagnostics / snapshot export); Pro shows welcome only with no upgrade entry or Campaign Link (highlights: record evidence / timeline / analysis); primary action label, start route, and optional toolbar selection are all edition-provided.
- `Debug → Onboarding` menu (Reset Welcome State / Show Welcome Now / Log Onboarding State) — Debug-only, compiled out of Release builds.

**Tests**
- `GuidanceStateStoreTests`, `GuidancePolicyTests`, `GuidanceCoordinatorTests` (incl. export banner hosting/lifecycle), `ExternalLinksTests`, OSS `GuidanceEditionTests`, `RoamingTestViewModelTests`
- New: `OnboardingStateStoreTests`, `OnboardingCoordinatorTests`, OSS `OnboardingEditionTests`, extended `GuidanceDebugTests` (staging atomic consume, configuration-driven seeding, production metadata without token)
- Full suite: 976 `WiFiLensTests` green; OSS + Pro builds green (Debug and Release)

**Pro submodule**
- Pinned to `wifi-lens-pro` `codex/lifecycle-guidance` @ `84cab1fe6c3211a58427da36b654c4c2e6760031` (PR #18), which adds: `ProReviewRequestBridge` + `RequestReviewAction` presentation with app-level visibility re-checks, `ProAnalysisPresentationState` session dedup + `analysisLoaded`, Rate (`action=write-review`) / Send Feedback (`mailto:`) Settings actions, the first-run welcome edition configuration (no upgrade entry), and the Lifecycle Guidance architecture section.

**Notes**
- No StoreKit in shared/OSS sources; the only `import StoreKit` in the Pro target is `ProReviewRequestBridge.swift`; no `SKStoreReviewController` anywhere.
- Review state persists only on actual `RequestReviewAction` invocation; invitation/review tokens are process-memory only.
- No UUID is logged, persisted, uploaded, or sent to Apple: guidance tokens stay test-sink-only (production metadata never carries them), onboarding creates no tokens, and debug state summaries contain no UUID/SSID/BSSID/diagnostic content.

**Debug-only manual testing controls**
- `Debug → Lifecycle Guidance` menu in Debug builds: Reset Lifecycle Guidance State, Prepare OSS Invitation Eligibility, Trigger Diagnostics Invitation, Trigger Export Invitation Banner, Pro Installation Override, Log Lifecycle Guidance State.
- `Debug → Onboarding` menu in Debug builds: Reset Welcome State, Show Welcome Now, Log Onboarding State.
- All entries reuse production paths: the real `ProInvitationCard` (diagnostics host renders it from a staged synthetic result — no Timeline/diagnostic history written) and the real `ExportSuccessBanner`; token lifecycle, pending gates, and `onAppear`/`onDisappear` semantics are intact; View Pro still opens the official `oss_invite` Campaign Link.
- Debug controls are fully excluded from Release builds.
