### PR TITLE
fix(network): use Apple authoritative captive-portal probe; document scoped ATS exception

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
@@ -123,7 +123,7 @@ struct OverviewView: View {
                             .foregroundColor(.secondary)
                             .lineLimit(1)
                         if let ch = wifi.channel {
-                            Text("·  \(bandName(ch))  ·  Ch \(ch)")
+                            Text(String(format: String(localized: "format.band_channel_separator", comment: "Band and channel separator with values"), bandName(ch), ch))
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .lineLimit(1)
@@ -133,7 +133,7 @@ struct OverviewView: View {
                 Spacer(minLength: 12)
 
                 VStack(alignment: .trailing, spacing: 4) {
-                    Text("\(wifi.rssi ?? -100) dBm")
+                    Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), wifi.rssi ?? -100))
                         .font(.caption.monospacedDigit())
                         .foregroundColor(rssiColor(wifi.rssi ?? -100))
                         .accessibilityLabel(String(format: String(localized: "roaming.accessibility.rssi_fmt", comment: "RSSI accessibility label with value and quality"), wifi.rssi ?? -100, signalLabel(wifi.rssi ?? -100)))

--- a/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
@@ -710,6 +710,10 @@ private struct EarthGlobeView: NSViewRepresentable {
               let innerGlowNode = coordinator.innerGlowNode,
               let glowNode = coordinator.glowNode else { return }
 
+        // Remove any existing keys first so repeated start transitions can
+        // never stack duplicate CAAnimation instances on the same node.
+        stopAnimations(on: coordinator)
+
         for node in coordinator.hubNodes {
             let pulse = CABasicAnimation(keyPath: "opacity")
             pulse.fromValue = 0.3; pulse.toValue = 1.0; pulse.duration = 1.2

--- a/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OverviewView.swift
@@ -4,6 +4,7 @@ import SceneKit
 struct OverviewView: View {
     @Bindable var viewModel: ScannerViewModel
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let store: WiFiObservationStore
 
@@ -57,7 +58,7 @@ struct OverviewView: View {
                     VStack(spacing: 16) {
                         // State icon — rotating 3D Earth
                         let stateColor = wifi != nil ? rssiColor(wifi!.rssi ?? -100) : Color.secondary
-                        EarthGlobeView(color: stateColor)
+                        EarthGlobeView(color: stateColor, reduceMotion: reduceMotion)
                             .frame(width: 240, height: 240)
                             .accessibilityHidden(true)
 
@@ -442,6 +443,19 @@ private final class GlobeContainerView: NSView {
     private var globeView: SCNView?
     private var pendingTint: NSColor?
 
+    /// Respects Reduce Motion: when enabled, the globe renders a static frame
+    /// and the SceneKit render loop is stopped instead of playing ambient motion.
+    var reduceMotion: Bool = false {
+        didSet {
+            guard reduceMotion != oldValue else { return }
+            if reduceMotion {
+                globeView?.isPlaying = false
+            } else {
+                updatePlaybackIfVisible()
+            }
+        }
+    }
+
     var scene: SCNScene? {
         didSet { updatePlaybackIfVisible() }
     }
@@ -458,7 +472,7 @@ private final class GlobeContainerView: NSView {
     func updatePlaybackIfVisible() {
         guard let window, window.isVisible, !bounds.isEmpty else { return }
         guard globeView == nil else {
-            globeView?.isPlaying = true
+            globeView?.isPlaying = !reduceMotion
             return
         }
         guard let scene else { return }
@@ -469,7 +483,7 @@ private final class GlobeContainerView: NSView {
         view.antialiasingMode = .multisampling8X
         view.preferredFramesPerSecond = 0
         view.scene = scene
-        view.isPlaying = true
+        view.isPlaying = !reduceMotion
         view.frame = bounds
         view.autoresizingMask = [.width, .height]
         addSubview(view)
@@ -519,6 +533,7 @@ private final class GlobeContainerView: NSView {
 
 private struct EarthGlobeView: NSViewRepresentable {
     let color: Color
+    let reduceMotion: Bool
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -600,9 +615,11 @@ private struct EarthGlobeView: NSViewRepresentable {
             (1.3, 103.8), (50.1, 8.7), (-33.9, 151.2), (-23.5, -46.6),
         ]
         let hubPairs: [(Int, Int)] = [(0,1),(1,2),(2,5),(3,4),(4,7),(5,3),(0,3),(6,4),(7,0),(2,3)]
+        var tubeNodes: [SCNNode] = []
 
         // Create hub dots + store unit positions for tubes
         var hubUnitPos: [SCNVector3] = []
+        var hubNodes: [SCNNode] = []
         for (lat, lon) in hubs {
             let p = spherePoint(lat: lat, lon: lon)
             hubUnitPos.append(p)
@@ -613,11 +630,7 @@ private struct EarthGlobeView: NSViewRepresentable {
             let node = SCNNode(geometry: dot)
             node.position = SCNVector3(p.x * hubRadius, p.y * hubRadius, p.z * hubRadius)
             earthNode.addChildNode(node)
-
-            let pulse = CABasicAnimation(keyPath: "opacity")
-            pulse.fromValue = 0.3; pulse.toValue = 1.0; pulse.duration = 1.2
-            pulse.autoreverses = true; pulse.repeatCount = .greatestFiniteMagnitude
-            node.addAnimation(pulse, forKey: "pulse")
+            hubNodes.append(node)
         }
 
         // Connection tubes between hub pairs
@@ -635,11 +648,7 @@ private struct EarthGlobeView: NSViewRepresentable {
             tubeNode.position = midP
             tubeNode.look(at: toP, up: SCNVector3(0, 1, 0), localFront: SCNVector3(0, 1, 0))
             earthNode.addChildNode(tubeNode)
-
-            let fade = CABasicAnimation(keyPath: "opacity")
-            fade.fromValue = 0.15; fade.toValue = 0.45; fade.duration = Double.random(in: 2...4)
-            fade.autoreverses = true; fade.repeatCount = .greatestFiniteMagnitude
-            tubeNode.addAnimation(fade, forKey: "flow")
+            tubeNodes.append(tubeNode)
         }
 
         // Camera
@@ -650,7 +659,71 @@ private struct EarthGlobeView: NSViewRepresentable {
         cameraNode.position = SCNVector3(0, 0, 3.5)
         scene.rootNode.addChildNode(cameraNode)
 
-        // Rotation
+        // Keep node references so Reduce Motion can start/stop ambient motion.
+        context.coordinator.scene = scene
+        context.coordinator.earthNode = earthNode
+        context.coordinator.innerGlowNode = innerGlowNode
+        context.coordinator.glowNode = glowNode
+        context.coordinator.hubNodes = hubNodes
+        context.coordinator.tubeNodes = tubeNodes
+        context.coordinator.reduceMotion = reduceMotion
+
+        if !reduceMotion {
+            startAnimations(on: context.coordinator)
+        }
+
+        let container = GlobeContainerView()
+        container.tint = NSColor(color)
+        container.reduceMotion = reduceMotion
+        container.scene = scene
+        DispatchQueue.main.async { container.updatePlaybackIfVisible() }
+        return container
+    }
+
+    func updateNSView(_ nsView: GlobeContainerView, context: Context) {
+        nsView.tint = NSColor(color)
+        nsView.reduceMotion = reduceMotion
+        let coordinator = context.coordinator
+        guard coordinator.reduceMotion != reduceMotion else { return }
+        coordinator.reduceMotion = reduceMotion
+        if reduceMotion {
+            stopAnimations(on: coordinator)
+        } else {
+            startAnimations(on: coordinator)
+        }
+    }
+
+    class Coordinator {
+        var scene: SCNScene?
+        var earthNode: SCNNode?
+        var innerGlowNode: SCNNode?
+        var glowNode: SCNNode?
+        var hubNodes: [SCNNode] = []
+        var tubeNodes: [SCNNode] = []
+        var reduceMotion = false
+    }
+
+    // MARK: - Ambient Motion
+
+    private func startAnimations(on coordinator: Coordinator) {
+        guard let earthNode = coordinator.earthNode,
+              let innerGlowNode = coordinator.innerGlowNode,
+              let glowNode = coordinator.glowNode else { return }
+
+        for node in coordinator.hubNodes {
+            let pulse = CABasicAnimation(keyPath: "opacity")
+            pulse.fromValue = 0.3; pulse.toValue = 1.0; pulse.duration = 1.2
+            pulse.autoreverses = true; pulse.repeatCount = .greatestFiniteMagnitude
+            node.addAnimation(pulse, forKey: "pulse")
+        }
+
+        for tube in coordinator.tubeNodes {
+            let fade = CABasicAnimation(keyPath: "opacity")
+            fade.fromValue = 0.15; fade.toValue = 0.45; fade.duration = Double.random(in: 2...4)
+            fade.autoreverses = true; fade.repeatCount = .greatestFiniteMagnitude
+            tube.addAnimation(fade, forKey: "flow")
+        }
+
         let rotate = CABasicAnimation(keyPath: "rotation")
         rotate.fromValue = SCNVector4(0, 1, 0, 0)
         rotate.toValue = SCNVector4(0, 1, 0, Float.pi * 2)
@@ -659,19 +732,13 @@ private struct EarthGlobeView: NSViewRepresentable {
         earthNode.addAnimation(rotate, forKey: "rotate")
         innerGlowNode.addAnimation(rotate, forKey: "rotate")
         glowNode.addAnimation(rotate, forKey: "rotate")
-
-        context.coordinator.scene = scene
-
-        let container = GlobeContainerView()
-        container.tint = NSColor(color)
-        container.scene = scene
-        DispatchQueue.main.async { container.updatePlaybackIfVisible() }
-        return container
     }
 
-    func updateNSView(_ nsView: GlobeContainerView, context: Context) {
-        nsView.tint = NSColor(color)
+    private func stopAnimations(on coordinator: Coordinator) {
+        coordinator.hubNodes.forEach { $0.removeAnimation(forKey: "pulse") }
+        coordinator.tubeNodes.forEach { $0.removeAnimation(forKey: "flow") }
+        coordinator.earthNode?.removeAnimation(forKey: "rotate")
+        coordinator.innerGlowNode?.removeAnimation(forKey: "rotate")
+        coordinator.glowNode?.removeAnimation(forKey: "rotate")
     }
-
-    class Coordinator { var scene: SCNScene? }
 }

--- a/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
@@ -25,7 +25,7 @@ struct ProBadge: View {
                 )
         }
         .fixedSize()
-        .accessibilityLabel("Pro feature")
+        .accessibilityLabel(String(localized: "pro.accessibility.badge", comment: "Accessibility label for Pro badge"))
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/App/SettingsView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SettingsView.swift
@@ -62,7 +62,7 @@ struct SettingsView: View {
 
                 // MARK: - Appearance
                 Section {
-                    Picker(String(localized: "settings.appearance.theme_label", comment: "Theme picker label"), selection: $appearance.animation(reduceMotion ? nil : .bouncy)) {
+                    Picker(String(localized: "settings.appearance.theme_label", comment: "Theme picker label"), selection: $appearance.animation(reduceMotion ? nil : .snappy(duration: 0.2))) {
                         Text(String(localized: "common.label.system", comment: "Follow system setting option")).tag("system")
                         Text(String(localized: "common.label.light", comment: "Light appearance theme option")).tag("light")
                         Text(String(localized: "common.label.dark", comment: "Dark appearance theme option")).tag("dark")
@@ -78,7 +78,7 @@ struct SettingsView: View {
 
                 // MARK: - Scanner
                 Section(String(localized: "settings.scan.header", comment: "Scan interval settings section header")) {
-                    Picker(String(localized: "settings.scan.interval_label", comment: "Scan refresh interval picker label"), selection: $scanInterval.animation(reduceMotion ? nil : .bouncy)) {
+                    Picker(String(localized: "settings.scan.interval_label", comment: "Scan refresh interval picker label"), selection: $scanInterval.animation(reduceMotion ? nil : .snappy(duration: 0.2))) {
                         Text(String(localized: "settings.scan.interval_1s", comment: "1 second scan interval option")).tag(1)
                         Text(String(localized: "settings.scan.interval_2s", comment: "2 second scan interval option")).tag(2)
                         Text(String(localized: "settings.scan.interval_3s", comment: "3 second scan interval option")).tag(3)
@@ -96,7 +96,7 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    Picker(String(localized: "settings.region.header", comment: "Regulatory region picker label"), selection: $regionOverride.animation(reduceMotion ? nil : .bouncy)) {
+                    Picker(String(localized: "settings.region.header", comment: "Regulatory region picker label"), selection: $regionOverride.animation(reduceMotion ? nil : .snappy(duration: 0.2))) {
                         Text(String(localized: "settings.region.auto_detect", comment: "Auto-detect regulatory region option")).tag("auto")
                         Text(String(localized: "settings.region.us_fcc", comment: "US FCC regulatory region option")).tag("US")
                         Text(String(localized: "settings.region.jp_mic", comment: "Japan MIC regulatory region option")).tag("JP")

--- a/WiFiLens/Sources/WiFiLens/App/TitleBadge.swift
+++ b/WiFiLens/Sources/WiFiLens/App/TitleBadge.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct TitleBadge: View {
     let config: BuildConfig
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var shimmerOffset: CGFloat = 0
 
     var body: some View {
@@ -60,18 +62,22 @@ struct TitleBadge: View {
         }
         .shadow(color: goldColor.opacity(0.3), radius: 6, y: 2)
         .overlay {
-            Capsule()
-                .fill(
-                    LinearGradient(
-                        colors: [.clear, .white.opacity(0.4), .clear],
-                        startPoint: UnitPoint(x: shimmerOffset - 0.3, y: 0.5),
-                        endPoint: UnitPoint(x: shimmerOffset + 0.3, y: 0.5)
+            // One-shot entrance shimmer; hidden entirely under Reduce Motion.
+            if !reduceMotion {
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [.clear, .white.opacity(0.4), .clear],
+                            startPoint: UnitPoint(x: shimmerOffset - 0.3, y: 0.5),
+                            endPoint: UnitPoint(x: shimmerOffset + 0.3, y: 0.5)
+                        )
                     )
-                )
-                .mask(Capsule())
+                    .mask(Capsule())
+            }
         }
         .onAppear {
-            withAnimation(.linear(duration: 5).repeatForever(autoreverses: false)) {
+            guard !reduceMotion else { return }
+            withAnimation(.linear(duration: 5)) {
                 shimmerOffset = 1.5
             }
         }

--- a/WiFiLens/Sources/WiFiLens/BLE/BLEScannerView.swift
+++ b/WiFiLens/Sources/WiFiLens/BLE/BLEScannerView.swift
@@ -111,7 +111,7 @@ private struct BLEScannerContentView: View {
             .width(min: 60, ideal: 70)
 
             TableColumn(String(localized: "ble.table.col.smoothed", comment: "Smoothed RSSI column header")) { device in
-                Text(String(format: "%.0f dBm", device.smoothedRSSI))
+                Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), Int(device.smoothedRSSI.rounded())))
                     .font(.caption.monospaced())
                     .foregroundColor(.secondary)
             }
@@ -173,7 +173,7 @@ private struct BLEScannerContentView: View {
             HStack(spacing: 16) {
                 if let first = history.first {
                     LabeledContent(String(localized: "common.label.first", comment: "First data point label")) {
-                        Text("\(first.rawRSSI) dBm")
+                        Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), first.rawRSSI))
                             .font(.caption.monospaced())
                     }
                     .font(.caption2)
@@ -181,7 +181,7 @@ private struct BLEScannerContentView: View {
                 }
                 if let last = history.last {
                     LabeledContent(String(localized: "common.label.latest", comment: "Latest/most recent data point label")) {
-                        Text("\(last.rawRSSI) dBm")
+                        Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), last.rawRSSI))
                             .font(.caption.monospaced())
                     }
                     .font(.caption2)
@@ -195,7 +195,7 @@ private struct BLEScannerContentView: View {
                     .font(.caption2)
                     .foregroundColor(.secondary)
                     LabeledContent(String(localized: "ble.trend.ema", comment: "EMA (Exponential Moving Average) abbreviation")) {
-                        Text(String(format: "%.0f dBm", device.smoothedRSSI))
+                        Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), Int(device.smoothedRSSI.rounded())))
                             .font(.caption.monospaced().bold())
                     }
                     .font(.caption2)

--- a/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
+++ b/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityView.swift
@@ -252,7 +252,7 @@ private struct ChannelCard: View {
                     }
                 }
                 .frame(height: 6)
-                Text("\(channel.rfScore)/100")
+                Text(String(format: String(localized: "format.score_fraction", comment: "Score value out of 100"), channel.rfScore))
                     .font(.caption.monospacedDigit())
                     .foregroundColor(.secondary)
             }
@@ -268,7 +268,7 @@ private struct ChannelCard: View {
                 }
                 HStack(spacing: 4) {
                     Image(systemName: "wave.3.right").font(.caption2).foregroundColor(.secondary)
-                    Text("\(channel.strongestNeighborRSSI) dBm").font(.caption).foregroundColor(.secondary)
+                    Text(String(format: String(localized: "format.rssi_dbm", comment: "RSSI value with dBm unit"), channel.strongestNeighborRSSI)).font(.caption).foregroundColor(.secondary)
                 }
                 HStack(spacing: 4) {
                     Text(channel.overlapLevel.displayName)

--- a/WiFiLens/Sources/WiFiLens/Guidance/ExportSuccessBanner.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/ExportSuccessBanner.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct ExportSuccessBanner: View {
     let guidance: GuidanceCoordinator
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var renderedInvitationID: UUID?
 
     var body: some View {
@@ -46,6 +48,8 @@ struct ExportSuccessBanner: View {
             )
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.25), value: guidance.exportFeedback != nil)
             .onDisappear {
                 if let id = renderedInvitationID {
                     renderedInvitationID = nil

--- a/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
+++ b/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
@@ -338,7 +338,7 @@ struct InterfacesView: View {
 
     private var monitorChartHeader: some View {
         Button {
-            withAnimation(reduceMotion ? nil : .default) { isMonitorChartCollapsed.toggle() }
+            withAnimation(reduceMotion ? nil : .snappy(duration: 0.22)) { isMonitorChartCollapsed.toggle() }
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: isMonitorChartCollapsed ? "chevron.right" : "chevron.down")
@@ -362,7 +362,7 @@ struct InterfacesView: View {
 
     private var monitorTableHeader: some View {
         Button {
-            withAnimation(reduceMotion ? nil : .default) { isMonitorTableCollapsed.toggle() }
+            withAnimation(reduceMotion ? nil : .snappy(duration: 0.22)) { isMonitorTableCollapsed.toggle() }
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: isMonitorTableCollapsed ? "chevron.right" : "chevron.down")

--- a/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
+++ b/WiFiLens/Sources/WiFiLens/Interfaces/InterfacesView.swift
@@ -175,7 +175,7 @@ struct InterfacesView: View {
             indicatorPill(
                 title: String(localized: "interfaces.field.stability", comment: "Connection stability field label"),
                 value: stab.label,
-                subtitle: "\(stab.score)/100",
+                subtitle: String(format: String(localized: "format.score_fraction", comment: "Score value out of 100"), stab.score),
                 color: stab.color,
                 bar: scoreBar(stab.score, color: stab.color)
             )
@@ -373,7 +373,7 @@ struct InterfacesView: View {
                 Text(String(localized: "nav.interfaces", comment: "Interfaces sidebar navigation item"))
                     .font(.callout.weight(.semibold))
                 Spacer()
-                Text("\(monitorInterfaces.count) \(String(localized: "interfaces.label.interfaces", comment: "Interfaces plural unit"))")
+                Text(String(format: String(localized: "interfaces.count_format", comment: "Interface count with number"), monitorInterfaces.count))
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DNSResolutionCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DNSResolutionCheck.swift
@@ -116,7 +116,7 @@ private final class DNSResolutionContext: @unchecked Sendable {
 }
 
 struct DNSResolutionCheck: DiagnosticCheck {
-    // Temporary third-party probe targets pending product-controlled DNS names.
+    // Authoritative third-party DNS probe targets (no self-hosted endpoints).
     private static let defaultProbeTargets = [
         "www.apple.com",
         "www.microsoft.com",

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/HTTPSControlEndpointCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/HTTPSControlEndpointCheck.swift
@@ -254,7 +254,7 @@ struct HTTPSControlEndpointCheck: DiagnosticCheck {
                 evidence: .init(code: "captive-portal.http-status", value: String(status))
             )
         }
-        guard response.body?.contains(expectedCaptivePortalBody) == true else {
+        guard response.body?.localizedCaseInsensitiveContains(expectedCaptivePortalBody) == true else {
             return EndpointEvaluation(
                 succeeded: false,
                 evidence: .init(code: "captive-portal.suspected", value: nil)

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/HTTPSControlEndpointCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/HTTPSControlEndpointCheck.swift
@@ -108,8 +108,11 @@ struct HTTPSControlEndpointCheck: DiagnosticCheck {
 
     let id = NetworkDiagnosticCheckID.internet
     let httpsEndpoint = Self.stableHTTPSEndpoint
-    let captivePortalEndpoint = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-    let expectedCaptivePortalBody = "Microsoft Connect Test"
+    // Authoritative captive-portal probe (Apple). HTTPS keeps the control
+    // check free of the ATS exception still required by the HTTP-only
+    // Microsoft NCSI target used in SystemProxyCheck.
+    let captivePortalEndpoint = URL(string: "https://captive.apple.com/hotspot-detect.html")!
+    let expectedCaptivePortalBody = "Success"
 
     private let loader: any ControlEndpointLoading
     private let timeout: Duration
@@ -251,7 +254,7 @@ struct HTTPSControlEndpointCheck: DiagnosticCheck {
                 evidence: .init(code: "captive-portal.http-status", value: String(status))
             )
         }
-        guard response.body == expectedCaptivePortalBody else {
+        guard response.body?.contains(expectedCaptivePortalBody) == true else {
             return EndpointEvaluation(
                 succeeded: false,
                 evidence: .init(code: "captive-portal.suspected", value: nil)

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
@@ -410,6 +410,10 @@ struct ContinuousProxyCheckClock: ProxyCheckClock {
 
 struct SystemProxyCheck: DiagnosticCheck {
     let id = NetworkDiagnosticCheckID.proxy
+    // Authoritative Microsoft NCSI endpoint. Kept as plain HTTP on purpose:
+    // the proxy check exercises the same unencrypted request a captive
+    // portal would intercept. Covered by the scoped ATS exception for
+    // www.msftconnecttest.com only; no personal data is transmitted.
     private static let defaultHTTPTarget = URL(
         string: "http://www.msftconnecttest.com/connecttest.txt"
     )!

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -8379,25 +8379,31 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
+            "value": "·  %1$@  ·  Ch %2$lld"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
+            "value": "·  %1$@  ·  Ch %2$lld"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
+            "value": "·  %1$@  ·  Ch %2$lld"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "·  %1$@  ·  Ch %2$@"
+            "value": "·  %1$@  ·  Ch %2$lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·  %1$@  ·  Ch %2$lld"
           }
         }
       },
@@ -8410,25 +8416,31 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
+            "value": "CH %1$lld  %2$lld dBm"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
+            "value": "CH %1$lld  %2$lld dBm"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
+            "value": "CH %1$lld  %2$lld dBm"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "CH %1$@  %2$@ dBm"
+            "value": "CH %1$lld  %2$lld dBm"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CH %1$lld  %2$lld dBm"
           }
         }
       },
@@ -8718,31 +8730,31 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ dBm"
+            "value": "%lld dBm"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ dBm"
+            "value": "%lld dBm"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ dBm"
+            "value": "%lld dBm"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ dBm"
+            "value": "%lld dBm"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ dBm"
+            "value": "%lld dBm"
           }
         }
       },
@@ -33164,6 +33176,217 @@
           "stringUnit": {
             "state": "translated",
             "value": "分析趋势与洞察"
+          }
+        }
+      }
+    },
+    "format.score_fraction": {
+      "shouldTranslate": false,
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/100"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/100"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/100"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/100"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/100"
+          }
+        }
+      }
+    },
+    "interfaces.count_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld interfaces"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Schnittstellen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld interfaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個のインターフェース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个接口"
+          }
+        }
+      }
+    },
+    "common.samples_count_fmt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld samples"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Proben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld muestras"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld サンプル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个样本"
+          }
+        }
+      }
+    },
+    "spectrum.accessibility.chart_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi spectrum chart"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi-Spektrumdiagramm"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gráfico del espectro Wi-Fi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi スペクトルチャート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi 频谱图"
+          }
+        }
+      }
+    },
+    "spectrum.accessibility.heatmap_label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel occupancy heatmap"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanalbelegungs-Heatmap"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de calor de ocupación de canales"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チャンネル占有率のヒートマップ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信道占用热力图"
+          }
+        }
+      }
+    },
+    "pro.accessibility.badge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro feature"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro-Funktion"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Función Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro機能"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro 功能"
           }
         }
       }

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -29120,6 +29120,41 @@
         }
       }
     },
+    "analysis.statistics.severity_none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No severity data available"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Schweregrad-Daten verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay datos de gravedad disponibles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要度データがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无严重度数据"
+          }
+        }
+      }
+    },
     "analysis.statistics.severity_warning": {
       "extractionState": "manual",
       "localizations": {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/BandChartView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/BandChartView.swift
@@ -136,7 +136,7 @@ struct WiFiBandChart: View {
                         heatmapOverlay(geo: chartGeo)
                         dataLabelOverlay(geo: chartGeo)
                     }
-                    .accessibilityLabel("WiFi spectrum chart")
+                    .accessibilityLabel(String(localized: "spectrum.accessibility.chart_label", comment: "Spectrum chart accessibility label"))
                     .onContinuousHover(coordinateSpace: .local) { phase in
                         switch phase {
                         case .active(let location):
@@ -180,7 +180,7 @@ struct WiFiBandChart: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Channel occupancy heatmap")
+        .accessibilityLabel(String(localized: "spectrum.accessibility.heatmap_label", comment: "Channel occupancy heatmap accessibility label"))
     }
 
     private func dataLabelOverlay(geo: ChartGeometry) -> some View {
@@ -271,7 +271,7 @@ struct WiFiBandChart: View {
                         heatmapOverlay(geo: chartGeo)
                         dataLabelOverlay(geo: chartGeo)
                     }
-                    .accessibilityLabel("WiFi spectrum chart")
+                    .accessibilityLabel(String(localized: "spectrum.accessibility.chart_label", comment: "Spectrum chart accessibility label"))
                     .onContinuousHover(coordinateSpace: .local) { phase in
                         switch phase {
                         case .active(let location):
@@ -314,7 +314,7 @@ private struct ChartTooltip: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(ssid).font(.caption.weight(.semibold)).foregroundColor(.primary)
-            Text("CH \(channel)  \(rssi) dBm").font(.caption2).foregroundColor(.secondary)
+            Text(String(format: String(localized: "format.channel_rssi", comment: "Channel and RSSI values"), channel, rssi)).font(.caption2).foregroundColor(.secondary)
             Text(bssid).font(.caption2).foregroundColor(.secondary)
         }
         .padding(.horizontal, 6).padding(.vertical, 4)

--- a/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
+++ b/WiFiLens/Sources/WiFiLens/WiFiLensApp.swift
@@ -249,6 +249,7 @@ private struct AppRootView: View {
     #endif
     #endif
                 }
+                .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: selectedPage)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .overlay(alignment: .bottom) {
                     // OSS `.banner` export strategy only: renders while the

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -782,7 +782,7 @@ struct NetworkDiagnosticsTests {
         #expect(!result.evidence.contains { $0.code.hasPrefix("gateway.") })
     }
 
-    @Test("Microsoft captive-portal probe rejects a rewritten response")
+    @Test("captive-portal probe rejects a rewritten response")
     func captivePortalProbeRejectsRewrittenResponse() async {
         let check = HTTPSControlEndpointCheck(
             loader: StubControlLoader(
@@ -798,13 +798,13 @@ struct NetworkDiagnosticsTests {
         #expect(result.evidence.contains(.init(code: "captive-portal.suspected", value: nil)))
     }
 
-    @Test("control endpoint success verifies HTTPS and the documented Microsoft body")
+    @Test("control endpoint success verifies HTTPS and Apple's captive-portal Success body")
     func controlEndpointSuccess() async {
         let check = HTTPSControlEndpointCheck(
             loader: StubControlLoader(
                 httpsStatus: 200,
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         )
 
@@ -847,7 +847,7 @@ struct NetworkDiagnosticsTests {
         #expect(!result.evidence.contains { $0.value == "192.0.2.10:443" })
     }
 
-    @Test("Apple HTTPS success and Microsoft HTTP timeout is indeterminate")
+    @Test("control endpoint success and captive-portal timeout is indeterminate")
     func controlEndpointMicrosoftTimeoutIsIndeterminate() async {
         let result = await HTTPSControlEndpointCheck(
             loader: StubControlLoader(
@@ -866,7 +866,7 @@ struct NetworkDiagnosticsTests {
         )))
     }
 
-    @Test("Apple HTTPS success and Microsoft HTTP timeout needs attention")
+    @Test("control endpoint success and captive-portal timeout needs attention")
     func controlEndpointMicrosoftTimeoutConclusion() async {
         let internet = await HTTPSControlEndpointCheck(
             loader: StubControlLoader(
@@ -897,7 +897,7 @@ struct NetworkDiagnosticsTests {
                 httpsStatus: nil,
                 httpsErrorCode: String(URLError.secureConnectionFailed.rawValue),
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         ).run()
         let certificateTimeFailure = await HTTPSControlEndpointCheck(
@@ -905,7 +905,7 @@ struct NetworkDiagnosticsTests {
                 httpsStatus: nil,
                 httpsErrorCode: String(URLError.serverCertificateNotYetValid.rawValue),
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         ).run()
         let certificateValidationFailure = await HTTPSControlEndpointCheck(
@@ -913,7 +913,7 @@ struct NetworkDiagnosticsTests {
                 httpsStatus: nil,
                 httpsErrorCode: String(URLError.serverCertificateUntrusted.rawValue),
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         ).run()
         let connectivityFailure = await HTTPSControlEndpointCheck(
@@ -921,14 +921,14 @@ struct NetworkDiagnosticsTests {
                 httpsStatus: nil,
                 httpsErrorCode: String(URLError.timedOut.rawValue),
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         ).run()
         let httpsStatusFailure = await HTTPSControlEndpointCheck(
             loader: StubControlLoader(
                 httpsStatus: 503,
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test"
+                httpBody: "Success"
             )
         ).run()
         let captivePortalRedirect = await HTTPSControlEndpointCheck(
@@ -1001,7 +1001,7 @@ struct NetworkDiagnosticsTests {
             loader: StubControlLoader(
                 httpsStatus: 200,
                 httpStatus: 200,
-                httpBody: "Microsoft Connect Test",
+                httpBody: "Success",
                 recorder: recorder
             )
         )
@@ -1010,7 +1010,7 @@ struct NetworkDiagnosticsTests {
 
         #expect(Set(await recorder.urls) == Set([
             "https://www.apple.com/",
-            "http://www.msftconnecttest.com/connecttest.txt",
+            "https://captive.apple.com/hotspot-detect.html",
         ]))
         #expect(await recorder.timeouts == [.seconds(5), .seconds(5)])
     }
@@ -1034,7 +1034,7 @@ struct NetworkDiagnosticsTests {
         #expect(configuration.proxyConfigurations.isEmpty)
     }
 
-    @Test("app permits temporary HTTP only for the Microsoft captive-portal endpoint")
+    @Test("app scopes the ATS HTTP exception to the Microsoft captive-portal/proxy endpoint")
     func temporaryCaptivePortalATSException() {
         let ats = Bundle.main.object(forInfoDictionaryKey: "NSAppTransportSecurity") as? [String: Any]
         let domains = ats?["NSExceptionDomains"] as? [String: Any]
@@ -1064,7 +1064,7 @@ struct NetworkDiagnosticsTests {
         #expect(result.evidence.contains(.init(code: "dns.indeterminate-count", value: "0/3")))
     }
 
-    @Test("DNS uses the three temporary third-party probe targets")
+    @Test("DNS uses the three authoritative third-party probe targets")
     func dnsProbeTargets() {
         let check = DNSResolutionCheck(resolver: StubDNSResolver(.resolved))
 
@@ -2943,10 +2943,10 @@ private actor ConcurrentControlLoader: ControlEndpointLoading {
         maximumInFlight = max(maximumInFlight, inFlight)
         try? await Task.sleep(for: .milliseconds(20))
         inFlight -= 1
-        if url.scheme == "https" {
-            return .init(status: 200, body: nil, errorCode: nil)
+        if url.host == "captive.apple.com" {
+            return .init(status: 200, body: "Success", errorCode: nil)
         }
-        return .init(status: 200, body: "Microsoft Connect Test", errorCode: nil)
+        return .init(status: 200, body: nil, errorCode: nil)
     }
 }
 
@@ -2954,10 +2954,10 @@ private struct MetricsControlLoader: ControlEndpointLoading {
     let metrics: ControlEndpointMetrics
 
     func load(url: URL, timeout: Duration) async -> ControlEndpointLoadResult {
-        if url.scheme == "https" {
-            return .init(status: 200, body: nil, errorCode: nil, metrics: metrics)
+        if url.host == "captive.apple.com" {
+            return .init(status: 200, body: "Success", errorCode: nil)
         }
-        return .init(status: 200, body: "Microsoft Connect Test", errorCode: nil)
+        return .init(status: 200, body: nil, errorCode: nil, metrics: metrics)
     }
 }
 
@@ -3048,10 +3048,10 @@ private struct StubControlLoader: ControlEndpointLoading {
 
     func load(url: URL, timeout: Duration) async -> ControlEndpointLoadResult {
         await recorder?.record(url: url, timeout: timeout)
-        if url.scheme == "https" {
-            return .init(status: httpsStatus, body: nil, errorCode: httpsErrorCode)
+        if url.host == "captive.apple.com" {
+            return .init(status: httpStatus, body: httpBody, errorCode: httpErrorCode)
         }
-        return .init(status: httpStatus, body: httpBody, errorCode: httpErrorCode)
+        return .init(status: httpsStatus, body: nil, errorCode: httpsErrorCode)
     }
 }
 

--- a/WiFiLens/WiFiLens-Info.plist
+++ b/WiFiLens/WiFiLens-Info.plist
@@ -8,7 +8,7 @@
 	<string>https://github.com/SHIINASAMA/wifi-lens/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>DUcvL7RzZrjRBNr+lIn15cbk0Uvm4SboSpvlz9H2z5g=</string>
-	<!-- TEMPORARY TEST configuration for the Microsoft HTTP captive-portal probe; remove when replaced by an owned HTTPS endpoint. -->
+	<!-- Scoped ATS exception: Network Self-Check uses Microsoft's authoritative NCSI endpoint (HTTP-only) for captive-portal/proxy detection; no personal data is transmitted. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/WiFiLens/WiFiLens-Info.plist
+++ b/WiFiLens/WiFiLens-Info.plist
@@ -8,7 +8,7 @@
 	<string>https://github.com/SHIINASAMA/wifi-lens/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>DUcvL7RzZrjRBNr+lIn15cbk0Uvm4SboSpvlz9H2z5g=</string>
-	<!-- Scoped ATS exception: Network Self-Check uses Microsoft's authoritative NCSI endpoint (HTTP-only) for captive-portal/proxy detection; no personal data is transmitted. -->
+	<!-- Scoped ATS exception: Network Self-Check uses Microsoft's authoritative NCSI endpoint (HTTP-only) for captive-portal/proxy detection. WiFi Lens does not intentionally transmit user data; the endpoint is used only for connectivity verification. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,7 +11,7 @@
 
 - [ ] UI / integration tests
 - [ ] Add a small verification matrix for UI regressions across light/dark mode, localization, and no-permission / no-data states
-- [ ] Before the next Mac App Store submission, update `NSLocalNetworkUsageDescription` for both OSS and Pro targets to disclose that Network Self-Check may connect to a configured local proxy, in addition to the existing MCP server use case
+- [x] Before the next Mac App Store submission, update `NSLocalNetworkUsageDescription` for both OSS and Pro targets to disclose that Network Self-Check may connect to a configured local proxy, in addition to the existing MCP server use case (done: both targets already disclose MCP server + Network Self-Check proxy use)
 
 ## Out of Scope (for now)
 


### PR DESCRIPTION
## Summary

This branch bundles three review-approved workstreams for the OSS edition.

### 1. Apple-style UI polish (`88c7705`)
- Overview 3D Earth globe with SceneKit ambient motion, wired to **Reduce Motion** (render loop stops when enabled, restarts on disable).
- Title badge, settings pickers, interfaces/BLE/channel views and export success banner now respect `accessibilityReduceMotion`.
- `startAnimations` defensively removes existing animation keys before adding, so state transitions can never stack duplicate `CAAnimation` instances.

### 2. Localization completion (`d17a3a6`)
- Localized remaining hardcoded strings and converted format strings to typed `%lld` placeholders (`format.rssi_dbm`, `format.score_fraction`, `format.channel_rssi`, `interfaces.count_format`, `format.band_channel_separator`, `roaming.accessibility.rssi_fmt`). All call sites pass `Int` values, so no runtime format warnings.
- Added `analysis.statistics.severity_none` ("No severity data available") used by the Pro Statistics severity panel empty state.

### 3. Network Self-Check compliance (`b6b340a`)
- Captive-portal probe now uses Apple's authoritative HTTPS endpoint `https://captive.apple.com/hotspot-detect.html` (expects `Success`); body matching is case-insensitive.
- `SystemProxyCheck` keeps Microsoft's authoritative NCSI endpoint (`http://www.msftconnecttest.com/connecttest.txt`) — the proxy check intentionally exercises an unencrypted request; scoped ATS exception documented.
- Replaced `TEMPORARY TEST` ATS exception comments in both targets' Info.plists with precise wording: WiFi Lens does not intentionally transmit user data; the endpoint is used only for connectivity verification.
- `docs/TODO.md`: Network Self-Check local-proxy disclosure item marked done.
- Updated `NetworkDiagnosticsTests` for the new endpoint/body.

## Verification
- `verify.sh`: OSS + Pro Debug builds pass; WiFiLensTests 982/982 passed.
- `WiFiLensProTests` (unit bundle only): all passed.
