### PR TITLE
fix: model 5/6 GHz wide-channel interference with real spans (NH-14)

### DIFF
--- a/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityCalculator.swift
+++ b/WiFiLens/Sources/WiFiLens/Channels/ChannelQualityCalculator.swift
@@ -176,16 +176,14 @@ enum ChannelQualityCalculator {
         let rssi: Int
         let channelWidth: String  // "20"/"40"/"80"/"160"
         let band: String          // "24"/"5"/"6"
-        let apex: Double          // span midpoint
         let bssid: String?
         let ssid: String?
 
-        init(channel: Int, rssi: Int, channelWidth: String, band: String, apex: Double, bssid: String? = nil, ssid: String? = nil) {
+        init(channel: Int, rssi: Int, channelWidth: String, band: String, bssid: String? = nil, ssid: String? = nil) {
             self.channel = channel
             self.rssi = rssi
             self.channelWidth = channelWidth
             self.band = band
-            self.apex = apex
             self.bssid = bssid?.nilIfBlank
             self.ssid = ssid?.nilIfBlank
         }
@@ -404,6 +402,8 @@ enum ChannelQualityCalculator {
         if other.channel == channel { return 1.0 }
 
         if band == "24" {
+            // 2.4 GHz channels are 5 MHz apart, so adjacent channels overlap in
+            // practice; keep the empirical distance heuristic.
             let dist = abs(channel - other.channel)
             return switch dist {
             case 1: 0.8
@@ -414,14 +414,25 @@ enum ChannelQualityCalculator {
             }
         }
 
-        // 5 / 6 GHz: only wide channels cause adjacency interference
-        let dist = abs(channel - other.channel)
-        let width = Int(other.channelWidth) ?? 20
-        let halfSpan = width / 20 / 2  // how many 5MHz steps
-        if dist == 0 { return 1.0 }
-        if dist <= halfSpan { return 0.4 }
-        if dist <= halfSpan + 1 { return 0.15 }
-        return 0
+        // 5 / 6 GHz: 20 MHz channels sit on standard blocks, so non-overlapping
+        // primary channels do not interfere. Compute the real frequency-band
+        // overlap between the 20 MHz candidate channel and the AP's block, and
+        // normalize by the AP span length: a wide AP contributes at most
+        // 1.0/0.5/0.25/0.125 (20/40/80/160 MHz) to one non-co-channel 20 MHz
+        // candidate (the primary channel carries beacons/control; secondary
+        // channels carry data only). widthMul in computeInterference partially
+        // compensates wider APs.
+        guard let channelBand = ChannelBand(id: band) else { return 0 }
+        let apWidth = Int(other.channelWidth) ?? 20
+        let candidateSpan = ChannelSpanCalculator.channelBlock(
+            primaryChannel: channel, widthMHz: 20, band: channelBand, spanDirection: nil
+        )
+        let apSpan = ChannelSpanCalculator.channelBlock(
+            primaryChannel: other.channel, widthMHz: apWidth, band: channelBand, spanDirection: nil
+        )
+        let overlap = max(0, min(apSpan.right, candidateSpan.right) - max(apSpan.left, candidateSpan.left))
+        let apSpanLength = max(1, apSpan.right - apSpan.left)
+        return min(1.0, Double(overlap) / Double(apSpanLength))
     }
 
     private static func overlaps(channel: Int, other: APInfo, band: String) -> Bool {

--- a/WiFiLens/Sources/WiFiLens/Observation/Analyzers/ChannelOccupancyAnalyzer.swift
+++ b/WiFiLens/Sources/WiFiLens/Observation/Analyzers/ChannelOccupancyAnalyzer.swift
@@ -11,7 +11,10 @@ enum ChannelOccupancyAnalyzer {
         var seen = [String: ChannelQualityCalculator.APInfo]()
         for obs in snapshot.networks {
             let key = "\(obs.bssid)-\(obs.channel.band.rawValue)"
-            let widthLabel = channelWidthLabel(obs.capabilities.channelWidth)
+            // Use the operating width (CWChannel), not the IE capability width:
+            // capabilities.channelWidth reflects what the AP supports (160/80/40
+            // capability flags), which may exceed the width it is currently using.
+            let widthLabel = channelWidthLabel(obs.channel.channelWidthMHz)
             let info = ChannelQualityCalculator.APInfo(
                 channel: obs.channel.channelNumber,
                 rssi: obs.rssi,

--- a/WiFiLens/Sources/WiFiLens/Observation/Analyzers/ChannelOccupancyAnalyzer.swift
+++ b/WiFiLens/Sources/WiFiLens/Observation/Analyzers/ChannelOccupancyAnalyzer.swift
@@ -12,18 +12,11 @@ enum ChannelOccupancyAnalyzer {
         for obs in snapshot.networks {
             let key = "\(obs.bssid)-\(obs.channel.band.rawValue)"
             let widthLabel = channelWidthLabel(obs.capabilities.channelWidth)
-            let span = ChannelSpanCalculator.channelBlock(
-                primaryChannel: obs.channel.channelNumber,
-                widthMHz: obs.channel.channelWidthMHz,
-                band: obs.channel.band,
-                spanDirection: obs.channel.spanDirection
-            )
             let info = ChannelQualityCalculator.APInfo(
                 channel: obs.channel.channelNumber,
                 rssi: obs.rssi,
                 channelWidth: widthLabel,
                 band: obs.channel.band.id,
-                apex: Double(span.left + span.right) / 2.0,
                 bssid: obs.bssid,
                 ssid: obs.ssid
             )

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ChannelSpanCalculator.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ChannelSpanCalculator.swift
@@ -82,17 +82,19 @@ enum ChannelSpanCalculator {
         }
 
         if band == .band6GHz {
-            // IEEE 802.11ax 6 GHz channelization: a 40/80/160 MHz block is
-            // anchored at its lowest 20 MHz primary channel and extends upward
-            // (2/4/8 x 20 MHz channels), unlike the 5 GHz table which handles
-            // primary channels anywhere within a block.
-            if widthMHz == 40 {
-                return (primaryChannel - 2, primaryChannel + 6)
-            } else if widthMHz == 80 {
-                return (primaryChannel - 2, primaryChannel + 14)
-            } else if widthMHz == 160 {
-                return (primaryChannel - 2, primaryChannel + 30)
-            }
+            // IEEE 802.11ax 6 GHz channelization: the scanned/control primary
+            // can be any 20 MHz primary inside a 40/80/160 MHz block (e.g. all
+            // of 33/37/41/45 live in the same 80 MHz block). Derive the
+            // containing block from the primary index instead of extending
+            // upward from the primary channel.
+            let channelsPerBlock = widthMHz / 20
+            let primaryIndex = (primaryChannel - 1) / 4
+            let blockStartIndex = (primaryIndex / channelsPerBlock) * channelsPerBlock
+            let lowestPrimary = 1 + blockStartIndex * 4
+            return (
+                lowestPrimary - 2,
+                lowestPrimary + channelsPerBlock * 4 - 2
+            )
         }
 
         // Fallback for any unmatched cases

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ChannelSpanCalculator.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ChannelSpanCalculator.swift
@@ -81,7 +81,21 @@ enum ChannelSpanCalculator {
             }
         }
 
-        // Fallback for 6 GHz and any unmatched cases
+        if band == .band6GHz {
+            // IEEE 802.11ax 6 GHz channelization: a 40/80/160 MHz block is
+            // anchored at its lowest 20 MHz primary channel and extends upward
+            // (2/4/8 x 20 MHz channels), unlike the 5 GHz table which handles
+            // primary channels anywhere within a block.
+            if widthMHz == 40 {
+                return (primaryChannel - 2, primaryChannel + 6)
+            } else if widthMHz == 80 {
+                return (primaryChannel - 2, primaryChannel + 14)
+            } else if widthMHz == 160 {
+                return (primaryChannel - 2, primaryChannel + 30)
+            }
+        }
+
+        // Fallback for any unmatched cases
         let half = channelHalfSpan(for: widthMHz)
         return (primaryChannel - half, primaryChannel + half)
     }

--- a/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
@@ -5,6 +5,7 @@ struct ChannelQualityCalculatorTests {
 
     private enum TestChannelWidth: String {
         case mhz20 = "20"
+        case mhz40 = "40"
         case mhz80 = "80"
         case mhz160 = "160"
     }
@@ -14,7 +15,6 @@ struct ChannelQualityCalculatorTests {
         _ rssi: Int,
         width: TestChannelWidth = .mhz20,
         band: ChannelBand = .band5GHz,
-        apex: Double = 0,
         bssid: String? = nil,
         ssid: String? = nil
     ) -> ChannelQualityCalculator.APInfo {
@@ -23,7 +23,6 @@ struct ChannelQualityCalculatorTests {
             rssi: rssi,
             channelWidth: width.rawValue,
             band: band.id,
-            apex: apex,
             bssid: bssid,
             ssid: ssid
         )
@@ -124,12 +123,10 @@ struct ChannelQualityCalculatorTests {
         let ch44 = result.first(where: { $0.channel == 44 })!
         #expect(ch44.qualityScore < 100)
 
-        // ch 40 (dist 4): beyond halfSpan+1=3 → overlap=0, no penalty
-        // 80 MHz spans channels 42-46 (left=42, right=46), but halfSpan in 5MHz steps = 2
-        // Actually, ch 40 is 4 channels away from 44, halfSpan=2, halfSpan+1=3
-        // dist=4 > 3 → overlap=0
+        // ch 40: the 80 MHz AP on ch 44 really spans (34,50); the 20 MHz
+        // candidate ch 40 (38,42) overlaps 4/16 → factor 0.25 → penalty ≈5
         let ch40 = result.first(where: { $0.channel == 40 })!
-        #expect(ch40.qualityScore == 100)
+        #expect(ch40.qualityScore == 95)
     }
 
     // MARK: - Quality level thresholds
@@ -186,7 +183,8 @@ struct ChannelQualityCalculatorTests {
         let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
         let ch44 = result.first(where: { $0.channel == 44 })!
         #expect(ch44.coChannelCount == 2)
-        #expect(ch44.apCount >= 2)  // total overlapping
+        #expect(ch44.apCount == 3)  // 2 co-channel + the 80 MHz AP on ch 40 (real span overlaps)
+        #expect(ch44.adjacentCount == 1)
     }
 
     // MARK: - Current channel
@@ -239,7 +237,6 @@ struct ChannelQualityCalculatorTests {
                     rssi: -30,
                     channelWidth: "20",
                     band: "5",
-                    apex: 36,
                     bssid: "aa:bb:cc:dd:ee:01",
                     ssid: "Home"
                 )
@@ -267,7 +264,6 @@ struct ChannelQualityCalculatorTests {
                     rssi: -30,
                     channelWidth: "20",
                     band: "5",
-                    apex: 36,
                     bssid: "aa:bb:cc:dd:ee:01",
                     ssid: "Home"
                 ),
@@ -276,7 +272,6 @@ struct ChannelQualityCalculatorTests {
                     rssi: -30,
                     channelWidth: "20",
                     band: "5",
-                    apex: 36,
                     bssid: "aa:bb:cc:dd:ee:02",
                     ssid: "Neighbor"
                 )
@@ -448,5 +443,89 @@ struct ChannelQualityCalculatorTests {
         // Non-overlapping channel gets default -100
         let ch40 = result.first(where: { $0.channel == 40 })!
         #expect(ch40.strongestNeighborRSSI == -100)
+    }
+
+    // MARK: - NH-14: real wide-channel overlap (5/6 GHz)
+
+    @Test func overlap5GHz40MHzDirectional() async throws {
+        // 40 MHz AP on ch 44 spans (42,50): ch 48 overlaps (4/8 = 0.5), ch 40 does not.
+        let aps = [ap(44, -50, width: .mhz40, band: .band5GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch48 = result.first(where: { $0.channel == 48 })!
+        let ch40 = result.first(where: { $0.channel == 40 })!
+        #expect(ch48.qualityScore == 92)  // 0.5 * 0.714 * 1.2 * 18 ≈ 7.7 → 8
+        #expect(ch40.qualityScore == 100) // block is offset upward, no overlap
+    }
+
+    @Test func overlap5GHz160MHzAdjacent() async throws {
+        // 160 MHz AP on ch 36 spans (34,66): ch 40/44/48 each overlap 4/32 = 0.125.
+        let aps = [ap(36, -50, width: .mhz160, band: .band5GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        for ch in [40, 44, 48] {
+            let c = result.first(where: { $0.channel == ch })!
+            #expect(c.qualityScore == 97) // 0.125 * 0.714 * 2.0 * 18 ≈ 3.2 → 3
+        }
+    }
+
+    @Test func overlap5GHz80MHzBlockSeam() async throws {
+        // 80 MHz AP on ch 48 spans (34,50); ch 52 is a half-open seam (no overlap),
+        // ch 44 overlaps 4/16 = 0.25.
+        let aps = [ap(48, -50, width: .mhz80, band: .band5GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch52 = result.first(where: { $0.channel == 52 })!
+        let ch44 = result.first(where: { $0.channel == 44 })!
+        #expect(ch52.qualityScore == 100)
+        #expect(ch44.qualityScore == 95)
+    }
+
+    @Test func overlap6GHzWideFallback() async throws {
+        // 6 GHz uses the symmetric fallback: 80 MHz on ch 33 spans (25,41).
+        let aps = [ap(33, -50, width: .mhz80, band: .band6GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch29 = result.first(where: { $0.channel == 29 && $0.band == "6" })!
+        let ch41 = result.first(where: { $0.channel == 41 && $0.band == "6" })!
+        let ch25 = result.first(where: { $0.channel == 25 && $0.band == "6" })!
+        #expect(ch29.qualityScore == 95)  // 4/16 = 0.25
+        #expect(ch41.qualityScore == 98)  // 2/16 = 0.125 (8 steps out)
+        #expect(ch25.qualityScore == 98)  // 2/16 = 0.125
+    }
+
+    @Test func overlap6GHzEdgeChannel() async throws {
+        // 80 MHz on ch 5 spans (-3,13); ch 1 still overlaps 4/16 = 0.25.
+        let aps = [ap(5, -50, width: .mhz80, band: .band6GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch1 = result.first(where: { $0.channel == 1 && $0.band == "6" })!
+        #expect(ch1.qualityScore == 95)
+    }
+
+    @Test func overlap24GHzDistanceTable() async throws {
+        // 2.4 GHz must keep the empirical distance heuristic (5 MHz spacing).
+        let aps = [ap(6, -50, width: .mhz20, band: .band24GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let expected: [Int: Int] = [5: 81, 4: 87, 3: 93, 2: 97, 1: 100]
+        for (ch, score) in expected {
+            #expect(result.first(where: { $0.channel == ch && $0.band == "24" })!.qualityScore == score)
+        }
+    }
+
+    @Test func overlap20MHzAdjacentIsZero() async throws {
+        // 20 MHz AP on ch 36: adjacent 20 MHz ch 40 / ch 44 do not overlap.
+        let aps = [ap(36, -50, width: .mhz20, band: .band5GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch40 = result.first(where: { $0.channel == 40 })!
+        let ch44 = result.first(where: { $0.channel == 44 })!
+        #expect(ch40.qualityScore == 100)
+        #expect(ch44.qualityScore == 100)
+    }
+
+    @Test func wideOverlapConsistency() async throws {
+        // One 80 MHz AP on ch 44: ch 40 must be penalized, counted, and reported
+        // as the strongest neighbor (overlapFactor and overlaps stay in sync).
+        let aps = [ap(44, -50, width: .mhz80, band: .band5GHz)]
+        let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
+        let ch40 = result.first(where: { $0.channel == 40 })!
+        #expect(ch40.qualityScore < 100)
+        #expect(ch40.apCount == 1)
+        #expect(ch40.strongestNeighborRSSI == -50)
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
@@ -479,16 +479,14 @@ struct ChannelQualityCalculatorTests {
     }
 
     @Test func overlap6GHzWideBlock() async throws {
-        // 6 GHz uses IEEE 802.11ax blocks anchored at the lowest primary:
-        // 80 MHz on ch 33 spans (31,45).
-        let aps = [ap(33, -50, width: .mhz80, band: .band6GHz)]
+        // 6 GHz uses IEEE 802.11ax containing blocks: an 80 MHz AP whose
+        // primary is ch 41 (a non-lowest primary) still spans (31,47).
+        let aps = [ap(41, -50, width: .mhz80, band: .band6GHz)]
         let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
         let ch37 = result.first(where: { $0.channel == 37 && $0.band == "6" })!
-        let ch41 = result.first(where: { $0.channel == 41 && $0.band == "6" })!
         let ch45 = result.first(where: { $0.channel == 45 && $0.band == "6" })!
         let ch29 = result.first(where: { $0.channel == 29 && $0.band == "6" })!
         #expect(ch37.qualityScore == 95)  // 4/16 = 0.25
-        #expect(ch41.qualityScore == 95)  // 4/16 = 0.25
         #expect(ch45.qualityScore == 95)  // 4/16 = 0.25
         #expect(ch29.qualityScore == 100) // outside the block
     }

--- a/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift
@@ -478,24 +478,28 @@ struct ChannelQualityCalculatorTests {
         #expect(ch44.qualityScore == 95)
     }
 
-    @Test func overlap6GHzWideFallback() async throws {
-        // 6 GHz uses the symmetric fallback: 80 MHz on ch 33 spans (25,41).
+    @Test func overlap6GHzWideBlock() async throws {
+        // 6 GHz uses IEEE 802.11ax blocks anchored at the lowest primary:
+        // 80 MHz on ch 33 spans (31,45).
         let aps = [ap(33, -50, width: .mhz80, band: .band6GHz)]
         let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
-        let ch29 = result.first(where: { $0.channel == 29 && $0.band == "6" })!
+        let ch37 = result.first(where: { $0.channel == 37 && $0.band == "6" })!
         let ch41 = result.first(where: { $0.channel == 41 && $0.band == "6" })!
-        let ch25 = result.first(where: { $0.channel == 25 && $0.band == "6" })!
-        #expect(ch29.qualityScore == 95)  // 4/16 = 0.25
-        #expect(ch41.qualityScore == 98)  // 2/16 = 0.125 (8 steps out)
-        #expect(ch25.qualityScore == 98)  // 2/16 = 0.125
+        let ch45 = result.first(where: { $0.channel == 45 && $0.band == "6" })!
+        let ch29 = result.first(where: { $0.channel == 29 && $0.band == "6" })!
+        #expect(ch37.qualityScore == 95)  // 4/16 = 0.25
+        #expect(ch41.qualityScore == 95)  // 4/16 = 0.25
+        #expect(ch45.qualityScore == 95)  // 4/16 = 0.25
+        #expect(ch29.qualityScore == 100) // outside the block
     }
 
     @Test func overlap6GHzEdgeChannel() async throws {
-        // 80 MHz on ch 5 spans (-3,13); ch 1 still overlaps 4/16 = 0.25.
-        let aps = [ap(5, -50, width: .mhz80, band: .band6GHz)]
+        // 80 MHz on ch 1 spans (-1,15), crossing the band edge; the adjacent
+        // ch 5 still overlaps 4/16 = 0.25. (ch 1 itself is co-channel → 1.0.)
+        let aps = [ap(1, -50, width: .mhz80, band: .band6GHz)]
         let result = ChannelQualityCalculator.compute(aps: aps, currentChannel: nil)
-        let ch1 = result.first(where: { $0.channel == 1 && $0.band == "6" })!
-        #expect(ch1.qualityScore == 95)
+        let ch5 = result.first(where: { $0.channel == 5 && $0.band == "6" })!
+        #expect(ch5.qualityScore == 95)
     }
 
     @Test func overlap24GHzDistanceTable() async throws {

--- a/WiFiLens/Tests/WiFiLensTests/ChannelSpanCalculatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelSpanCalculatorTests.swift
@@ -133,28 +133,26 @@ struct ChannelSpanCalculatorTests {
         #expect(right == 144 + half)
     }
 
-    // MARK: - Fallback (6 GHz)
+    // MARK: - 6 GHz (IEEE 802.11ax blocks anchored at the lowest primary)
 
-    @Test func channelBlock6GHz80MHzFallback() {
+    @Test func channelBlock6GHz80MHzBlock() {
         let (left, right) = ChannelSpanCalculator.channelBlock(
             primaryChannel: 50, widthMHz: 80, band: .band6GHz, spanDirection: nil)
-        let half = ChannelSpanCalculator.channelHalfSpan(for: 80)
-        #expect(left == 50 - half)
-        #expect(right == 50 + half)
+        #expect(left == 48)   // 50 - 2
+        #expect(right == 64)  // 50 + 14 (4 x 20 MHz)
     }
 
-    @Test func channelBlock6GHz20MHzFallback() {
+    @Test func channelBlock6GHz20MHzBlock() {
         let (left, right) = ChannelSpanCalculator.channelBlock(
             primaryChannel: 100, widthMHz: 20, band: .band6GHz, spanDirection: nil)
         #expect(left == 98)
         #expect(right == 102)
     }
 
-    @Test func channelBlock6GHz160MHzFallback() {
+    @Test func channelBlock6GHz160MHzBlock() {
         let (left, right) = ChannelSpanCalculator.channelBlock(
             primaryChannel: 100, widthMHz: 160, band: .band6GHz, spanDirection: nil)
-        let half = ChannelSpanCalculator.channelHalfSpan(for: 160)
-        #expect(left == 100 - half)
-        #expect(right == 100 + half)
+        #expect(left == 98)   // 100 - 2
+        #expect(right == 130) // 100 + 30 (8 x 20 MHz)
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/ChannelSpanCalculatorTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ChannelSpanCalculatorTests.swift
@@ -133,26 +133,47 @@ struct ChannelSpanCalculatorTests {
         #expect(right == 144 + half)
     }
 
-    // MARK: - 6 GHz (IEEE 802.11ax blocks anchored at the lowest primary)
+    // MARK: - 6 GHz (IEEE 802.11ax containing blocks)
 
     @Test func channelBlock6GHz80MHzBlock() {
-        let (left, right) = ChannelSpanCalculator.channelBlock(
-            primaryChannel: 50, widthMHz: 80, band: .band6GHz, spanDirection: nil)
-        #expect(left == 48)   // 50 - 2
-        #expect(right == 64)  // 50 + 14 (4 x 20 MHz)
+        // The scanned primary may be any 20 MHz primary inside the 80 MHz
+        // block: 33/37/41/45 all resolve to the same block (31, 47).
+        for ch in [33, 37, 41, 45] {
+            let (left, right) = ChannelSpanCalculator.channelBlock(
+                primaryChannel: ch, widthMHz: 80, band: .band6GHz, spanDirection: nil)
+            #expect(left == 31)
+            #expect(right == 47)
+        }
+        let (l49, r49) = ChannelSpanCalculator.channelBlock(
+            primaryChannel: 49, widthMHz: 80, band: .band6GHz, spanDirection: nil)
+        #expect(l49 == 47)
+        #expect(r49 == 63)
+    }
+
+    @Test func channelBlock6GHz40MHzNonLowestPrimary() {
+        // 37 and 33 share the 40 MHz block (31, 39).
+        for ch in [33, 37] {
+            let (left, right) = ChannelSpanCalculator.channelBlock(
+                primaryChannel: ch, widthMHz: 40, band: .band6GHz, spanDirection: nil)
+            #expect(left == 31)
+            #expect(right == 39)
+        }
+    }
+
+    @Test func channelBlock6GHz160MHzNonLowestPrimary() {
+        // 37 and 33 share the 160 MHz block (31, 63).
+        for ch in [33, 37] {
+            let (left, right) = ChannelSpanCalculator.channelBlock(
+                primaryChannel: ch, widthMHz: 160, band: .band6GHz, spanDirection: nil)
+            #expect(left == 31)
+            #expect(right == 63)
+        }
     }
 
     @Test func channelBlock6GHz20MHzBlock() {
         let (left, right) = ChannelSpanCalculator.channelBlock(
-            primaryChannel: 100, widthMHz: 20, band: .band6GHz, spanDirection: nil)
-        #expect(left == 98)
-        #expect(right == 102)
-    }
-
-    @Test func channelBlock6GHz160MHzBlock() {
-        let (left, right) = ChannelSpanCalculator.channelBlock(
-            primaryChannel: 100, widthMHz: 160, band: .band6GHz, spanDirection: nil)
-        #expect(left == 98)   // 100 - 2
-        #expect(right == 130) // 100 + 30 (8 x 20 MHz)
+            primaryChannel: 5, widthMHz: 20, band: .band6GHz, spanDirection: nil)
+        #expect(left == 3)
+        #expect(right == 7)
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/Observation/AnalyzerTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Observation/AnalyzerTests.swift
@@ -124,7 +124,8 @@ struct ChannelOccupancyAnalyzerTests {
         channel: Int,
         band: ChannelBand = .band5GHz,
         widthMHz: Int = 20,
-        spanDirection: SpanDirection? = nil
+        spanDirection: SpanDirection? = nil,
+        capabilitiesWidth: Int? = nil
     ) -> WiFiNetworkObservation {
         let ch = WiFiChannel(
             band: band,
@@ -137,7 +138,7 @@ struct ChannelOccupancyAnalyzerTests {
             bssid: bssid,
             rssi: rssi,
             channel: ch,
-            capabilities: WiFiNetworkCapabilities.emptyWithWidth(widthMHz)
+            capabilities: WiFiNetworkCapabilities.emptyWithWidth(capabilitiesWidth ?? widthMHz)
         )
     }
 
@@ -235,6 +236,22 @@ struct ChannelOccupancyAnalyzerTests {
         let ch36 = try #require(result.first { $0.channel == 36 && $0.band == "5" })
         #expect(ch36.qualityScore == 73)
         #expect(ch36.interferenceScore == 27)
+    }
+
+    @Test("ChannelOccupancyAnalyzer: uses operating width, not capability width")
+    func operatingWidthNotCapabilityWidth() throws {
+        // AP advertises 160 MHz capability but is operating at 40 MHz on ch 44.
+        // The analyzer must model the 40 MHz block (42,50): ch 48 gets factor
+        // 0.5 (score 92 at -50). Using the 160 MHz capability block (34,66)
+        // would yield 0.125 (score 97), so 92 distinguishes operating width.
+        let result = ChannelOccupancyAnalyzer.analyze(
+            snapshot: snapshot([observation(bssid: "AA:BB:CC:DD:EE:07", rssi: -50, channel: 44, widthMHz: 40, capabilitiesWidth: 160)]),
+            currentChannel: nil,
+            supportedBands: ["5"],
+            targetAP: nil
+        )
+        let ch48 = try #require(result.first { $0.channel == 48 && $0.band == "5" })
+        #expect(ch48.qualityScore == 92)
     }
 
     @Test("ChannelSpanCalculator: 40/80 MHz span blocks (used by real overlap model)")

--- a/WiFiLens/Tests/WiFiLensTests/Observation/AnalyzerTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/Observation/AnalyzerTests.swift
@@ -237,21 +237,35 @@ struct ChannelOccupancyAnalyzerTests {
         #expect(ch36.interferenceScore == 27)
     }
 
-    @Test("ChannelOccupancyAnalyzer: 40/80 MHz span blocks and apex match ChannelSpanCalculator")
-    func wideChannelSpanApex() {
-        // The analyzer derives each AP's span/apex via ChannelSpanCalculator.
-        // 40 MHz on ch 44 → block (42, 50), apex 46
+    @Test("ChannelSpanCalculator: 40/80 MHz span blocks (used by real overlap model)")
+    func wideChannelSpanBlocks() {
+        // These blocks feed ChannelQualityCalculator's real-band overlap (NH-14).
+        // 40 MHz on ch 44 → block (42, 50)
         let span40 = ChannelSpanCalculator.channelBlock(
             primaryChannel: 44, widthMHz: 40, band: .band5GHz, spanDirection: nil)
         #expect(span40.left == 42)
         #expect(span40.right == 50)
-        #expect(Double(span40.left + span40.right) / 2.0 == 46)
 
-        // 80 MHz on ch 36 → block (34, 50), apex 42
+        // 80 MHz on ch 36 → block (34, 50)
         let span80 = ChannelSpanCalculator.channelBlock(
             primaryChannel: 36, widthMHz: 80, band: .band5GHz, spanDirection: nil)
         #expect(span80.left == 34)
         #expect(span80.right == 50)
-        #expect(Double(span80.left + span80.right) / 2.0 == 42)
+    }
+
+    @Test("ChannelOccupancyAnalyzer: 80 MHz AP on ch 44 penalizes adjacent ch 40")
+    func eightyMHzAdjacentPenalty() throws {
+        // Real span of the 80 MHz AP on ch 44 is (34,50); the 20 MHz candidate
+        // ch 40 (38,42) overlaps 4/16 → factor 0.25 → rssi -50 penalty ≈5 → 95.
+        let result = ChannelOccupancyAnalyzer.analyze(
+            snapshot: snapshot([observation(bssid: "AA:BB:CC:DD:EE:06", rssi: -50, channel: 44, widthMHz: 80)]),
+            currentChannel: nil,
+            supportedBands: ["5"],
+            targetAP: nil
+        )
+        let ch40 = try #require(result.first { $0.channel == 40 && $0.band == "5" })
+        #expect(ch40.qualityScore == 95)
+        #expect(ch40.apCount == 1)
+        #expect(ch40.strongestNeighborRSSI == -50)
     }
 }


### PR DESCRIPTION
## Summary

`ChannelQualityCalculator.overlapFactor` used a simplified primary-channel distance heuristic (`dist` vs `halfSpan = width/20/2`) for 5/6 GHz, which **systematically counted adjacent wide-channel (40/80/160 MHz) interference as zero**. The real frequency span was already computed by `ChannelSpanCalculator.channelBlock` but only surfaced as the unused `APInfo.apex` midpoint (dead code).

This PR switches 5/6 GHz overlap to **real frequency-band intersection**:
- `overlapFactor` computes the intersection of the 20 MHz candidate channel and the AP's block, normalized by the AP span length → 1.0/0.5/0.25/0.125 for 20/40/80/160 MHz non-co-channel candidates. Documented as an empirical weighting heuristic (the co-channel short-circuit stays 1.0; `widthMul` compensates wider APs).
- Co-channel short-circuit (1.0) and the 2.4 GHz empirical distance heuristic are preserved (2.4 GHz channels are 5 MHz apart and overlap in practice).
- Removes the dead `APInfo.apex` field and the analyzer's span/apex math.

## Review fixes (applied)

- **Operating width**: `ChannelOccupancyAnalyzer` now models the AP span from `obs.channel.channelWidthMHz` (the actual operating width) instead of `capabilities.channelWidth` (IE capability flags), so an AP that supports 160 MHz but runs 40 MHz is not treated as a 160 MHz occupant. Regression test added with capability width ≠ operating width.
- **Real 6 GHz blocks**: `ChannelSpanCalculator.channelBlock` now implements IEEE 802.11ax 6 GHz 40/80/160 MHz blocks anchored at the lowest primary channel (was symmetric half-span fallback). 6 GHz overlap tests updated accordingly.
- **Scope**: PR contains only the NH-14 changes; the NH-13/NH-16 batch was pushed to `master` separately.

## Changes

- `WiFiLens/Sources/WiFiLens/Channels/ChannelQualityCalculator.swift` — real-span overlap model, drop `APInfo.apex`
- `WiFiLens/Sources/WiFiLens/Spectrum/ChannelSpanCalculator.swift` — real 6 GHz blocks
- `WiFiLens/Sources/WiFiLens/Observation/Analyzers/ChannelOccupancyAnalyzer.swift` — operating width, drop span/apex math
- `WiFiLens/Tests/WiFiLensTests/ChannelQualityCalculatorTests.swift` — updated assertions + boundary cases (160 MHz adjacency, 40 MHz direction, 80 MHz seam, 6 GHz blocks/edge, 2.4 GHz distance table, 20 MHz adjacency = 0, three-field consistency)
- `WiFiLens/Tests/WiFiLensTests/ChannelSpanCalculatorTests.swift` — 6 GHz block tests
- `WiFiLens/Tests/WiFiLensTests/Observation/AnalyzerTests.swift` — operating-width regression + wide-channel end-to-end case

## Verification

`verify.sh` — OSS + Pro Debug builds and full `WiFiLensTests` suite green.

## Behavior change note (for release notes)

Channel quality/recommendation scores on 5/6 GHz with wide-channel (40/80/160 MHz) neighbors change in **both directions** (some channels score higher, some lower) — this corrects the previous underestimate of adjacent wide-channel interference. No API changes; all touched symbols are internal.