### PR TITLE
feat(i18n): add French localization

### DIFF
--- a/.agents/skills/i18n-completer/references/LOCALIZATION_TERMS.md
+++ b/.agents/skills/i18n-completer/references/LOCALIZATION_TERMS.md
@@ -80,3 +80,34 @@ Standardized terms for `en`, `ja`, `zh-Hans`, `de`, `es` translations in `Locali
 5. **Punctuation** — follow target language conventions (e.g., `…` not `...` in ja/zh-Hans, `«»` in fr)
 6. **Tone** — use informal "你" (zh-Hans), not formal "您"
 7. **AP in prose** — short labels (badges, table headers, menu items) keep the abbreviation `AP`. Longer explanatory prose may expand the full term for readability (zh 接入点, ja アクセスポイント, de Zugangspunkt, es punto de acceso); existing AP Radar long-form usages are sanctioned.
+
+## fr (Français)
+
+| English | Use | Do NOT use | Notes |
+|---------|-----|------------|-------|
+| channel | canal | ~~fréquence~~ | "fréquence" reserved for frequency (e.g. frequency band = bande de fréquence) |
+| Wi-Fi | Wi-Fi | — | |
+| WiFi Lens | WiFi Lens | — | Product name, never hyphenated |
+| AP | AP | ~~point d'accès~~ | Abbreviation kept as-is in short labels/badges; prose may expand to "point d'accès" |
+| scan / scanning | scan / analyse | ~~balayage~~ | "analyse" for analysis; "scan" for the scan action/feature |
+| System Settings | Réglages Système | ~~Préférences Système~~ | macOS 13+ French uses "Réglages Système" |
+| recommendation | recommandation | ~~suggestion~~ | For channel recommendations |
+| permission (noun) | autorisation | — | "autoriser" for the verb allow/grant |
+| network | réseau | — | |
+| device | appareil | ~~dispositif~~ | |
+| signal | signal | — | |
+| hide / hidden (network) | masquer / réseau masqué | ~~caché~~ | |
+| enable (verb) | activer | — | For toggling features on |
+| disabled | désactivé | — | For feature states/toggles |
+| granted | accordée / accordé | — | Permission states |
+| denied | refusée / refusé | — | Permission states |
+| overlap | chevauchement | ~~recouvrement~~ | Channel overlap |
+| open (verb) | ouvrir | — | Opening settings/apps |
+| interface (network) | interface | — | Network interface |
+| you (informal) | tu | ~~vous~~ | App uses informal tone throughout |
+
+## General Rules (fr addition)
+
+1. **Guillemets** — use `« »` for quoted text in French
+2. **Feminine/plural agreement** — match the noun gender/number for quality tiers, permission states, and "X est/est désactivé" forms
+3. **Product name & abbreviations** — never translate `WiFi Lens`, `AP`, `RSSI`, `MCS`, `NSS`, `BSSID`, `SSID`, `DFS`, `EMA` in short labels; keep them as-is

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -114,6 +114,12 @@
             "state": "translated",
             "value": "%lld 个AP"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld AP"
+          }
         }
       }
     },
@@ -166,6 +172,12 @@
             "state": "translated",
             "value": "无法排除正常行为"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un comportement normal ne peut pas être exclu"
+          }
         }
       }
     },
@@ -200,6 +212,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖率不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couverture indisponible"
           }
         }
       }
@@ -236,6 +254,12 @@
             "state": "translated",
             "value": "证据跨多个网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les preuves couvrent plusieurs réseaux"
+          }
         }
       }
     },
@@ -270,6 +294,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖率不完整"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couverture incomplète"
           }
         }
       }
@@ -306,6 +336,12 @@
             "state": "translated",
             "value": "缺少 BSSID"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID manquant"
+          }
         }
       }
     },
@@ -340,6 +376,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "缺少网关标识"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identité de la passerelle manquante"
           }
         }
       }
@@ -376,6 +418,12 @@
             "state": "translated",
             "value": "缺少 SSID"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID manquant"
+          }
         }
       }
     },
@@ -410,6 +458,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "证据跨越会话边界"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les preuves franchissent une limite de session"
           }
         }
       }
@@ -446,6 +500,12 @@
             "state": "translated",
             "value": "未达到阈值"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuil non atteint"
+          }
         }
       }
     },
@@ -480,6 +540,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30 分钟内至少记录到三次断开连接事件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au moins trois déconnexions enregistrées se sont produites en 30 minutes."
           }
         }
       }
@@ -516,6 +582,12 @@
             "state": "translated",
             "value": "查看关联的 Timeline 事件及其周边观测。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte les événements de la chronologie associés et leurs observations environnantes."
+          }
         }
       }
     },
@@ -550,6 +622,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测到重复断开连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnexions répétées observées"
           }
         }
       }
@@ -586,6 +664,12 @@
             "state": "translated",
             "value": "15 分钟内至少记录到三次网关延迟突增事件。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au moins trois pics de latence de la passerelle enregistrés se sont produits en 15 minutes."
+          }
         }
       }
     },
@@ -620,6 +704,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "查看关联的 Timeline 事件；此观测不能证明网关故障。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte les événements de la chronologie associés ; cette observation n'établit pas une panne de la passerelle."
           }
         }
       }
@@ -656,6 +746,12 @@
             "state": "translated",
             "value": "重复观测到网关延迟"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observations répétées de latence de la passerelle"
+          }
         }
       }
     },
@@ -690,6 +786,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "10 分钟内至少记录到三次连接持续期间的 BSSID 变更。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au moins trois changements de BSSID enregistrés pendant une continuité connectée se sont produits en 10 minutes."
           }
         }
       }
@@ -726,6 +828,12 @@
             "state": "translated",
             "value": "查看关联的 Timeline 事件；仅凭重复漫游无法确定原因。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte les événements de la chronologie associés ; l'itinérance répétée ne suffit pas à identifier une cause."
+          }
         }
       }
     },
@@ -760,6 +868,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测到重复漫游"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance répétée observée"
           }
         }
       }
@@ -796,6 +910,12 @@
             "state": "translated",
             "value": "适用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicable"
+          }
         }
       }
     },
@@ -830,6 +950,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "适用性有限"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicabilité limitée"
           }
         }
       }
@@ -866,6 +992,12 @@
             "state": "translated",
             "value": "BSSID：%@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID : %@"
+          }
         }
       }
     },
@@ -900,6 +1032,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "连接性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectivité"
           }
         }
       }
@@ -936,6 +1074,12 @@
             "state": "translated",
             "value": "性能"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Performances"
+          }
         }
       }
     },
@@ -970,6 +1114,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "稳定性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stabilité"
           }
         }
       }
@@ -1006,6 +1156,12 @@
             "state": "translated",
             "value": "高置信度"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance élevée"
+          }
         }
       }
     },
@@ -1040,6 +1196,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "低置信度"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance faible"
           }
         }
       }
@@ -1076,6 +1238,12 @@
             "state": "translated",
             "value": "中等置信度"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance moyenne"
+          }
         }
       }
     },
@@ -1110,6 +1278,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%d 条观测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d observations"
           }
         }
       }
@@ -1146,6 +1320,12 @@
             "state": "translated",
             "value": "证据：%d 个事件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preuves : %d événements"
+          }
         }
       }
     },
@@ -1180,6 +1360,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "聚类持续时长：%d 分钟"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durée du groupe : %d min"
           }
         }
       }
@@ -1216,6 +1402,12 @@
             "state": "translated",
             "value": "证据：%@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preuve : %@"
+          }
         }
       }
     },
@@ -1247,6 +1439,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ – %@"
@@ -1286,6 +1484,12 @@
             "state": "translated",
             "value": "洞察不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyses indisponibles"
+          }
         }
       }
     },
@@ -1320,6 +1524,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已记录的发现"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Constats enregistrés"
           }
         }
       }
@@ -1356,6 +1566,12 @@
             "state": "translated",
             "value": "这些发现描述已记录的观测，并链接回 Timeline 证据。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ces constats décrivent des observations enregistrées et renvoient aux preuves de la chronologie."
+          }
         }
       }
     },
@@ -1390,6 +1606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passerelle : %@"
           }
         }
       }
@@ -1426,6 +1648,12 @@
             "state": "translated",
             "value": "历史记录太短"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique trop court"
+          }
         }
       }
     },
@@ -1460,6 +1688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已记录的历史有限。下方发现仅基于已记录事件的集中出现。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique enregistré est limité. Les constats ci-dessous reposent uniquement sur les groupes présents dans les événements enregistrés."
           }
         }
       }
@@ -1496,6 +1730,12 @@
             "state": "translated",
             "value": "无法评估本地观测。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les observations locales n'ont pas pu être évaluées."
+          }
         }
       }
     },
@@ -1530,6 +1770,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在评估本地观测…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Évaluation des observations locales…"
           }
         }
       }
@@ -1566,6 +1812,12 @@
             "state": "translated",
             "value": "类别 %@ · %@ · %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catégorie %@ · %@ · %@"
+          }
         }
       }
     },
@@ -1600,6 +1852,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau"
           }
         }
       }
@@ -1636,6 +1894,12 @@
             "state": "translated",
             "value": "AP：%@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP : %@"
+          }
         }
       }
     },
@@ -1670,6 +1934,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau : %@"
           }
         }
       }
@@ -1706,6 +1976,12 @@
             "state": "translated",
             "value": "网络：无法归属"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau : non attribué"
+          }
         }
       }
     },
@@ -1740,6 +2016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "此时间范围内没有历史记录"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun historique sur cette période"
           }
         }
       }
@@ -1776,6 +2058,12 @@
             "state": "translated",
             "value": "没有观测到持久化事件。这不是对网络健康度的判断。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement persistant n'a été observé. Cela ne constitue pas un constat sur la santé du réseau."
+          }
         }
       }
     },
@@ -1810,6 +2098,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有规则发现"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun constat de règle"
           }
         }
       }
@@ -1846,6 +2140,12 @@
             "state": "translated",
             "value": "没有开启的规则匹配已记录观测。这不表示网络正常。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune règle activée n'a correspondu aux observations enregistrées. Cela ne signifie pas que le réseau est sain."
+          }
         }
       }
     },
@@ -1880,6 +2180,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "部分分析"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse partielle"
           }
         }
       }
@@ -1916,6 +2222,12 @@
             "state": "translated",
             "value": "观测覆盖范围无法确认或不完整。下方发现仅基于已记录事件的集中出现。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La couverture d'observation est indisponible ou incomplète. Les constats ci-dessous reposent uniquement sur les groupes présents dans les événements enregistrés."
+          }
         }
       }
     },
@@ -1950,6 +2262,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "时间范围"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Période"
           }
         }
       }
@@ -1986,6 +2304,12 @@
             "state": "translated",
             "value": "信息"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informatif"
+          }
         }
       }
     },
@@ -2020,6 +2344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "警告"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement"
           }
         }
       }
@@ -2057,6 +2387,12 @@
             "state": "translated",
             "value": "洞察将在此显示。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les analyses apparaîtront ici."
+          }
         }
       }
     },
@@ -2088,6 +2424,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@ · %@"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ · %@ · %@"
@@ -2127,6 +2469,12 @@
             "state": "translated",
             "value": "在 Timeline 中查看"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir dans la chronologie"
+          }
         }
       }
     },
@@ -2161,6 +2509,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖缺口：%lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lacunes de couverture : %lld"
           }
         }
       }
@@ -2197,6 +2551,12 @@
             "state": "translated",
             "value": "无法确认观测覆盖范围"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couverture d'observation indisponible"
+          }
         }
       }
     },
@@ -2231,6 +2591,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "变化事件不记录连续的观测覆盖范围。计数仅描述已记录的事件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les événements de changement n'enregistrent pas la couverture d'observation continue. Les comptages décrivent uniquement les événements enregistrés."
           }
         }
       }
@@ -2267,6 +2633,12 @@
             "state": "translated",
             "value": "%lld 小时 %lld 分钟"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld h %lld min"
+          }
         }
       }
     },
@@ -2301,6 +2673,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 分钟"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min"
           }
         }
       }
@@ -2337,6 +2715,12 @@
             "state": "translated",
             "value": "覆盖范围不完整"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La couverture est incomplète"
+          }
         }
       }
     },
@@ -2371,6 +2755,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测间隔限制了可得出的结论。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les lacunes d'observation limitent les conclusions possibles."
           }
         }
       }
@@ -2407,6 +2797,12 @@
             "state": "translated",
             "value": "历史记录存储在本机本地。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique est stocké localement sur ce Mac."
+          }
         }
       }
     },
@@ -2441,6 +2837,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "此时间范围内没有历史记录"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun historique sur cette période"
           }
         }
       }
@@ -2477,6 +2879,12 @@
             "state": "translated",
             "value": "没有观测到持久化事件。这不表示网络活动为零。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement persistant n'a été observé. Cela ne signifie pas une activité réseau nulle."
+          }
         }
       }
     },
@@ -2511,6 +2919,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未在记录本地观测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement local…"
           }
         }
       }
@@ -2547,6 +2961,12 @@
             "state": "translated",
             "value": "观测 %@ – %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observé %@ – %@"
+          }
         }
       }
     },
@@ -2581,6 +3001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测时长：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durée observée : %@"
           }
         }
       }
@@ -2617,6 +3043,12 @@
             "state": "translated",
             "value": "正在记录本地观测"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'enregistrement des observations locales est actif"
+          }
         }
       }
     },
@@ -2651,6 +3083,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅根据已经记录的事件进行判断"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le jugement repose uniquement sur les événements enregistrés"
           }
         }
       }
@@ -2687,6 +3125,12 @@
             "state": "translated",
             "value": "有限分析：%@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse limitée : %@"
+          }
         }
       }
     },
@@ -2721,6 +3165,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "原因："
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raison : "
           }
         }
       }
@@ -2757,6 +3207,12 @@
             "state": "translated",
             "value": "概览范围只能提供信息性结论"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le périmètre global ne peut fournir que des conclusions informatives"
+          }
         }
       }
     },
@@ -2791,6 +3247,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测覆盖不完整"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La couverture d'observation est incomplète"
           }
         }
       }
@@ -2827,6 +3289,12 @@
             "state": "translated",
             "value": "观测覆盖不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La couverture d'observation est indisponible"
+          }
         }
       }
     },
@@ -2861,6 +3329,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "历史记录太短"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique enregistré est trop court"
           }
         }
       }
@@ -2897,6 +3371,12 @@
             "state": "translated",
             "value": "缺少 AP 信息"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les informations sur le point d'accès sont manquantes"
+          }
         }
       }
     },
@@ -2931,6 +3411,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "当前数据缺少该规则需要的事件类型"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les données actuelles ne contiennent pas le type d'événement requis par cette règle"
           }
         }
       }
@@ -2967,6 +3453,12 @@
             "state": "translated",
             "value": "无法确认网关身份"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'identité de la passerelle ne peut pas être confirmée"
+          }
         }
       }
     },
@@ -3001,6 +3493,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "缺少必要的网络名称信息"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les informations de nom de réseau requises sont manquantes"
           }
         }
       }
@@ -3037,6 +3535,12 @@
             "state": "translated",
             "value": "当前分析范围不是单一网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le périmètre d'analyse actuel n'est pas un réseau unique"
+          }
         }
       }
     },
@@ -3071,6 +3575,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "存储层不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La couche de stockage est indisponible"
           }
         }
       }
@@ -3107,6 +3617,12 @@
             "state": "translated",
             "value": "事件无法归属到具体网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les événements ne peuvent pas être attribués à un réseau précis"
+          }
         }
       }
     },
@@ -3141,6 +3657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "当前无法评估：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'évaluer pour l'instant : %@"
           }
         }
       }
@@ -3177,6 +3699,12 @@
             "state": "translated",
             "value": "无法运行的规则：%@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Règles indisponibles : %@"
+          }
         }
       }
     },
@@ -3211,6 +3739,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "所选作用域可以运行所有规则。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les règles peuvent s'exécuter pour le périmètre sélectionné."
           }
         }
       }
@@ -3247,6 +3781,12 @@
             "state": "translated",
             "value": "历史记录太短"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique court"
+          }
         }
       }
     },
@@ -3281,6 +3821,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测历史太短，无法进行完整分析。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique observé est trop court pour une analyse complète."
           }
         }
       }
@@ -3317,6 +3863,12 @@
             "state": "translated",
             "value": "本地历史记录存储不可用。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le stockage de l'historique local est indisponible."
+          }
         }
       }
     },
@@ -3351,6 +3903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "有足够的观测证据"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preuves observées suffisantes"
           }
         }
       }
@@ -3387,6 +3945,12 @@
             "state": "translated",
             "value": "统计仅描述已记录的观测，不评估网络健康度。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les statistiques décrivent uniquement les observations enregistrées ; elles n'évaluent pas la santé du réseau."
+          }
         }
       }
     },
@@ -3421,6 +3985,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重复的网关延迟观测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observations répétées de latence de la passerelle"
           }
         }
       }
@@ -3457,6 +4027,12 @@
             "state": "translated",
             "value": "重复断开"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnexion répétée"
+          }
         }
       }
     },
@@ -3491,6 +4067,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AP 切换"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changement d'AP"
           }
         }
       }
@@ -3527,6 +4109,12 @@
             "state": "translated",
             "value": "AP 切换"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changement d'AP"
+          }
         }
       }
     },
@@ -3536,31 +4124,37 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relative Änderung: %.1f%%"
+            "value": "Relative Änderung: %@"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relative change: %.1f%%"
+            "value": "Relative change: %@"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cambio relativo: %.1f%%"
+            "value": "Cambio relativo: %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "相対変化：%.1f%%"
+            "value": "相対変化：%@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "相对变化：%.1f%%"
+            "value": "相对变化：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variation relative : %@"
           }
         }
       }
@@ -3597,6 +4191,12 @@
             "state": "translated",
             "value": "与上一周期比较"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comparé à la période précédente"
+          }
         }
       }
     },
@@ -3631,6 +4231,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "事件总数变化：%lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variation totale des événements : %lld"
           }
         }
       }
@@ -3667,6 +4273,12 @@
             "state": "translated",
             "value": "连接变化"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changements de connexion"
+          }
         }
       }
     },
@@ -3701,6 +4313,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexions"
           }
         }
       }
@@ -3737,6 +4355,12 @@
             "state": "translated",
             "value": "观测范围：%@ 至 %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observé du %@ au %@"
+          }
         }
       }
     },
@@ -3746,31 +4370,37 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abdeckung: %lld%%"
+            "value": "Abdeckung: %@"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Coverage: %lld%%"
+            "value": "Coverage: %@"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cobertura: %lld%%"
+            "value": "Cobertura: %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "カバレッジ：%lld%%"
+            "value": "カバレッジ：%@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "覆盖：%lld%%"
+            "value": "覆盖：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couverture : %@"
           }
         }
       }
@@ -3807,6 +4437,12 @@
             "state": "translated",
             "value": "断开连接"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnexions"
+          }
         }
       }
     },
@@ -3841,6 +4477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "事件分布"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répartition des événements"
           }
         }
       }
@@ -3877,6 +4519,12 @@
             "state": "translated",
             "value": "首条已记录事件：%@。末条已记录事件：%@。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premier événement enregistré : %@. Dernier événement enregistré : %@."
+          }
         }
       }
     },
@@ -3911,6 +4559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "统计不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques indisponibles"
           }
         }
       }
@@ -3947,6 +4601,12 @@
             "state": "translated",
             "value": "网关延迟观测"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observations de latence de la passerelle"
+          }
         }
       }
     },
@@ -3981,6 +4641,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关延迟观测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observations de latence de la passerelle"
           }
         }
       }
@@ -4017,6 +4683,12 @@
             "state": "translated",
             "value": "最近的重要事件：%@ · %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernier événement notable : %@ · %@"
+          }
         }
       }
     },
@@ -4051,6 +4723,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法加载本地历史记录。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique local n'a pas pu être chargé."
           }
         }
       }
@@ -4087,6 +4765,12 @@
             "state": "translated",
             "value": "正在加载本地历史记录…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement de l'historique local…"
+          }
         }
       }
     },
@@ -4121,6 +4805,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "历史记录存储在本机本地。你可以在设置 → 数据中清除。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique est stocké localement sur ce Mac. Tu peux l'effacer dans Réglages → Données."
           }
         }
       }
@@ -4157,6 +4847,12 @@
             "state": "translated",
             "value": "本地历史记录"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique local"
+          }
         }
       }
     },
@@ -4191,6 +4887,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最集中区间：%@（%lld 个事件）"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalle le plus concentré : %@ · %lld événements"
           }
         }
       }
@@ -4227,6 +4929,12 @@
             "state": "translated",
             "value": "网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau"
+          }
         }
       }
     },
@@ -4261,6 +4969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AP：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP : %@"
           }
         }
       }
@@ -4297,6 +5011,12 @@
             "state": "translated",
             "value": "全部网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les réseaux"
+          }
         }
       }
     },
@@ -4331,6 +5051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau : %@"
           }
         }
       }
@@ -4367,6 +5093,12 @@
             "state": "translated",
             "value": "选中的网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseaux sélectionnés"
+          }
         }
       }
     },
@@ -4401,6 +5133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未归属事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événements non attribués"
           }
         }
       }
@@ -4437,6 +5175,12 @@
             "state": "translated",
             "value": "WiFi Lens 在此时间范围内没有记录时间线历史。这不是对网络健康度的判断。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens n'a pas enregistré d'historique de chronologie pour cette période. Cela ne constitue pas un constat sur la santé du réseau."
+          }
         }
       }
     },
@@ -4471,6 +5215,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有本地历史记录"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun historique local"
           }
         }
       }
@@ -4507,6 +5257,12 @@
             "state": "translated",
             "value": "WiFi Lens 观测了此时间范围，但没有事件与当前网络和筛选条件匹配。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens a observé cette plage temporelle, mais aucun événement ne correspond au réseau et au filtre actuels."
+          }
         }
       }
     },
@@ -4541,6 +5297,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有匹配的事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement correspondant"
           }
         }
       }
@@ -4577,6 +5339,12 @@
             "state": "translated",
             "value": "选择时间范围以查看本地 Timeline 历史记录。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne une période pour inspecter l'historique local de la chronologie."
+          }
         }
       }
     },
@@ -4611,6 +5379,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有分析结果"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun résultat d'analyse"
           }
         }
       }
@@ -4647,6 +5421,12 @@
             "state": "translated",
             "value": "应用正在观测时，WiFi Lens 会记录本地时间线观测。随着观测持续，新的历史记录会出现。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens enregistre les observations locales de la chronologie pendant que l'app observe. De nouvelles données apparaissent au fil des observations."
+          }
         }
       }
     },
@@ -4681,6 +5461,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "观测状态"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État d'observation"
           }
         }
       }
@@ -4717,6 +5503,12 @@
             "state": "translated",
             "value": "时间范围"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Période"
+          }
         }
       }
     },
@@ -4751,6 +5543,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "周期：%@ – %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Période : %@ – %@"
           }
         }
       }
@@ -4787,6 +5585,12 @@
             "state": "translated",
             "value": "7天"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 jours"
+          }
         }
       }
     },
@@ -4821,6 +5625,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30天"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 jours"
           }
         }
       }
@@ -4857,6 +5667,12 @@
             "state": "translated",
             "value": "今天"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aujourd'hui"
+          }
         }
       }
     },
@@ -4891,6 +5707,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "漫游"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance"
           }
         }
       }
@@ -4927,6 +5749,12 @@
             "state": "translated",
             "value": "范围"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Périmètre"
+          }
         }
       }
     },
@@ -4961,6 +5789,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话数：%lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sessions : %lld"
           }
         }
       }
@@ -4997,6 +5831,12 @@
             "state": "translated",
             "value": "严重"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Critique"
+          }
         }
       }
     },
@@ -5031,6 +5871,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "严重度分布"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répartition par sévérité"
           }
         }
       }
@@ -5067,6 +5913,12 @@
             "state": "translated",
             "value": "信息"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info"
+          }
         }
       }
     },
@@ -5102,6 +5954,12 @@
             "state": "translated",
             "value": "暂无严重度数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune donnée de sévérité disponible"
+          }
         }
       }
     },
@@ -5136,6 +5994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "警告"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissements"
           }
         }
       }
@@ -5173,6 +6037,12 @@
             "state": "translated",
             "value": "统计信息将在此显示。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les statistiques apparaîtront ici."
+          }
         }
       }
     },
@@ -5207,6 +6077,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "事件总数"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total des événements"
           }
         }
       }
@@ -5244,6 +6120,12 @@
             "state": "translated",
             "value": "%1$@，BSSID %2$@，信号已丢失"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, BSSID %2$@, signal perdu"
+          }
         }
       }
     },
@@ -5279,6 +6161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$@，BSSID %2$@，信号强度 %3$@，%4$@，%5$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, BSSID %2$@, puissance du signal %3$@, %4$@, %5$@"
           }
         }
       }
@@ -5316,6 +6204,12 @@
             "state": "translated",
             "value": "无法使用声音，将继续进行 RSSI 追踪。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le son n'est pas disponible. Le suivi RSSI continue sans audio."
+          }
         }
       }
     },
@@ -5351,6 +6245,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "更换目标"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de cible"
           }
         }
       }
@@ -5388,6 +6288,12 @@
             "state": "translated",
             "value": "选择一个接入点，WiFi Lens 将持续追踪其信号强度，并随着信号增强播放更密集的柔和提示音。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne un point d'accès et WiFi Lens suivra sa puissance de signal en diffusant de légères impulsions qui s'accélèrent à mesure que le signal se renforce."
+          }
         }
       }
     },
@@ -5423,6 +6329,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AP 雷达根据接收信号强度提供辅助提示，无法判断接入点的真实方向或精确距离。墙体、反射、设备姿态和无线干扰都可能影响结果。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP Radar fournit des indications basées sur la puissance du signal reçu. Il ne peut pas déterminer la direction réelle ni la distance précise d'un point d'accès. Les murs, réflexions, l'orientation de l'appareil et les interférences sans fil peuvent affecter le résultat."
           }
         }
       }
@@ -5460,6 +6372,12 @@
             "state": "translated",
             "value": "解锁"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préréglage Geiger débloqué !"
+          }
         }
       }
     },
@@ -5495,6 +6413,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请确认 Wi-Fi 已开启，然后重试。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assure-toi que le Wi-Fi est activé, puis réessaie."
           }
         }
       }
@@ -5532,6 +6456,12 @@
             "state": "translated",
             "value": "未发现接入点"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun point d'accès trouvé"
+          }
         }
       }
     },
@@ -5567,6 +6497,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新扫描"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer le scan"
           }
         }
       }
@@ -5604,6 +6540,12 @@
             "state": "translated",
             "value": "最近一次扫描失败，结果可能不是最新。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dernier scan a échoué. Les résultats peuvent être obsolètes."
+          }
         }
       }
     },
@@ -5638,6 +6580,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择此接入点并开始追踪。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne ce point d'accès et lance son suivi."
           }
         }
       }
@@ -5675,6 +6623,12 @@
             "state": "translated",
             "value": "选择接入点"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner un point d'accès"
+          }
         }
       }
     },
@@ -5707,6 +6661,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d dBm"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%d dBm"
@@ -5747,6 +6707,12 @@
             "state": "translated",
             "value": "原始信号：%d dBm"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal brut : %d dBm"
+          }
         }
       }
     },
@@ -5781,6 +6747,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号强度"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puissance du signal"
           }
         }
       }
@@ -5818,6 +6790,12 @@
             "state": "translated",
             "value": "暂时无法检测到此接入点。请继续移动或等待下一次扫描。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce point d'accès est temporairement indisponible. Continue de te déplacer ou attends le prochain scan."
+          }
         }
       }
     },
@@ -5853,6 +6831,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最后看到：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière apparition : %@"
           }
         }
       }
@@ -5890,6 +6874,12 @@
             "state": "translated",
             "value": "正在重新扫描…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveau scan…"
+          }
         }
       }
     },
@@ -5925,6 +6915,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号已丢失"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal perdu"
           }
         }
       }
@@ -5962,6 +6958,12 @@
             "state": "translated",
             "value": "声音关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Son désactivé"
+          }
         }
       }
     },
@@ -5997,6 +6999,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "声音开启"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Son activé"
           }
         }
       }
@@ -6034,6 +7042,12 @@
             "state": "translated",
             "value": "声音已关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "son désactivé"
+          }
         }
       }
     },
@@ -6070,6 +7084,12 @@
             "state": "translated",
             "value": "声音已开启"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "son activé"
+          }
         }
       }
     },
@@ -6104,6 +7124,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在追踪"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suivi"
           }
         }
       }
@@ -6141,6 +7167,12 @@
             "state": "translated",
             "value": "停止追踪"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter le suivi"
+          }
         }
       }
     },
@@ -6176,6 +7208,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "有 %lld 个接入点"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld points d'accès disponibles"
           }
         }
       }
@@ -6213,6 +7251,12 @@
             "state": "translated",
             "value": "信道 %d"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal %d"
+          }
         }
       }
     },
@@ -6248,6 +7292,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "隐藏网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau masqué"
           }
         }
       }
@@ -6285,6 +7335,12 @@
             "state": "translated",
             "value": "信号正在增强"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se rapproche"
+          }
         }
       }
     },
@@ -6320,6 +7376,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在测量"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mesure"
           }
         }
       }
@@ -6357,6 +7419,12 @@
             "state": "translated",
             "value": "信号正在减弱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'éloigne"
+          }
         }
       }
     },
@@ -6393,6 +7461,12 @@
             "state": "translated",
             "value": "信号基本稳定"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal stable"
+          }
         }
       }
     },
@@ -6427,6 +7501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "BLE RSSI 趋势图，%1$d 个样本，范围 %2$d 至 %3$d dBm"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique de tendance RSSI BLE, %1$d échantillons, plage %2$d à %3$d dBm"
           }
         }
       }
@@ -6464,6 +7544,12 @@
             "state": "translated",
             "value": "蓝牙运行于 2.4 GHz 频段，密集的 BLE 设备可能干扰 2.4 GHz Wi-Fi 网络及附近的蓝牙设备。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le Bluetooth fonctionne dans la bande 2,4 GHz — une activité BLE dense peut interférer avec les réseaux Wi-Fi 2,4 GHz et les appareils Bluetooth proches."
+          }
         }
       }
     },
@@ -6499,6 +7585,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 个设备"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld appareils"
           }
         }
       }
@@ -6536,6 +7628,12 @@
             "state": "translated",
             "value": "在设置中开启蓝牙分析后，可扫描附近设备并监测信号强度。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active l'analyse Bluetooth dans les réglages pour scanner les appareils à proximité et surveiller la puissance du signal."
+          }
         }
       }
     },
@@ -6571,6 +7669,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "蓝牙分析已关闭"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse Bluetooth désactivée"
           }
         }
       }
@@ -6608,6 +7712,12 @@
             "state": "translated",
             "value": "正在扫描 BLE 设备…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche d'appareils BLE…"
+          }
         }
       }
     },
@@ -6643,6 +7753,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "蓝牙权限被拒绝。请在系统设置中开启。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation Bluetooth a été refusée. Active-la dans Réglages Système."
           }
         }
       }
@@ -6680,6 +7796,12 @@
             "state": "translated",
             "value": "扫描 BLE 设备需要蓝牙权限。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation Bluetooth est requise pour scanner les appareils BLE."
+          }
         }
       }
     },
@@ -6715,6 +7837,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要蓝牙权限。请在系统设置中开启。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation Bluetooth est requise. Active-la dans Réglages Système."
           }
         }
       }
@@ -6752,6 +7880,12 @@
             "state": "translated",
             "value": "%@ — RSSI 历史记录"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — historique RSSI"
+          }
         }
       }
     },
@@ -6787,6 +7921,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "BLE 设备扫描"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan des appareils BLE"
           }
         }
       }
@@ -6824,6 +7964,12 @@
             "state": "translated",
             "value": "蓝牙已关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth désactivé"
+          }
         }
       }
     },
@@ -6859,6 +8005,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请在系统设置中开启蓝牙以扫描 BLE 设备。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active Bluetooth dans Réglages Système pour scanner les appareils BLE."
           }
         }
       }
@@ -6896,6 +8048,12 @@
             "state": "translated",
             "value": "蓝牙已关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth est désactivé"
+          }
         }
       }
     },
@@ -6931,6 +8089,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请在设置中授予蓝牙权限以扫描 BLE 设备。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorde l'autorisation Bluetooth dans les réglages pour scanner les appareils BLE."
           }
         }
       }
@@ -6968,6 +8132,12 @@
             "state": "translated",
             "value": "蓝牙权限被拒绝"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation Bluetooth refusée"
+          }
         }
       }
     },
@@ -7003,6 +8173,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请在设置 → 权限中授予蓝牙权限以扫描附近的 BLE 设备。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorde l'autorisation Bluetooth dans Réglages → Autorisations pour scanner les appareils BLE à proximité."
           }
         }
       }
@@ -7040,6 +8216,12 @@
             "state": "translated",
             "value": "需要蓝牙权限"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation Bluetooth requise"
+          }
         }
       }
     },
@@ -7075,6 +8257,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "权限被拒绝"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation refusée"
           }
         }
       }
@@ -7112,6 +8300,12 @@
             "state": "translated",
             "value": "权限被拒绝"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation refusée"
+          }
         }
       }
     },
@@ -7147,6 +8341,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在重置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialisation"
           }
         }
       }
@@ -7184,6 +8384,12 @@
             "state": "translated",
             "value": "不支持"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non pris en charge"
+          }
         }
       }
     },
@@ -7219,6 +8425,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "广播"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annonces"
           }
         }
       }
@@ -7256,6 +8468,12 @@
             "state": "translated",
             "value": "标识符"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifiant"
+          }
         }
       }
     },
@@ -7291,6 +8509,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最后发现"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière apparition"
           }
         }
       }
@@ -7328,6 +8552,12 @@
             "state": "translated",
             "value": "平滑值"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lissé"
+          }
         }
       }
     },
@@ -7360,6 +8590,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dBm"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "dBm"
@@ -7400,6 +8636,12 @@
             "state": "translated",
             "value": "EMA"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EMA"
+          }
         }
       }
     },
@@ -7435,6 +8677,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "原始"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brut"
           }
         }
       }
@@ -7472,6 +8720,12 @@
             "state": "translated",
             "value": "平滑"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lissé"
+          }
         }
       }
     },
@@ -7507,6 +8761,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道%lld, %@, %@, 评分%lld/100"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal %lld, %@, %@, score %lld sur 100"
           }
         }
       }
@@ -7544,6 +8804,12 @@
             "state": "translated",
             "value": "按%@排序"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trier par %@"
+          }
         }
       }
     },
@@ -7579,6 +8845,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "● 当前"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "● Actuel"
           }
         }
       }
@@ -7616,6 +8888,12 @@
             "state": "translated",
             "value": "DFS/高级"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DFS/Avancé"
+          }
         }
       }
     },
@@ -7651,6 +8929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "★ 推荐"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "★ Recommandé"
           }
         }
       }
@@ -7688,6 +8972,12 @@
             "state": "translated",
             "value": "信道推荐现融入地区法规、DFS 要求及设备兼容性。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les recommandations de canaux intègrent désormais les réglementations régionales, les exigences DFS et la compatibilité des appareils."
+          }
         }
       }
     },
@@ -7723,6 +9013,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "· 相邻:"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· Adj :"
           }
         }
       }
@@ -7760,6 +9056,12 @@
             "state": "translated",
             "value": "同频:"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Co :"
+          }
         }
       }
     },
@@ -7795,6 +9097,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重叠"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "chevauchement"
           }
         }
       }
@@ -7832,6 +9140,12 @@
             "state": "translated",
             "value": "高级"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avancé"
+          }
         }
       }
     },
@@ -7867,6 +9181,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "推荐"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommandé"
           }
         }
       }
@@ -7904,6 +9224,12 @@
             "state": "translated",
             "value": "已限制"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restreint"
+          }
         }
       }
     },
@@ -7939,6 +9265,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "推荐"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rec"
           }
         }
       }
@@ -7976,6 +9308,12 @@
             "state": "translated",
             "value": "专业"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Professionnel"
+          }
         }
       }
     },
@@ -8011,6 +9349,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "简洁"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simple"
           }
         }
       }
@@ -8048,6 +9392,12 @@
             "state": "translated",
             "value": "高"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevé"
+          }
         }
       }
     },
@@ -8083,6 +9433,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "低"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible"
           }
         }
       }
@@ -8120,6 +9476,12 @@
             "state": "translated",
             "value": "繁忙"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Occupé"
+          }
         }
       }
     },
@@ -8155,6 +9517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "拥堵"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encombré"
           }
         }
       }
@@ -8192,6 +9560,12 @@
             "state": "translated",
             "value": "优秀"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excellent"
+          }
         }
       }
     },
@@ -8227,6 +9601,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一般"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correct"
           }
         }
       }
@@ -8264,6 +9644,12 @@
             "state": "translated",
             "value": "使用前需要进行信道检查"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessite une vérification du canal avant utilisation"
+          }
         }
       }
     },
@@ -8299,6 +9685,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "此信道上没有其他网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun autre réseau sur ce canal"
           }
         }
       }
@@ -8336,6 +9728,12 @@
             "state": "translated",
             "value": "附近网络较多 — 切换信道可能会提升速度"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beaucoup de réseaux à proximité — changer de canal peut améliorer la vitesse"
+          }
         }
       }
     },
@@ -8371,6 +9769,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "你当前使用的信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ton canal actuel"
           }
         }
       }
@@ -8408,6 +9812,12 @@
             "state": "translated",
             "value": "已在使用优质信道 — 无需更改"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déjà sur un excellent canal — aucun changement nécessaire"
+          }
         }
       }
     },
@@ -8443,6 +9853,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要雷达检测（偶尔会切换信道）"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilise la détection radar (peut occasionnellement changer de canal)"
           }
         }
       }
@@ -8480,6 +9896,12 @@
             "state": "translated",
             "value": "附近网络的干扰较强"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forte interférence des réseaux voisins"
+          }
         }
       }
     },
@@ -8515,6 +9937,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "与相邻信道重叠较多"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chevauchement important avec les canaux voisins"
           }
         }
       }
@@ -8552,6 +9980,12 @@
             "state": "translated",
             "value": "仅限室内使用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réservé à un usage intérieur uniquement"
+          }
         }
       }
     },
@@ -8587,6 +10021,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "此频段不如 2.4 GHz 拥挤"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette bande est moins encombrée que la 2,4 GHz"
           }
         }
       }
@@ -8624,6 +10064,12 @@
             "state": "translated",
             "value": "此信道上的设备较少"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peu d'appareils sur ce canal"
+          }
         }
       }
     },
@@ -8659,6 +10105,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无线干扰较低"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible interférence sans fil"
           }
         }
       }
@@ -8696,6 +10148,12 @@
             "state": "translated",
             "value": "与相邻信道的重叠较少"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chevauchement minimal avec les canaux voisins"
+          }
         }
       }
     },
@@ -8731,6 +10189,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "为什么推荐此信道？"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pourquoi ce canal ?"
           }
         }
       }
@@ -8768,6 +10232,12 @@
             "state": "translated",
             "value": "偶尔受雷达信号影响"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parfois affecté par les signaux radar"
+          }
         }
       }
     },
@@ -8803,6 +10273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "推荐信道标有星号，已通过地区法规和设备兼容性检查。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les canaux recommandés sont marqués d'une étoile et ont réussi les contrôles réglementaires et de compatibilité."
           }
         }
       }
@@ -8840,6 +10316,12 @@
             "state": "translated",
             "value": "信道推荐可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommandations de canaux disponibles"
+          }
         }
       }
     },
@@ -8875,6 +10357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "排除当前 AP 后，该信道已足够干净，WiFi Lens 不建议切换。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après avoir exclu ton AP actuel, ce canal est déjà assez propre, donc WiFi Lens ne recommande pas de changer."
           }
         }
       }
@@ -8912,6 +10400,12 @@
             "state": "translated",
             "value": "当前信道已足够好"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le canal actuel est déjà satisfaisant"
+          }
         }
       }
     },
@@ -8947,6 +10441,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "开始扫描以评估信道质量和推荐。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lance un scan pour évaluer la qualité du canal et les recommandations."
           }
         }
       }
@@ -8984,6 +10484,12 @@
             "state": "translated",
             "value": "暂无信道数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore de données de canal"
+          }
         }
       }
     },
@@ -9019,6 +10525,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在反事实评分下，没有允许的信道比当前信道高出至少 10 分。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun canal autorisé n'est au moins 10 points meilleur que le canal actuel selon la notation contrefactuelle."
           }
         }
       }
@@ -9056,6 +10568,12 @@
             "state": "translated",
             "value": "无显著更优的信道"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun canal nettement meilleur"
+          }
         }
       }
     },
@@ -9091,6 +10609,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一个或多个反事实候选信道因地区法规或设备兼容性检查而被降级。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un ou plusieurs candidats contrefactuels ont été rétrogradés par les règles régionales ou les contrôles de compatibilité."
           }
         }
       }
@@ -9128,6 +10652,12 @@
             "state": "translated",
             "value": "候选信道已被规则过滤"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Candidats filtrés par les règles"
+          }
         }
       }
     },
@@ -9163,6 +10693,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens 需要当前 AP 的标识以将其从反事实评分中排除。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens a besoin de l'identité de l'AP actuel pour l'exclure de la notation contrefactuelle."
           }
         }
       }
@@ -9200,6 +10736,12 @@
             "state": "translated",
             "value": "当前 AP 未识别"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP actuel non identifié"
+          }
         }
       }
     },
@@ -9235,6 +10777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "相邻"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adj"
           }
         }
       }
@@ -9272,6 +10820,12 @@
             "state": "translated",
             "value": "AP数"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP"
+          }
         }
       }
     },
@@ -9307,6 +10861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "频段"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bande"
           }
         }
       }
@@ -9344,6 +10904,12 @@
             "state": "translated",
             "value": "信道"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CH"
+          }
         }
       }
     },
@@ -9379,6 +10945,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "类别"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classe"
           }
         }
       }
@@ -9416,6 +10988,12 @@
             "state": "translated",
             "value": "同频"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Co-Ch"
+          }
         }
       }
     },
@@ -9451,6 +11029,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "干扰"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intf"
           }
         }
       }
@@ -9488,6 +11072,12 @@
             "state": "translated",
             "value": "等级"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niveau"
+          }
         }
       }
     },
@@ -9524,6 +11114,12 @@
             "state": "translated",
             "value": "重叠"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chevauchement"
+          }
         }
       }
     },
@@ -9556,6 +11152,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSI"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "RSSI"
@@ -9595,6 +11197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "评分"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Score"
           }
         }
       }
@@ -9706,6 +11314,12 @@
             "state": "translated",
             "value": "授权"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser l'accès"
+          }
         }
       }
     },
@@ -9741,6 +11355,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         }
       }
@@ -9778,6 +11398,12 @@
             "state": "translated",
             "value": "重新检查"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier à nouveau"
+          }
         }
       }
     },
@@ -9813,6 +11439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检查更新…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des mises à jour…"
           }
         }
       }
@@ -9850,6 +11482,12 @@
             "state": "translated",
             "value": "立即检查"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier maintenant"
+          }
         }
       }
     },
@@ -9885,6 +11523,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "清除"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
           }
         }
       }
@@ -9922,6 +11566,12 @@
             "state": "translated",
             "value": "关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer"
+          }
         }
       }
     },
@@ -9957,6 +11607,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "导出"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter"
           }
         }
       }
@@ -9994,6 +11650,12 @@
             "state": "translated",
             "value": "过滤"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer"
+          }
         }
       }
     },
@@ -10029,6 +11691,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "全部暂停"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout figer"
           }
         }
       }
@@ -10066,6 +11734,12 @@
             "state": "translated",
             "value": "忽略"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer"
+          }
         }
       }
     },
@@ -10101,6 +11775,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加载"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charger"
           }
         }
       }
@@ -10138,6 +11818,12 @@
             "state": "translated",
             "value": "打开蓝牙偏好设置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les réglages Bluetooth"
+          }
         }
       }
     },
@@ -10173,6 +11859,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开定位偏好设置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les réglages de localisation"
           }
         }
       }
@@ -10210,6 +11902,12 @@
             "state": "translated",
             "value": "打开定位偏好设置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les réglages de localisation"
+          }
         }
       }
     },
@@ -10245,6 +11943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开偏好设置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les réglages"
           }
         }
       }
@@ -10282,6 +11986,12 @@
             "state": "translated",
             "value": "打开系统设置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Réglages Système"
+          }
         }
       }
     },
@@ -10317,6 +12027,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remplacer"
           }
         }
       }
@@ -10354,6 +12070,12 @@
             "state": "translated",
             "value": "暂停"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
         }
       }
     },
@@ -10389,6 +12111,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "退出"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         }
       }
@@ -10426,6 +12154,12 @@
             "state": "translated",
             "value": "重置缩放"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser le zoom"
+          }
         }
       }
     },
@@ -10461,6 +12195,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "恢复"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre"
           }
         }
       }
@@ -10498,6 +12238,12 @@
             "state": "translated",
             "value": "在 Finder 中显示日志"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les journaux dans le Finder"
+          }
         }
       }
     },
@@ -10533,6 +12279,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
           }
         }
       }
@@ -10570,6 +12322,12 @@
             "state": "translated",
             "value": "设置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages"
+          }
         }
       }
     },
@@ -10605,6 +12363,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "设置…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages…"
           }
         }
       }
@@ -10642,6 +12406,12 @@
             "state": "translated",
             "value": "开始"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer"
+          }
         }
       }
     },
@@ -10677,6 +12447,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "停止"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter"
           }
         }
       }
@@ -10714,6 +12490,12 @@
             "state": "translated",
             "value": "切换展开"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agrandir/réduire"
+          }
         }
       }
     },
@@ -10748,6 +12530,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "实验性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expérimental"
           }
         }
       }
@@ -10784,6 +12572,12 @@
             "state": "translated",
             "value": "预览"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu"
+          }
         }
       }
     },
@@ -10815,6 +12609,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Pro"
@@ -10855,6 +12655,12 @@
             "state": "translated",
             "value": "暂无图表数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore de données de graphique"
+          }
         }
       }
     },
@@ -10890,6 +12696,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无 Wi-Fi 连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune connexion Wi-Fi"
           }
         }
       }
@@ -10927,6 +12739,12 @@
             "state": "translated",
             "value": "扫描失败"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du scan"
+          }
         }
       }
     },
@@ -10962,6 +12780,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wi-Fi 扫描失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du scan Wi-Fi"
           }
         }
       }
@@ -10999,6 +12823,12 @@
             "state": "translated",
             "value": "正在收集数据…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collecte des données…"
+          }
         }
       }
     },
@@ -11034,6 +12864,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
           }
         }
       }
@@ -11071,6 +12907,12 @@
             "state": "translated",
             "value": "连接"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion"
+          }
         }
       }
     },
@@ -11106,6 +12948,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "深色"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sombre"
           }
         }
       }
@@ -11143,6 +12991,12 @@
             "state": "translated",
             "value": "被拒绝"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refusé"
+          }
         }
       }
     },
@@ -11178,6 +13032,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "详情"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails"
           }
         }
       }
@@ -11215,6 +13075,12 @@
             "state": "translated",
             "value": "未连接"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecté"
+          }
         }
       }
     },
@@ -11250,6 +13116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "下载"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger"
           }
         }
       }
@@ -11287,6 +13159,12 @@
             "state": "translated",
             "value": "首次"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premier"
+          }
         }
       }
     },
@@ -11322,6 +13200,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "通用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
           }
         }
       }
@@ -11359,6 +13243,12 @@
             "state": "translated",
             "value": "已授予"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accordé"
+          }
         }
       }
     },
@@ -11394,6 +13284,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最近"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus récent"
           }
         }
       }
@@ -11431,6 +13327,12 @@
             "state": "translated",
             "value": "浅色"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clair"
+          }
         }
       }
     },
@@ -11466,6 +13368,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加载中…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement..."
           }
         }
       }
@@ -11503,6 +13411,12 @@
             "state": "translated",
             "value": "名称"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
+          }
         }
       }
     },
@@ -11537,6 +13451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "réseaux"
           }
         }
       }
@@ -11574,6 +13494,12 @@
             "state": "translated",
             "value": "无"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun"
+          }
         }
       }
     },
@@ -11609,6 +13535,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "现在"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "maintenant"
           }
         }
       }
@@ -11646,6 +13578,12 @@
             "state": "translated",
             "value": "等待中"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente"
+          }
         }
       }
     },
@@ -11681,6 +13619,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "就绪"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prêt"
           }
         }
       }
@@ -11718,6 +13662,12 @@
             "state": "translated",
             "value": "必需"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requis"
+          }
         }
       }
     },
@@ -11753,6 +13703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "个样本"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "échantillons"
           }
         }
       }
@@ -11790,6 +13746,12 @@
             "state": "translated",
             "value": "采样数"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échantillons"
+          }
         }
       }
     },
@@ -11825,6 +13787,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "扫描中"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan"
           }
         }
       }
@@ -11862,6 +13830,12 @@
             "state": "translated",
             "value": "跟随系统"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Système"
+          }
         }
       }
     },
@@ -11897,6 +13871,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "次切换"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "transitions"
           }
         }
       }
@@ -11934,6 +13914,12 @@
             "state": "translated",
             "value": "未知"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnu"
+          }
         }
       }
     },
@@ -11970,6 +13956,12 @@
             "state": "translated",
             "value": "上传"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer"
+          }
         }
       }
     },
@@ -12005,6 +13997,12 @@
             "state": "translated",
             "value": "%lld 个样本"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld échantillons"
+          }
         }
       }
     },
@@ -12036,6 +14034,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi_Spectrum_Snapshot"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "WiFi_Spectrum_Snapshot"
@@ -12075,6 +14079,12 @@
             "state": "translated",
             "value": "图像编码失败。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'encodage de l'image."
+          }
         }
       }
     },
@@ -12109,6 +14119,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有可见的频段可导出。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune bande visible à exporter."
           }
         }
       }
@@ -12145,6 +14161,12 @@
             "state": "translated",
             "value": "图表渲染失败。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du rendu du graphique."
+          }
         }
       }
     },
@@ -12179,6 +14201,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法导出: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'exporter : %@"
           }
         }
       }
@@ -12215,6 +14243,12 @@
             "state": "translated",
             "value": "导出失败"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'export"
+          }
         }
       }
     },
@@ -12249,6 +14283,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "图表图像已成功导出。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image du graphique exportée avec succès."
           }
         }
       }
@@ -12285,6 +14325,12 @@
             "state": "translated",
             "value": "Markdown 报告已成功导出。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapport Markdown exporté avec succès."
+          }
         }
       }
     },
@@ -12319,6 +14365,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "应用版本"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version de l'app"
           }
         }
       }
@@ -12355,6 +14407,12 @@
             "state": "translated",
             "value": "导出时间"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporté"
+          }
         }
       }
     },
@@ -12389,6 +14447,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络列表"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liste des réseaux"
           }
         }
       }
@@ -12425,6 +14489,12 @@
             "state": "translated",
             "value": "无可用网络。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun réseau disponible."
+          }
         }
       }
     },
@@ -12459,6 +14529,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens — 频谱快照"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens — Instantané du spectre"
           }
         }
       }
@@ -12495,6 +14571,12 @@
             "state": "translated",
             "value": "导出完成"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export terminé"
+          }
         }
       }
     },
@@ -12529,6 +14611,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "导出频谱图为图像…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter le graphique en image..."
           }
         }
       }
@@ -12565,6 +14653,12 @@
             "state": "translated",
             "value": "导出为 Markdown 报告…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter en rapport Markdown..."
+          }
         }
       }
     },
@@ -12599,6 +14693,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "快照已成功导出"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantané exporté avec succès"
           }
         }
       }
@@ -12890,6 +14990,12 @@
             "state": "translated",
             "value": "%lld 分钟前"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il y a %lld min"
+          }
         }
       }
     },
@@ -12925,6 +15031,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld/100 · %2$lld 个附近网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld/100 · %2$lld à proximité"
           }
         }
       }
@@ -13049,6 +15161,12 @@
             "state": "translated",
             "value": "%lld 个样本"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld échantillons"
+          }
         }
       }
     },
@@ -13158,6 +15276,12 @@
             "state": "translated",
             "value": "%lld 秒前"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il y a %lld s"
+          }
         }
       }
     },
@@ -13192,6 +15316,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不再显示"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus afficher"
           }
         }
       }
@@ -13228,6 +15358,12 @@
             "state": "translated",
             "value": "稍后"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus tard"
+          }
         }
       }
     },
@@ -13262,6 +15398,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "本次诊断反映了当前的网络状态。WiFi Lens Pro 可以保留随时间发生的变化，帮助识别间歇性问题与长期趋势。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce diagnostic reflète l'état actuel du réseau. WiFi Lens Pro peut conserver les changements dans le temps et aider à identifier les problèmes intermittents et les tendances à long terme."
           }
         }
       }
@@ -13298,6 +15440,12 @@
             "state": "translated",
             "value": "此快照记录了当前的网络状态。WiFi Lens Pro 可以保留随时间发生的变化，帮助识别间歇性问题与长期趋势。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cet instantané capture l'état actuel du réseau. WiFi Lens Pro peut conserver les changements dans le temps et aider à identifier les problèmes intermittents et les tendances à long terme."
+          }
         }
       }
     },
@@ -13332,6 +15480,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "探索 WiFi Lens Pro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Découvrir WiFi Lens Pro"
           }
         }
       }
@@ -13368,6 +15522,12 @@
             "state": "translated",
             "value": "查看 WiFi Lens Pro"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir WiFi Lens Pro"
+          }
         }
       }
     },
@@ -13402,6 +15562,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 个接口"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld interfaces"
           }
         }
       }
@@ -13439,6 +15605,12 @@
             "state": "translated",
             "value": "未找到网络接口"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune interface réseau trouvée"
+          }
         }
       }
     },
@@ -13475,6 +15647,12 @@
             "state": "translated",
             "value": "选择下方接口以监听吞吐量"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne une interface ci-dessous pour surveiller le débit"
+          }
         }
       }
     },
@@ -13507,6 +15685,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "BSSID"
@@ -13547,6 +15731,12 @@
             "state": "translated",
             "value": "信道 %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal %@"
+          }
         }
       }
     },
@@ -13583,6 +15773,12 @@
             "state": "translated",
             "value": "DNS"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS"
+          }
         }
       }
     },
@@ -13614,6 +15810,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1f ms"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%.1f ms"
@@ -13654,6 +15856,12 @@
             "state": "translated",
             "value": "硬件 MAC"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC matérielle"
+          }
         }
       }
     },
@@ -13686,6 +15894,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv4"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "IPv4"
@@ -13726,6 +15940,12 @@
             "state": "translated",
             "value": "IPv4 地址"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adresse IPv4"
+          }
         }
       }
     },
@@ -13758,6 +15978,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "k / r / v"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "k / r / v"
@@ -13798,6 +16024,12 @@
             "state": "translated",
             "value": "MAC"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAC"
+          }
         }
       }
     },
@@ -13830,6 +16062,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MCS / NSS"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "MCS / NSS"
@@ -13907,6 +16145,12 @@
             "state": "translated",
             "value": "PHY"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PHY"
+          }
         }
       }
     },
@@ -13942,6 +16186,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "PHY 模式"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode PHY"
           }
         }
       }
@@ -13979,6 +16229,12 @@
             "state": "translated",
             "value": "路由器"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routeur"
+          }
         }
       }
     },
@@ -14014,6 +16270,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "稳定性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stabilité"
           }
         }
       }
@@ -14051,6 +16313,12 @@
             "state": "translated",
             "value": "子网"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sous-réseau"
+          }
         }
       }
     },
@@ -14086,6 +16354,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "子网掩码"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masque de sous-réseau"
           }
         }
       }
@@ -14123,6 +16397,12 @@
             "state": "translated",
             "value": "吞吐量"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Débit"
+          }
         }
       }
     },
@@ -14158,6 +16438,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "发送速率"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Débit Tx"
           }
         }
       }
@@ -14195,6 +16481,12 @@
             "state": "translated",
             "value": "以太网"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ethernet"
+          }
         }
       }
     },
@@ -14230,6 +16522,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "个接口"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "interfaces"
           }
         }
       }
@@ -14267,6 +16565,12 @@
             "state": "translated",
             "value": "其他接口"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autres interfaces"
+          }
         }
       }
     },
@@ -14302,6 +16606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "SSID 不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID indisponible"
           }
         }
       }
@@ -14339,6 +16649,12 @@
             "state": "translated",
             "value": "虚拟"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virtuelle"
+          }
         }
       }
     },
@@ -14371,6 +16687,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi‑Fi"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Wi‑Fi"
@@ -14411,6 +16733,12 @@
             "state": "translated",
             "value": "监听"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surveillance"
+          }
         }
       }
     },
@@ -14446,6 +16774,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开 WiFi Lens"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir WiFi Lens"
           }
         }
       }
@@ -14483,6 +16817,12 @@
             "state": "translated",
             "value": "立即刷新"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiser"
+          }
         }
       }
     },
@@ -14518,6 +16858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "查看全部"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout afficher"
           }
         }
       }
@@ -14555,6 +16901,12 @@
             "state": "translated",
             "value": "未连接 Wi-Fi"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune connexion Wi-Fi"
+          }
         }
       }
     },
@@ -14590,6 +16942,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已断开"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecté"
           }
         }
       }
@@ -14627,6 +16985,12 @@
             "state": "translated",
             "value": "延迟飙升"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pic de latence"
+          }
         }
       }
     },
@@ -14662,6 +17026,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已重连"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecté"
           }
         }
       }
@@ -14699,6 +17069,12 @@
             "state": "translated",
             "value": "漫游"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance"
+          }
         }
       }
     },
@@ -14734,6 +17110,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号下降"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal affaibli"
           }
         }
       }
@@ -14771,6 +17153,12 @@
             "state": "translated",
             "value": "最近一小时无事件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement dans la dernière heure"
+          }
         }
       }
     },
@@ -14806,6 +17194,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "最近事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événements récents"
           }
         }
       }
@@ -14843,6 +17237,12 @@
             "state": "translated",
             "value": "信道"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal"
+          }
         }
       }
     },
@@ -14878,6 +17278,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passerelle"
           }
         }
       }
@@ -14915,6 +17321,12 @@
             "state": "translated",
             "value": "质量"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualité"
+          }
         }
       }
     },
@@ -14951,6 +17363,12 @@
             "state": "translated",
             "value": "信号"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal"
+          }
         }
       }
     },
@@ -14983,6 +17401,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "SSID"
@@ -15023,6 +17447,12 @@
             "state": "translated",
             "value": "高延迟"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevée"
+          }
         }
       }
     },
@@ -15058,6 +17488,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正常"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normale"
           }
         }
       }
@@ -15095,6 +17531,12 @@
             "state": "translated",
             "value": "一般"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correcte"
+          }
         }
       }
     },
@@ -15130,6 +17572,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "良好"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonne"
           }
         }
       }
@@ -15167,6 +17615,12 @@
             "state": "translated",
             "value": "差"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mauvaise"
+          }
         }
       }
     },
@@ -15202,6 +17656,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "良好"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bon"
           }
         }
       }
@@ -15239,6 +17699,12 @@
             "state": "translated",
             "value": "中等"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modéré"
+          }
         }
       }
     },
@@ -15274,6 +17740,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "强"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fort"
           }
         }
       }
@@ -15311,6 +17783,12 @@
             "state": "translated",
             "value": "弱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible"
+          }
         }
       }
     },
@@ -15346,6 +17824,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "收集中…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collecte des données..."
           }
         }
       }
@@ -15383,6 +17867,12 @@
             "state": "translated",
             "value": "下降"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dégradation"
+          }
         }
       }
     },
@@ -15418,6 +17908,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "高延迟"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevé"
           }
         }
       }
@@ -15455,6 +17951,12 @@
             "state": "translated",
             "value": "改善"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amélioration"
+          }
         }
       }
     },
@@ -15490,6 +17992,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "延迟趋势"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance de latence"
           }
         }
       }
@@ -15527,6 +18035,12 @@
             "state": "translated",
             "value": "正常"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
         }
       }
     },
@@ -15562,6 +18076,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号趋势"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance du signal"
           }
         }
       }
@@ -15599,6 +18119,12 @@
             "state": "translated",
             "value": "稳定"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stable"
+          }
         }
       }
     },
@@ -15634,6 +18160,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AP 雷达"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP Radar"
           }
         }
       }
@@ -15671,6 +18203,12 @@
             "state": "translated",
             "value": "蓝牙"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth"
+          }
         }
       }
     },
@@ -15706,6 +18244,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canaux"
           }
         }
       }
@@ -15743,6 +18287,12 @@
             "state": "translated",
             "value": "调试图表"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique de débogage"
+          }
         }
       }
     },
@@ -15778,6 +18328,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "帮助"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aide"
           }
         }
       }
@@ -15815,6 +18371,12 @@
             "state": "translated",
             "value": "帮助中心"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centre d'aide"
+          }
         }
       }
     },
@@ -15849,6 +18411,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "洞察"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyses"
           }
         }
       }
@@ -15886,6 +18454,12 @@
             "state": "translated",
             "value": "接口"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaces"
+          }
         }
       }
     },
@@ -15920,6 +18494,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络自检"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic réseau"
           }
         }
       }
@@ -15957,6 +18537,12 @@
             "state": "translated",
             "value": "网络信息"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Infos réseau"
+          }
         }
       }
     },
@@ -15992,6 +18578,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络列表"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tableau des réseaux"
           }
         }
       }
@@ -16029,6 +18621,12 @@
             "state": "translated",
             "value": "概览"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vue d'ensemble"
+          }
         }
       }
     },
@@ -16064,6 +18662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "漫游测试"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test d'itinérance"
           }
         }
       }
@@ -16101,6 +18705,12 @@
             "state": "translated",
             "value": "频谱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spectre"
+          }
         }
       }
     },
@@ -16137,6 +18747,12 @@
             "state": "translated",
             "value": "频谱图调试图表"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique de débogage du spectre"
+          }
         }
       }
     },
@@ -16171,6 +18787,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "统计"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques"
           }
         }
       }
@@ -16208,6 +18830,12 @@
             "state": "translated",
             "value": "时间线"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chronologie"
+          }
         }
       }
     },
@@ -16242,6 +18870,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "开始检测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer le diagnostic"
           }
         }
       }
@@ -16278,6 +18912,12 @@
             "state": "translated",
             "value": "重新检测"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer"
+          }
         }
       }
     },
@@ -16312,6 +18952,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion réseau"
           }
         }
       }
@@ -16348,6 +18994,12 @@
             "state": "translated",
             "value": "DNS 解析"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résolution DNS"
+          }
         }
       }
     },
@@ -16382,6 +19034,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关可达性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Joignabilité de la passerelle"
           }
         }
       }
@@ -16418,6 +19076,12 @@
             "state": "translated",
             "value": "互联网访问"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès Internet"
+          }
         }
       }
     },
@@ -16452,6 +19116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "IPv6 访问"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès IPv6"
           }
         }
       }
@@ -16488,6 +19158,12 @@
             "state": "translated",
             "value": "系统网络路径"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin réseau système"
+          }
         }
       }
     },
@@ -16522,6 +19198,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "系统代理"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy système"
           }
         }
       }
@@ -16558,6 +19240,12 @@
             "state": "translated",
             "value": "请检查下方标记为需要注意的检测结果。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passe en revue tout résultat signalé ci-dessous."
+          }
         }
       }
     },
@@ -16592,6 +19280,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要注意"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessite une attention"
           }
         }
       }
@@ -16628,6 +19322,12 @@
             "state": "translated",
             "value": "所有检测均已完成，未发现问题。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les contrôles se sont terminés sans détecter de problème."
+          }
         }
       }
     },
@@ -16662,6 +19362,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络正常"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau normal"
           }
         }
       }
@@ -16698,6 +19404,12 @@
             "state": "translated",
             "value": "此 Mac 当前没有可用的网络连接。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce Mac n'a actuellement pas de connexion réseau fonctionnelle."
+          }
         }
       }
     },
@@ -16732,6 +19444,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau indisponible"
           }
         }
       }
@@ -16768,6 +19486,12 @@
             "state": "translated",
             "value": "未连接到可用网络，请检查 Wi-Fi 或网线"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune connexion réseau disponible. Vérifie le Wi-Fi ou l'Ethernet"
+          }
         }
       }
     },
@@ -16802,6 +19526,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "暂时无法确认网络连接状态，请稍后重试"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion réseau n'a pas pu être confirmée. Réessaie plus tard"
           }
         }
       }
@@ -16838,6 +19568,12 @@
             "state": "translated",
             "value": "连接可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion disponible"
+          }
         }
       }
     },
@@ -16872,6 +19608,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检查此 Mac 的网络连接、DNS 解析和系统代理设置。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifie la connexion réseau de ce Mac, la résolution DNS et les réglages du proxy système."
           }
         }
       }
@@ -16908,6 +19650,12 @@
             "state": "translated",
             "value": "路由器"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routeur"
+          }
         }
       }
     },
@@ -16942,6 +19690,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法解析域名，部分网站可能无法打开；请检查 DNS 设置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les noms de domaine ne peuvent pas être résolus, certains sites peuvent donc ne pas s'ouvrir. Vérifie les réglages DNS"
           }
         }
       }
@@ -16978,6 +19732,12 @@
             "state": "translated",
             "value": "DNS 解析可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La résolution DNS est disponible"
+          }
         }
       }
     },
@@ -17012,6 +19772,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "各测试域名的 DNS 解析结果不一致"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La résolution DNS n'est pas cohérente entre les noms de test"
           }
         }
       }
@@ -17048,6 +19814,12 @@
             "state": "translated",
             "value": "暂时无法完成 DNS 检查，请稍后重试"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le contrôle DNS n'a pas pu être terminé. Réessaie plus tard"
+          }
         }
       }
     },
@@ -17082,6 +19854,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "域名解析正常"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La résolution des noms de domaine fonctionne"
           }
         }
       }
@@ -17118,6 +19896,12 @@
             "state": "translated",
             "value": "无法确定 DNS 结果"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le résultat DNS n'a pas pu être déterminé"
+          }
         }
       }
     },
@@ -17152,6 +19936,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "所有测试域名的 DNS 解析均失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La résolution DNS a échoué pour tous les noms de test"
           }
         }
       }
@@ -17188,6 +19978,12 @@
             "state": "translated",
             "value": "网关不可达"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passerelle injoignable"
+          }
         }
       }
     },
@@ -17222,6 +20018,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关状态未知"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Joignabilité de la passerelle inconnue"
           }
         }
       }
@@ -17258,6 +20060,12 @@
             "state": "translated",
             "value": "网关可达"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passerelle joignable"
+          }
         }
       }
     },
@@ -17292,6 +20100,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一个或多个控制端点响应与预期结果不符。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une ou plusieurs réponses du point de contrôle ne correspondent pas au résultat attendu."
           }
         }
       }
@@ -17328,6 +20142,12 @@
             "state": "translated",
             "value": "控制端点检查需要注意"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les contrôles du point de contrôle nécessitent une attention"
+          }
         }
       }
     },
@@ -17362,6 +20182,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "当前系统时间不在 HTTPS 证书的有效期内"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le certificat HTTPS n'est pas valide pour l'heure système actuelle"
           }
         }
       }
@@ -17398,6 +20224,12 @@
             "state": "translated",
             "value": "无法建立直接 HTTPS 连接"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion HTTPS directe n'a pas pu être établie"
+          }
         }
       }
     },
@@ -17432,6 +20264,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "HTTPS 访问成功，但强制门户控制端点未在规定时间内响应。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'accès HTTPS a réussi, mais le point de contrôle du portail captif n'a pas répondu à temps."
           }
         }
       }
@@ -17468,6 +20306,12 @@
             "state": "translated",
             "value": "控制端点检查结果无法确定"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le contrôle du point de contrôle n'est pas concluant"
+          }
         }
       }
     },
@@ -17502,6 +20346,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "HTTPS 请求成功，强制门户控制响应符合预期。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La requête HTTPS a réussi et la réponse du point de contrôle correspondait."
           }
         }
       }
@@ -17538,6 +20388,12 @@
             "state": "translated",
             "value": "已验证 HTTPS 访问"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès HTTPS vérifié"
+          }
         }
       }
     },
@@ -17572,6 +20428,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "HTTPS 连接在 TLS 或证书验证期间失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion HTTPS a échoué lors de la validation TLS ou du certificat"
           }
         }
       }
@@ -17608,6 +20470,12 @@
             "state": "translated",
             "value": "无法验证通过 IPv6 的 HTTPS 访问。IPv4 访问可能仍然可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'accès HTTPS IPv6 n'a pas pu être vérifié. L'accès IPv4 peut encore fonctionner"
+          }
         }
       }
     },
@@ -17642,6 +20510,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已验证通过 IPv6 的 HTTPS 访问"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès HTTPS IPv6 vérifié"
           }
         }
       }
@@ -17678,6 +20552,12 @@
             "state": "translated",
             "value": "没有可用的全局 IPv6 地址，因此跳过了可选的 IPv6 检查"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune adresse IPv6 globale n'est disponible, le contrôle IPv6 facultatif a donc été ignoré"
+          }
         }
       }
     },
@@ -17712,6 +20592,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有可用的系统网络路径。请检查 Wi-Fi 或以太网"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun chemin réseau système disponible. Vérifie le Wi-Fi ou l'Ethernet"
           }
         }
       }
@@ -17748,6 +20634,12 @@
             "state": "translated",
             "value": "暂时无法确认系统网络路径，请稍后重试"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin réseau système n'a pas pu être confirmé. Réessaie plus tard"
+          }
         }
       }
     },
@@ -17782,6 +20674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "系统网络路径可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin réseau système est disponible"
           }
         }
       }
@@ -17818,6 +20716,12 @@
             "state": "translated",
             "value": "系统代理无法连接，可能导致网页无法访问；请检查或关闭代理设置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le proxy système est injoignable et peut empêcher l'ouverture de sites. Vérifie ou désactive les réglages du proxy"
+          }
         }
       }
     },
@@ -17852,6 +20756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "测试的代理路由需要身份验证"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une route proxy testée nécessite une authentification"
           }
         }
       }
@@ -17888,6 +20798,12 @@
             "state": "translated",
             "value": "检测到自动代理配置，但未进行评估。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une configuration de proxy automatique a été détectée et n'a pas été évaluée."
+          }
         }
       }
     },
@@ -17922,6 +20838,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "测试的 HTTP 和 HTTPS 路由使用直接连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les routes HTTP et HTTPS testées utilisent des connexions directes"
           }
         }
       }
@@ -17958,6 +20880,12 @@
             "state": "translated",
             "value": "未使用系统代理"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy système non utilisé"
+          }
         }
       }
     },
@@ -17992,6 +20920,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "所选代理无法访问控制端点"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le proxy sélectionné ne peut pas atteindre le point de contrôle"
           }
         }
       }
@@ -18028,6 +20962,12 @@
             "state": "translated",
             "value": "所选代理端点不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le point de terminaison du proxy sélectionné est indisponible"
+          }
         }
       }
     },
@@ -18062,6 +21002,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法完整确认系统代理是否可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le proxy système n'a pas pu être entièrement vérifié"
           }
         }
       }
@@ -18098,6 +21044,12 @@
             "state": "translated",
             "value": "测试的 HTTP 和 HTTPS 路由使用不同的代理路径"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les routes HTTP et HTTPS testées utilisent des chemins de proxy différents"
+          }
         }
       }
     },
@@ -18132,6 +21084,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "系统代理可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy système disponible"
           }
         }
       }
@@ -18168,6 +21126,12 @@
             "state": "translated",
             "value": "自动代理配置不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La configuration automatique du proxy est indisponible"
+          }
         }
       }
     },
@@ -18202,6 +21166,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "测试的代理路由不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une route proxy testée est indisponible"
           }
         }
       }
@@ -18238,6 +21208,12 @@
             "state": "translated",
             "value": "测试的代理路由可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les routes proxy testées sont disponibles"
+          }
         }
       }
     },
@@ -18272,6 +21248,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检测到活跃的虚拟网络接口"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface réseau virtuelle active détectée"
           }
         }
       }
@@ -18308,6 +21290,12 @@
             "state": "translated",
             "value": "通过虚拟网卡路由"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routage via une interface réseau virtuelle"
+          }
         }
       }
     },
@@ -18342,6 +21330,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法确定测试的代理路由"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de déterminer les routes proxy testées"
           }
         }
       }
@@ -18378,6 +21372,12 @@
             "state": "translated",
             "value": "运行诊断以检查此 Mac 的网络，结果将显示在这里。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lance le diagnostic pour vérifier le réseau de ce Mac. Les résultats apparaîtront ici."
+          }
         }
       }
     },
@@ -18412,6 +21412,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "打开浏览器并完成网络登录。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre un navigateur et termine la connexion au réseau."
           }
         }
       }
@@ -18448,6 +21454,12 @@
             "state": "translated",
             "value": "网络门户可能正在拦截网页访问。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le réseau peut exiger une connexion via un portail captif."
+          }
         }
       }
     },
@@ -18482,6 +21494,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络可能需要登录。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le réseau peut nécessiter une connexion."
           }
         }
       }
@@ -18518,6 +21536,12 @@
             "state": "translated",
             "value": "开启自动设置日期和时间，然后重新运行检查。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active la date et l'heure automatiques, puis relance le contrôle."
+          }
         }
       }
     },
@@ -18552,6 +21576,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mac 的日期或时间可能不正确。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La date ou l'heure du Mac peut être incorrecte."
           }
         }
       }
@@ -18588,6 +21618,12 @@
             "state": "translated",
             "value": "安全连接的证书时间无效。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La date du certificat de la connexion sécurisée est invalide."
+          }
         }
       }
     },
@@ -18622,6 +21658,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新连接网络，或尝试其他 DNS 配置。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecte-toi au réseau ou essaie une autre configuration DNS."
           }
         }
       }
@@ -18658,6 +21700,12 @@
             "state": "translated",
             "value": "当前网络或 DNS 配置可能没有响应。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le réseau ou la configuration DNS actuelle peut ne pas répondre."
+          }
         }
       }
     },
@@ -18692,6 +21740,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "域名解析不可用。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La résolution de noms est indisponible."
           }
         }
       }
@@ -18728,6 +21782,12 @@
             "state": "translated",
             "value": "检查网络设置，然后重新运行检查。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifie les réglages réseau et relance le contrôle."
+          }
         }
       }
     },
@@ -18762,6 +21822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "结果指向网络配置或连接问题。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le résultat pointe vers un problème de configuration ou de connectivité réseau."
           }
         }
       }
@@ -18798,6 +21864,12 @@
             "state": "translated",
             "value": "网络检查发现了问题。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce contrôle réseau a détecté un problème."
+          }
         }
       }
     },
@@ -18832,6 +21904,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检查网络设置，然后重新运行检查。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifie les réglages réseau, puis relance le contrôle."
           }
         }
       }
@@ -18868,6 +21946,12 @@
             "state": "translated",
             "value": "现有证据不足，无法确认单一原因。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les preuves disponibles ne sont pas concluantes, aucune cause unique ne peut donc être confirmée."
+          }
         }
       }
     },
@@ -18902,6 +21986,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法确认此项检查。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce contrôle n'a pas pu être confirmé."
           }
         }
       }
@@ -18938,6 +22028,12 @@
             "state": "translated",
             "value": "重新连接网络，然后再次运行检查。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecte le réseau, puis relance le contrôle."
+          }
         }
       }
     },
@@ -18972,6 +22068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wi-Fi、以太网或选中的网络服务可能已断开。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le Wi-Fi, l'Ethernet ou le service réseau sélectionné peuvent être déconnectés."
           }
         }
       }
@@ -19008,6 +22110,12 @@
             "state": "translated",
             "value": "Mac 没有可用的网络路径。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le Mac n'a pas de chemin réseau utilisable."
+          }
         }
       }
     },
@@ -19042,6 +22150,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检查代理凭据，或重新登录。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifie les identifiants du proxy ou reconnecte-toi."
           }
         }
       }
@@ -19078,6 +22192,12 @@
             "state": "translated",
             "value": "代理凭据可能未设置或已过期。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les identifiants du proxy peuvent être manquants ou expirés."
+          }
         }
       }
     },
@@ -19112,6 +22232,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "代理要求登录。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le proxy a demandé une connexion."
           }
         }
       }
@@ -19148,6 +22274,12 @@
             "state": "translated",
             "value": "启动代理应用，或禁用失效的系统代理。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarre l'app de proxy ou désactive le proxy système obsolète."
+          }
         }
       }
     },
@@ -19182,6 +22314,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "代理应用可能已停止，或旧代理设置仍处于开启状态。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'app de proxy peut être arrêtée, ou un ancien réglage de proxy peut rester actif."
           }
         }
       }
@@ -19218,6 +22356,12 @@
             "state": "translated",
             "value": "无法访问已配置的代理路径。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une route proxy configurée n'a pas pu être atteinte."
+          }
         }
       }
     },
@@ -19252,6 +22396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "完成更改后，再次运行网络自检。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relance l'auto-contrôle réseau après avoir effectué le changement."
           }
         }
       }
@@ -19288,6 +22438,12 @@
             "state": "translated",
             "value": "检查项目"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôle"
+          }
         }
       }
     },
@@ -19322,6 +22478,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "结果"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résultat"
           }
         }
       }
@@ -19358,6 +22520,12 @@
             "state": "translated",
             "value": "状态"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut"
+          }
         }
       }
     },
@@ -19392,6 +22560,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "附加检测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôles supplémentaires"
           }
         }
       }
@@ -19428,6 +22602,12 @@
             "state": "translated",
             "value": "互联网"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet"
+          }
         }
       }
     },
@@ -19462,6 +22642,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "局域网连通性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LAN"
           }
         }
       }
@@ -19498,6 +22684,12 @@
             "state": "translated",
             "value": "本机环境"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce Mac"
+          }
         }
       }
     },
@@ -19532,6 +22724,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "检测中…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification…"
           }
         }
       }
@@ -19568,6 +22766,12 @@
             "state": "translated",
             "value": "检测完成"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contrôle terminé"
+          }
         }
       }
     },
@@ -19602,6 +22806,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待检测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente d'exécution"
           }
         }
       }
@@ -19638,6 +22848,12 @@
             "state": "translated",
             "value": "异常"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anormal"
+          }
         }
       }
     },
@@ -19672,6 +22888,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已阻止"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqué"
           }
         }
       }
@@ -19708,6 +22930,12 @@
             "state": "translated",
             "value": "无法判断"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indéterminé"
+          }
         }
       }
     },
@@ -19743,6 +22971,12 @@
             "state": "translated",
             "value": "正常"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
         }
       }
     },
@@ -19777,6 +23011,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已跳过"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoré"
           }
         }
       }
@@ -19814,6 +23054,12 @@
             "state": "translated",
             "value": "信道 %1$lld 附近有 %2$lld 个 AP。建议考虑 %3$@。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le canal %1$lld compte %2$lld AP proches. Envisage %3$@."
+          }
         }
       }
     },
@@ -19849,6 +23095,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道拥挤"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal encombré"
           }
         }
       }
@@ -19886,6 +23138,12 @@
             "state": "translated",
             "value": "信号强、信道干净，并使用 WPA3 安全性。你正在获得最佳体验。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal fort, canal propre et sécurité WPA3. Tu profites de la meilleure expérience."
+          }
         }
       }
     },
@@ -19921,6 +23179,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "你的连接状态很好"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta connexion est excellente"
           }
         }
       }
@@ -19958,6 +23222,12 @@
             "state": "translated",
             "value": "当前信道还有改善空间。请尝试切换到较不拥挤的信道。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ton canal pourrait être amélioré. Essaie de passer à un canal moins encombré."
+          }
         }
       }
     },
@@ -19993,6 +23263,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道质量一般"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualité de canal médiocre"
           }
         }
       }
@@ -20030,6 +23306,12 @@
             "state": "translated",
             "value": "靠近路由器或切换信道可能会改善连接。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu pourrais améliorer ta connexion en te rapprochant du routeur ou en changeant de canal."
+          }
         }
       }
     },
@@ -20065,6 +23347,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "连接正常"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion est correcte"
           }
         }
       }
@@ -20102,6 +23390,12 @@
             "state": "translated",
             "value": "你正在使用 Wi‑Fi %1$@。建议升级到 Wi‑Fi 6 或 7 以获得更快速度。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu es en Wi‑Fi %1$@. Envisage de passer au Wi‑Fi 6 ou 7 pour des vitesses plus rapides."
+          }
         }
       }
     },
@@ -20137,6 +23431,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "较旧的 Wi‑Fi 世代"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancienne génération Wi‑Fi"
           }
         }
       }
@@ -20174,6 +23474,12 @@
             "state": "translated",
             "value": "你的网络使用 %1$@。建议升级到 WPA3 以提高安全性。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ton réseau utilise %1$@. Passe à WPA3 pour une meilleure sécurité."
+          }
         }
       }
     },
@@ -20209,6 +23515,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "安全警告"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement de sécurité"
           }
         }
       }
@@ -20246,6 +23558,12 @@
             "state": "translated",
             "value": "无法确定连接质量。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de déterminer la qualité de la connexion."
+          }
         }
       }
     },
@@ -20281,6 +23599,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未知"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnu"
           }
         }
       }
@@ -20318,6 +23642,12 @@
             "state": "translated",
             "value": "请尝试靠近接入点，或移除障碍物。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essaie de te rapprocher de ton point d'accès ou de retirer les obstacles."
+          }
         }
       }
     },
@@ -20354,6 +23684,12 @@
             "state": "translated",
             "value": "信号弱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal faible"
+          }
         }
       }
     },
@@ -20388,6 +23724,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "偏高"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevée"
           }
         }
       }
@@ -20424,6 +23766,12 @@
             "state": "translated",
             "value": "高"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevée"
+          }
         }
       }
     },
@@ -20458,6 +23806,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正常"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normale"
           }
         }
       }
@@ -20494,6 +23848,12 @@
             "state": "translated",
             "value": "不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indisponible"
+          }
         }
       }
     },
@@ -20528,6 +23888,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "尚可"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correcte"
           }
         }
       }
@@ -20564,6 +23930,12 @@
             "state": "translated",
             "value": "良好"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonne"
+          }
         }
       }
     },
@@ -20598,6 +23970,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "差"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mauvaise"
           }
         }
       }
@@ -20634,6 +24012,12 @@
             "state": "translated",
             "value": "未知"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnue"
+          }
         }
       }
     },
@@ -20668,6 +24052,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "良好"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bon"
           }
         }
       }
@@ -20704,6 +24094,12 @@
             "state": "translated",
             "value": "一般"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modéré"
+          }
         }
       }
     },
@@ -20738,6 +24134,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "强"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fort"
           }
         }
       }
@@ -20774,6 +24176,12 @@
             "state": "translated",
             "value": "弱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible"
+          }
         }
       }
     },
@@ -20808,6 +24216,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "尚可"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correcte"
           }
         }
       }
@@ -20844,6 +24258,12 @@
             "state": "translated",
             "value": "良好"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonne"
+          }
         }
       }
     },
@@ -20878,6 +24298,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "差"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mauvaise"
           }
         }
       }
@@ -20914,6 +24340,12 @@
             "state": "translated",
             "value": "未知"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnue"
+          }
         }
       }
     },
@@ -20948,6 +24380,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "了解你的 Wi-Fi 状况，找到不那么拥挤的信道。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Découvre ce qui se passe avec ton Wi-Fi et trouve des canaux moins encombrés."
           }
         }
       }
@@ -20984,6 +24422,12 @@
             "state": "translated",
             "value": "关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
+          }
         }
       }
     },
@@ -21018,6 +24462,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "反馈与社区 · Discord"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour & communauté · Discord"
           }
         }
       }
@@ -21054,6 +24504,12 @@
             "state": "translated",
             "value": "分析趋势与洞察"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyser les tendances et les perspectives"
+          }
         }
       }
     },
@@ -21088,6 +24544,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一键诊断网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer un diagnostic en un geste"
           }
         }
       }
@@ -21124,6 +24586,12 @@
             "state": "translated",
             "value": "导出 Wi-Fi 快照"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter des instantanés Wi-Fi"
+          }
         }
       }
     },
@@ -21158,6 +24626,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "实时查看信道使用情况"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir l'utilisation des canaux en direct"
           }
         }
       }
@@ -21194,6 +24668,12 @@
             "state": "translated",
             "value": "录制 Wi-Fi 数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer des preuves Wi-Fi"
+          }
         }
       }
     },
@@ -21228,6 +24708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在时间线中回顾"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulter ta chronologie"
           }
         }
       }
@@ -21264,6 +24750,12 @@
             "state": "translated",
             "value": "了解 WiFi Lens Pro"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Découvrir WiFi Lens Pro"
+          }
         }
       }
     },
@@ -21298,6 +24790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "跳过"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passer"
           }
         }
       }
@@ -21334,6 +24832,12 @@
             "state": "translated",
             "value": "开始分析"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencer l'analyse"
+          }
         }
       }
     },
@@ -21369,6 +24873,12 @@
             "state": "translated",
             "value": "开始录制"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer l'enregistrement"
+          }
         }
       }
     },
@@ -21403,6 +24913,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "欢迎使用 WiFi Lens"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenue dans WiFi Lens"
           }
         }
       }
@@ -21440,6 +24956,12 @@
             "state": "translated",
             "value": "全球Wi‑Fi网络的3D可视化"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualisation 3D des réseaux Wi‑Fi dans le monde"
+          }
         }
       }
     },
@@ -21475,6 +24997,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "优秀信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meilleurs canaux"
           }
         }
       }
@@ -21512,6 +25040,12 @@
             "state": "translated",
             "value": "检测到 %lld 个网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld réseaux détectés"
+          }
         }
       }
     },
@@ -21547,6 +25081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal"
           }
         }
       }
@@ -21584,6 +25124,12 @@
             "state": "translated",
             "value": "安全"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sécurité"
+          }
         }
       }
     },
@@ -21619,6 +25165,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal"
           }
         }
       }
@@ -21656,6 +25208,12 @@
             "state": "translated",
             "value": "良好"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bon"
+          }
         }
       }
     },
@@ -21691,6 +25249,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "强"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fort"
           }
         }
       }
@@ -21728,6 +25292,12 @@
             "state": "translated",
             "value": "弱"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible"
+          }
         }
       }
     },
@@ -21763,6 +25333,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在检查连接…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification de la connexion..."
           }
         }
       }
@@ -21800,6 +25376,12 @@
             "state": "translated",
             "value": "连接到 Wi‑Fi 网络即可查看诊断与建议。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecte-toi à un réseau Wi‑Fi pour voir les diagnostics et les recommandations."
+          }
         }
       }
     },
@@ -21835,6 +25417,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未连接 Wi‑Fi"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non connecté au Wi‑Fi"
           }
         }
       }
@@ -21872,6 +25460,12 @@
             "state": "translated",
             "value": "需要授权"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisation requise"
+          }
         }
       }
     },
@@ -21907,6 +25501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待授权"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente d'autorisation"
           }
         }
       }
@@ -21944,6 +25544,12 @@
             "state": "translated",
             "value": "检测到上次崩溃"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crash précédent détecté"
+          }
         }
       }
     },
@@ -21979,6 +25585,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "定位服务已关闭"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les services de localisation sont désactivés"
           }
         }
       }
@@ -22016,6 +25628,12 @@
             "state": "translated",
             "value": "已授权，但 macOS 仍未返回 SSID。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation est accordée, mais macOS ne renvoie toujours pas les SSID."
+          }
         }
       }
     },
@@ -22051,6 +25669,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS 需要定位服务权限才能读取 Wi-Fi 网络名称。我们不会追踪或存储你的位置。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS requiert l'autorisation des services de localisation pour lire les noms des réseaux Wi-Fi. Ta position n'est jamais suivie ni stockée."
           }
         }
       }
@@ -22088,6 +25712,12 @@
             "state": "translated",
             "value": "需要定位服务。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Services de localisation requis."
+          }
         }
       }
     },
@@ -22123,6 +25753,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "需要定位服务权限才能读取 Wi-Fi SSID。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation des services de localisation est requise pour lire les SSID Wi-Fi."
           }
         }
       }
@@ -22160,6 +25796,12 @@
             "state": "translated",
             "value": "读取 Wi-Fi 网络名称需要定位服务权限。请在系统设置中开启。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'autorisation des services de localisation est requise pour lire les noms des réseaux Wi-Fi. Active-la dans Réglages Système."
+          }
         }
       }
     },
@@ -22196,6 +25838,12 @@
             "state": "translated",
             "value": "需要定位服务"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Services de localisation requis"
+          }
         }
       }
     },
@@ -22231,6 +25879,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待定位服务授权…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de l'autorisation des services de localisation..."
           }
         }
       }
@@ -22270,6 +25924,12 @@
             "state": "translated",
             "value": "Pro 功能"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionnalité Pro"
+          }
         }
       }
     },
@@ -22304,6 +25964,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ (Pro功能)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Fonctionnalité Pro)"
           }
         }
       }
@@ -22341,6 +26007,12 @@
             "state": "translated",
             "value": "会话录制"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement de session"
+          }
         }
       }
     },
@@ -22376,6 +26048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "从时间线历史记录中获取可解释的洞察。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtiens des constats explicables à partir de ton historique de chronologie."
           }
         }
       }
@@ -22413,6 +26091,12 @@
             "state": "translated",
             "value": "洞察"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyses"
+          }
         }
       }
     },
@@ -22447,6 +26131,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "了解更多"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En savoir plus"
           }
         }
       }
@@ -22483,6 +26173,12 @@
             "state": "translated",
             "value": "WiFi Lens Pro 提供此功能"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible dans WiFi Lens Pro"
+          }
         }
       }
     },
@@ -22517,6 +26213,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在菜单栏中显示 Wi-Fi 状态和事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l'état Wi-Fi et les événements dans la barre des menus"
           }
         }
       }
@@ -22553,6 +26255,12 @@
             "state": "translated",
             "value": "菜单栏图标"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône de barre des menus"
+          }
         }
       }
     },
@@ -22588,6 +26296,12 @@
             "state": "translated",
             "value": "录制和回放 Wi-Fi 会话，分析信号变化趋势"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistre et rejoue des sessions Wi-Fi pour analyser les tendances du signal au fil du temps"
+          }
         }
       }
     },
@@ -22622,6 +26336,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "会话录制"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement de session"
           }
         }
       }
@@ -22659,6 +26379,12 @@
             "state": "translated",
             "value": "分析本地时间线历史记录。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse ton historique local de chronologie."
+          }
         }
       }
     },
@@ -22695,6 +26421,12 @@
             "state": "translated",
             "value": "统计"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques"
+          }
         }
       }
     },
@@ -22730,6 +26462,12 @@
             "state": "translated",
             "value": "查看 Wi-Fi 连接事件并浏览最近的网络变化"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte les événements de connexion Wi-Fi et parcours les changements réseau récents"
+          }
         }
       }
     },
@@ -22764,6 +26502,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "事件时间线"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chronologie d'événements"
           }
         }
       }
@@ -22801,6 +26545,12 @@
             "state": "translated",
             "value": "暂无录制数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore de données enregistrées"
+          }
         }
       }
     },
@@ -22836,6 +26586,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "请在下表中勾选想要关注的AP信号源"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coche les AP sur lesquels tu souhaites te concentrer dans le tableau ci-dessous"
           }
         }
       }
@@ -22873,6 +26629,12 @@
             "state": "translated",
             "value": "请切换到实时标签页开始扫描附近的AP。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passe à l'onglet En direct pour commencer à scanner les AP proches."
+          }
         }
       }
     },
@@ -22908,6 +26670,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未检测到 AP"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun point d'accès détecté"
           }
         }
       }
@@ -22945,6 +26713,12 @@
             "state": "translated",
             "value": "加载会话文件失败"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du chargement du fichier de session"
+          }
         }
       }
     },
@@ -22980,6 +26754,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刚刚"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "maintenant"
           }
         }
       }
@@ -23017,6 +26797,12 @@
             "state": "translated",
             "value": "无AP数据可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune donnée d'AP disponible"
+          }
         }
       }
     },
@@ -23052,6 +26838,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未加载会话"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune session chargée"
           }
         }
       }
@@ -23089,6 +26881,12 @@
             "state": "translated",
             "value": "开始新录制将丢弃当前会话数据。如需保留，请先保存。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le lancement d'un nouvel enregistrement supprimera les données de session actuelles. Enregistre avant de continuer si tu souhaites les conserver."
+          }
         }
       }
     },
@@ -23124,6 +26922,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖现有录制数据？"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Écraser l'enregistrement existant ?"
           }
         }
       }
@@ -23161,6 +26965,12 @@
             "state": "translated",
             "value": "开始录制"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer l'enregistrement"
+          }
         }
       }
     },
@@ -23196,6 +27006,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无AP数据"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune donnée d'AP"
           }
         }
       }
@@ -23233,6 +27049,12 @@
             "state": "translated",
             "value": "准备录制"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prêt à enregistrer"
+          }
         }
       }
     },
@@ -23268,6 +27090,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "录制中…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement…"
           }
         }
       }
@@ -23305,6 +27133,12 @@
             "state": "translated",
             "value": "录制已停止"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement arrêté"
+          }
         }
       }
     },
@@ -23340,6 +27174,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "延迟: %@ ms, %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latence : %@ ms, %@"
           }
         }
       }
@@ -23377,6 +27217,12 @@
             "state": "translated",
             "value": "RSSI: %lld dBm, %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSI : %lld dBm, %@"
+          }
         }
       }
     },
@@ -23412,6 +27258,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "开始漫游测试"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer le test d'itinérance"
           }
         }
       }
@@ -23449,6 +27301,12 @@
             "state": "translated",
             "value": "停止漫游测试"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter le test d'itinérance"
+          }
         }
       }
     },
@@ -23480,6 +27338,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ch %lld"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Ch %lld"
@@ -23519,6 +27383,12 @@
             "state": "translated",
             "value": "RSSI %lld dBm"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSI %lld dBm"
+          }
         }
       }
     },
@@ -23550,6 +27420,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RTT %.1f ms"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "RTT %.1f ms"
@@ -23589,6 +27465,12 @@
             "state": "translated",
             "value": "Tx %.0f Mbps"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tx %.0f Mbit/s"
+          }
         }
       }
     },
@@ -23624,6 +27506,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加载会话失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du chargement de la session"
           }
         }
       }
@@ -23661,6 +27549,12 @@
             "state": "translated",
             "value": "未连接到任何 Wi-Fi 网络。请在开始漫游测试前连接网络。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non connecté à un réseau Wi-Fi. Connecte-toi à un réseau avant de lancer le test d'itinérance."
+          }
         }
       }
     },
@@ -23696,6 +27590,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存会话失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'enregistrement de la session"
           }
         }
       }
@@ -23733,6 +27633,12 @@
             "state": "translated",
             "value": "延迟"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latence"
+          }
         }
       }
     },
@@ -23768,6 +27674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "极佳"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excellente"
           }
         }
       }
@@ -23805,6 +27717,12 @@
             "state": "translated",
             "value": "良好"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonne"
+          }
         }
       }
     },
@@ -23840,6 +27758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "差"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mauvaise"
           }
         }
       }
@@ -23877,6 +27801,12 @@
             "state": "translated",
             "value": "开始新漫游测试将丢弃当前会话数据。如需保留，请先保存。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le lancement d'un nouveau test d'itinérance supprimera les données de session actuelles. Enregistre avant de continuer si tu souhaites les conserver."
+          }
         }
       }
     },
@@ -23912,6 +27842,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "覆盖漫游会话？"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Écraser la session d'itinérance ?"
           }
         }
       }
@@ -23949,6 +27885,12 @@
             "state": "translated",
             "value": "加载漫游会话"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Charger la session d'itinérance"
+          }
         }
       }
     },
@@ -23984,6 +27926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存漫游会话"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer la session d'itinérance"
           }
         }
       }
@@ -24021,6 +27969,12 @@
             "state": "translated",
             "value": "未检测到 AP 切换"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune transition AP détectée"
+          }
         }
       }
     },
@@ -24056,6 +28010,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待 AP 切换…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de transitions AP..."
           }
         }
       }
@@ -24093,6 +28053,12 @@
             "state": "translated",
             "value": "新信道"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ch après"
+          }
         }
       }
     },
@@ -24128,6 +28094,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "旧信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ch avant"
           }
         }
       }
@@ -24165,6 +28137,12 @@
             "state": "translated",
             "value": "旧 BSSID"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID source"
+          }
         }
       }
     },
@@ -24200,6 +28178,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "新 RSSI"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSI après"
           }
         }
       }
@@ -24237,6 +28221,12 @@
             "state": "translated",
             "value": "旧 RSSI"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RSSI avant"
+          }
         }
       }
     },
@@ -24272,6 +28262,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "时间"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heure"
           }
         }
       }
@@ -24309,6 +28305,12 @@
             "state": "translated",
             "value": "新 BSSID"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BSSID cible"
+          }
         }
       }
     },
@@ -24345,6 +28347,12 @@
             "state": "translated",
             "value": "此功能适用于配备电池的 Mac 笔记本电脑，桌面 Mac 无法模拟移动漫游场景。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette fonctionnalité est conçue pour les Mac portables équipés d'une batterie. Les Mac de bureau ne peuvent pas simuler les scénarios d'itinérance mobile."
+          }
         }
       }
     },
@@ -24376,6 +28384,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "App Store"
@@ -24415,6 +28429,12 @@
             "state": "translated",
             "value": "核心依赖"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dépendances principales"
+          }
         }
       }
     },
@@ -24450,6 +28470,12 @@
             "state": "translated",
             "value": "开发者"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développeur"
+          }
         }
       }
     },
@@ -24481,6 +28507,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "GitHub"
@@ -24520,6 +28552,12 @@
             "state": "translated",
             "value": "关于"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À propos"
+          }
         }
       }
     },
@@ -24551,6 +28589,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens"
@@ -24590,6 +28634,12 @@
             "state": "translated",
             "value": "版本 %@ (%@)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@ (%@)"
+          }
         }
       }
     },
@@ -24625,6 +28675,12 @@
             "state": "translated",
             "value": "官方网站"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site officiel"
+          }
         }
       }
     },
@@ -24656,6 +28712,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "X"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "X"
@@ -24696,6 +28758,12 @@
             "state": "translated",
             "value": "一款简单的 macOS Wi-Fi 信道与信号强度分析工具。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un analyseur simple de canaux Wi-Fi et de puissance de signal pour macOS."
+          }
         }
       }
     },
@@ -24728,6 +28796,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens"
@@ -24768,6 +28842,12 @@
             "state": "translated",
             "value": "WiFi Lens OSS"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens OSS"
+          }
         }
       }
     },
@@ -24800,6 +28880,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens Pro"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens Pro"
@@ -24840,6 +28926,12 @@
             "state": "translated",
             "value": "外观"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparence"
+          }
         }
       }
     },
@@ -24875,6 +28967,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "隐藏标题徽章"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le badge de titre"
           }
         }
       }
@@ -24912,6 +29010,12 @@
             "state": "translated",
             "value": "主题"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème"
+          }
         }
       }
     },
@@ -24947,6 +29051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AP 雷达"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP Radar"
           }
         }
       }
@@ -24984,6 +29094,12 @@
             "state": "translated",
             "value": "选择追踪 AP 期间播放的提示音。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisis le ton des impulsions jouées pendant le suivi d'un AP."
+          }
         }
       }
     },
@@ -25019,6 +29135,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "脉冲提示音"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Son des impulsions"
           }
         }
       }
@@ -25056,6 +29178,12 @@
             "state": "translated",
             "value": "哔哔"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bip"
+          }
         }
       }
     },
@@ -25091,6 +29219,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "盖革计数器"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compteur Geiger"
           }
         }
       }
@@ -25128,6 +29262,12 @@
             "state": "translated",
             "value": "在 AP 雷达页面通过隐藏手势解锁。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Débloqué par un geste secret sur la page AP Radar."
+          }
         }
       }
     },
@@ -25163,6 +29303,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "柔和脉冲"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impulsion douce"
           }
         }
       }
@@ -25200,6 +29346,12 @@
             "state": "translated",
             "value": "滴答"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tic"
+          }
         }
       }
     },
@@ -25235,6 +29387,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "试听声音"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu du son"
           }
         }
       }
@@ -25272,6 +29430,12 @@
             "state": "translated",
             "value": "清除时间线数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer les données de chronologie"
+          }
         }
       }
     },
@@ -25307,6 +29471,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "清除"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
           }
         }
       }
@@ -25344,6 +29514,12 @@
             "state": "translated",
             "value": "确认清除"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmer l'effacement"
+          }
         }
       }
     },
@@ -25379,6 +29555,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "永久删除本机上记录的所有时间线事件和本地分析历史。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprime définitivement tous les événements de chronologie enregistrés et l'historique d'analyse local de ce Mac."
           }
         }
       }
@@ -25416,6 +29598,12 @@
             "state": "translated",
             "value": "已清除"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacé"
+          }
         }
       }
     },
@@ -25451,6 +29639,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "清除日志"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer les journaux"
           }
         }
       }
@@ -25488,6 +29682,12 @@
             "state": "translated",
             "value": "诊断"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
         }
       }
     },
@@ -25523,6 +29723,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "诊断日志仅存储在你的设备本地。WiFi Lens 不会收集、上传或分享这些日志。你可以随时自由查看、分享或删除它们。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les journaux de diagnostic sont stockés localement sur ton appareil. WiFi Lens ne les collecte, ne les envoie ni ne les partage jamais. Tu peux librement les consulter, les partager ou les supprimer à tout moment."
           }
         }
       }
@@ -25560,6 +29766,12 @@
             "state": "translated",
             "value": "扫描附近的蓝牙设备，分析信号强度和活动模式。默认关闭。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanne les appareils Bluetooth proches et analyse la puissance du signal et les modes d'activité. Désactivé par défaut."
+          }
         }
       }
     },
@@ -25595,6 +29807,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "蓝牙分析"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse Bluetooth"
           }
         }
       }
@@ -25632,6 +29850,12 @@
             "state": "translated",
             "value": "在菜单栏中显示 Wi-Fi 状态和事件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l'état Wi-Fi et les événements dans la barre des menus"
+          }
         }
       }
     },
@@ -25667,6 +29891,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "菜单栏图标"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône de barre des menus"
           }
         }
       }
@@ -25704,6 +29934,12 @@
             "state": "translated",
             "value": "清空…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer…"
+          }
         }
       }
     },
@@ -25739,6 +29975,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "移除本地厂商数据，但不更改提醒设置。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les données de fournisseur locales sans modifier le réglage de rappel."
           }
         }
       }
@@ -25776,6 +30018,12 @@
             "state": "translated",
             "value": "清空数据库"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer la base de données"
+          }
         }
       }
     },
@@ -25811,6 +30059,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "安装其他数据库前，厂商值将显示为破折号。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les valeurs de fournisseur s'afficheront comme un tiret cadratin jusqu'à ce que tu installes une autre base de données."
           }
         }
       }
@@ -25848,6 +30102,12 @@
             "state": "translated",
             "value": "清空 MAC 厂商数据库？"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer la base de données des fournisseurs MAC ?"
+          }
         }
       }
     },
@@ -25882,6 +30142,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一个或多个 IEEE 注册表文件无法下载，请重试。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un ou plusieurs fichiers de registre IEEE n'ont pas pu être téléchargés. Réessaie."
           }
         }
       }
@@ -25919,6 +30185,12 @@
             "state": "translated",
             "value": "分配 %@/%lld 对应的组织存在冲突。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'affectation %@/%lld comporte des organisations en conflit."
+          }
         }
       }
     },
@@ -25954,6 +30226,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "数据库错误"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de base de données"
           }
         }
       }
@@ -25991,6 +30269,12 @@
             "state": "translated",
             "value": "下载被重定向到不允许的地址：%@。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le téléchargement a redirigé vers une adresse non autorisée : %@."
+          }
         }
       }
     },
@@ -26026,6 +30310,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 下载失败。请重试或使用手动导入。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le téléchargement de %@ a échoué. Réessaie ou utilise l'import manuel."
           }
         }
       }
@@ -26063,6 +30353,12 @@
             "state": "translated",
             "value": "下载失败"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du téléchargement"
+          }
         }
       }
     },
@@ -26098,6 +30394,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择了多个 %@ 文件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus d'un fichier %@ a été sélectionné."
           }
         }
       }
@@ -26135,6 +30437,12 @@
             "state": "translated",
             "value": "无法读取 %@。请重新选择四个 CSV 文件。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'a pas pu être lu. Sélectionne à nouveau les quatre fichiers CSV."
+          }
         }
       }
     },
@@ -26170,6 +30478,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 超过了 %@ 的文件大小限制。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ dépasse la limite de taille de fichier de %@."
           }
         }
       }
@@ -26207,6 +30521,12 @@
             "state": "translated",
             "value": "无法读取文件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fichiers n'ont pas pu être lus"
+          }
         }
       }
     },
@@ -26242,6 +30562,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "IEEE 为 %@ 返回了 HTTP %lld。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour %@, IEEE a renvoyé le code HTTP %lld."
           }
         }
       }
@@ -26279,6 +30605,12 @@
             "state": "translated",
             "value": "%@ 包含无效的 %@ 分配：%@。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contient une affectation %@ invalide : %@."
+          }
         }
       }
     },
@@ -26314,6 +30646,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 不是有效的 UTF-8 CSV 数据。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'est pas des données CSV UTF-8 valides."
           }
         }
       }
@@ -26351,6 +30689,12 @@
             "state": "translated",
             "value": "%@ 包含无效的组织名称。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contient un nom d'organisation invalide."
+          }
         }
       }
     },
@@ -26386,6 +30730,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 包含格式错误的 CSV 数据。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contient des données CSV mal formées."
           }
         }
       }
@@ -26423,6 +30773,12 @@
             "state": "translated",
             "value": "%@ 缺少必需列：%@。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ne contient pas les colonnes requises : %@."
+          }
         }
       }
     },
@@ -26458,6 +30814,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "缺少 %@ 文件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier %@ est manquant."
           }
         }
       }
@@ -26495,6 +30857,12 @@
             "state": "translated",
             "value": "%@ 包含多种注册表类型。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ contient plus d'un type de registre."
+          }
         }
       }
     },
@@ -26530,6 +30898,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "导入前请先校验全部四个 CSV 文件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valide les quatre fichiers CSV avant de les importer."
           }
         }
       }
@@ -26567,6 +30941,12 @@
             "state": "translated",
             "value": "无法保存、加载或移除本地数据库。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La base de données locale n'a pas pu être enregistrée, chargée ou supprimée."
+          }
         }
       }
     },
@@ -26602,6 +30982,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "MAC 厂商数据库错误"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de base de données des fournisseurs MAC"
           }
         }
       }
@@ -26639,6 +31025,12 @@
             "state": "translated",
             "value": "%@ 至少需要 %lld 条有效记录，但只找到 %lld 条。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nécessite au moins %lld enregistrements valides ; %lld ont été trouvés."
+          }
         }
       }
     },
@@ -26674,6 +31066,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "所选文件超过了 %@ 的总大小限制。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fichiers sélectionnés dépassent la limite de taille totale de %@."
           }
         }
       }
@@ -26711,6 +31109,12 @@
             "state": "translated",
             "value": "不支持数据库格式版本 %lld。请清空或更新数据库。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le format de base de données version %lld n'est pas pris en charge. Efface ou mets à jour la base de données."
+          }
         }
       }
     },
@@ -26746,6 +31150,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "文件无效"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fichiers ne sont pas valides"
           }
         }
       }
@@ -26783,6 +31193,12 @@
             "state": "translated",
             "value": "请选择恰好 %lld 个文件。当前选择了 %lld 个。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne exactement %lld fichiers. Tu en as sélectionné %lld."
+          }
         }
       }
     },
@@ -26819,6 +31235,12 @@
             "state": "translated",
             "value": "数据库保存在这台 Mac 上，仅在你主动请求时更新。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La base de données reste sur ce Mac et n'est mise à jour que lorsque tu le demandes."
+          }
         }
       }
     },
@@ -26853,6 +31275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "厂商名称来自内置的 IEEE 注册表快照，不会在运行时更新。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les noms de fournisseurs proviennent d'un instantané de registre IEEE intégré et ne sont pas mis à jour à l'exécution."
           }
         }
       }
@@ -26890,6 +31318,12 @@
             "state": "translated",
             "value": "MAC 厂商数据库"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base de données des fournisseurs MAC"
+          }
         }
       }
     },
@@ -26925,6 +31359,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "有效记录"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrements valides"
           }
         }
       }
@@ -26962,6 +31402,12 @@
             "state": "translated",
             "value": "数据库为空时提醒我"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Me rappeler quand la base de données est vide"
+          }
         }
       }
     },
@@ -26997,6 +31443,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未安装本地 MAC 厂商数据库时显示提醒。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher un rappel lorsqu'aucune base de données de fournisseurs MAC locale n'est installée."
           }
         }
       }
@@ -27034,6 +31486,12 @@
             "state": "translated",
             "value": "不再询问"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus demander"
+          }
         }
       }
     },
@@ -27069,6 +31527,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "稍后"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus tard"
           }
         }
       }
@@ -27106,6 +31570,12 @@
             "state": "translated",
             "value": "安装公开注册表数据库后，可在网络表格中显示注册组织。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installe la base de données de registre public pour afficher les organisations enregistrées dans le tableau des réseaux."
+          }
         }
       }
     },
@@ -27141,6 +31611,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "设置 MAC 厂商信息？"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurer les informations de fournisseur MAC ?"
           }
         }
       }
@@ -27178,6 +31654,12 @@
             "state": "translated",
             "value": "从 IEEE 下载"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargé depuis IEEE"
+          }
         }
       }
     },
@@ -27213,6 +31695,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "来源"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
           }
         }
       }
@@ -27250,6 +31738,12 @@
             "state": "translated",
             "value": "手动导入"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importé manuellement"
+          }
         }
       }
     },
@@ -27284,6 +31778,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "内置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intégré"
           }
         }
       }
@@ -27321,6 +31821,12 @@
             "state": "translated",
             "value": "已安装"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installée"
+          }
         }
       }
     },
@@ -27356,6 +31862,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "状态"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut"
           }
         }
       }
@@ -27393,6 +31905,12 @@
             "state": "translated",
             "value": "正在加载…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement…"
+          }
         }
       }
     },
@@ -27428,6 +31946,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未安装"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non installée"
           }
         }
       }
@@ -27465,6 +31989,12 @@
             "state": "translated",
             "value": "不可用"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indisponible"
+          }
         }
       }
     },
@@ -27500,6 +32030,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "不可用原因"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raison de l'indisponibilité"
           }
         }
       }
@@ -27537,6 +32073,12 @@
             "state": "translated",
             "value": "更新…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour…"
+          }
         }
       }
     },
@@ -27572,6 +32114,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "选择从 IEEE 下载或手动导入 CSV。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisis un téléchargement IEEE ou un import CSV manuel."
           }
         }
       }
@@ -27609,6 +32157,12 @@
             "state": "translated",
             "value": "直接从 IEEE 下载四个公开地址注册表。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharge directement les quatre registres d'adresses publics auprès d'IEEE."
+          }
         }
       }
     },
@@ -27644,6 +32198,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "从 IEEE 下载"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger depuis IEEE"
           }
         }
       }
@@ -27681,6 +32241,12 @@
             "state": "translated",
             "value": "放弃已准备的导入并关闭此面板。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abandonner l'import préparé et fermer cette feuille."
+          }
         }
       }
     },
@@ -27716,6 +32282,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "取消当前操作并关闭此面板。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler l'opération en cours et fermer cette feuille."
           }
         }
       }
@@ -27753,6 +32325,12 @@
             "state": "translated",
             "value": "选择四个 CSV 文件…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir quatre fichiers CSV…"
+          }
         }
       }
     },
@@ -27788,6 +32366,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "一起选择 MA-L、MA-M、MA-S 和 IAB CSV 文件。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisis ensemble les fichiers CSV MA-L, MA-M, MA-S et IAB."
           }
         }
       }
@@ -27825,6 +32409,12 @@
             "state": "translated",
             "value": "正在清空…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacement…"
+          }
         }
       }
     },
@@ -27860,6 +32450,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "从 IEEE 下载"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger depuis IEEE"
           }
         }
       }
@@ -27897,6 +32493,12 @@
             "state": "translated",
             "value": "下载约 5.6 MB。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharge environ 5,6 Mo."
+          }
         }
       }
     },
@@ -27932,6 +32534,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在下载…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement…"
           }
         }
       }
@@ -27969,6 +32577,12 @@
             "state": "translated",
             "value": "导入"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer"
+          }
         }
       }
     },
@@ -28004,6 +32618,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "安装已校验的本地注册表数据库。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installe la base de données de registre locale validée."
           }
         }
       }
@@ -28041,6 +32661,12 @@
             "state": "translated",
             "value": "正在安装…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation…"
+          }
         }
       }
     },
@@ -28076,6 +32702,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "IEEE 会收到包括你的 IP 地址在内的常规连接元数据。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IEEE reçoit des métadonnées de connexion ordinaires, y compris ton adresse IP."
           }
         }
       }
@@ -28113,6 +32745,12 @@
             "state": "translated",
             "value": "BSSID、SSID 和 Wi-Fi 扫描数据始终保留在这台 Mac 上。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les BSSID, SSID et données de scan Wi-Fi restent sur ce Mac."
+          }
         }
       }
     },
@@ -28148,6 +32786,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "下载全部四个官方 CSV 文件，然后一起选择。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharge les quatre fichiers CSV officiels, puis sélectionne-les ensemble."
           }
         }
       }
@@ -28185,6 +32829,12 @@
             "state": "translated",
             "value": "导入 IEEE CSV 文件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer les fichiers CSV IEEE"
+          }
         }
       }
     },
@@ -28220,6 +32870,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "注册表数据标识地址块注册主体，可能与设备品牌不同。WiFi Lens 与 IEEE 无关联，也未获其认可。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les données de registre identifient le détenteur du bloc d'adresses et peuvent différer de la marque de l'appareil. WiFi Lens n'est pas affilié à IEEE ni approuvé par lui."
           }
         }
       }
@@ -28257,6 +32913,12 @@
             "state": "translated",
             "value": "已完成 %lld/%lld 个文件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld fichier(s) sur %lld terminé(s)"
+          }
         }
       }
     },
@@ -28292,6 +32954,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld/%lld 个文件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld fichier(s) sur %lld"
           }
         }
       }
@@ -28329,6 +32997,12 @@
             "state": "translated",
             "value": "正在读取文件…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture des fichiers…"
+          }
         }
       }
     },
@@ -28364,6 +33038,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "下载 %@ CSV"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger %@ CSV"
           }
         }
       }
@@ -28401,6 +33081,12 @@
             "state": "translated",
             "value": "%@ — %@ 条有效记录"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@ enregistrements valides"
+          }
         }
       }
     },
@@ -28436,6 +33122,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 条有效记录"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ enregistrements valides"
           }
         }
       }
@@ -28473,6 +33165,12 @@
             "state": "translated",
             "value": "%@ — 正在等待有效文件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — en attente d'un fichier valide"
+          }
         }
       }
     },
@@ -28508,6 +33206,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "等待校验"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de validation"
           }
         }
       }
@@ -28545,6 +33249,12 @@
             "state": "translated",
             "value": "自动"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatique"
+          }
         }
       }
     },
@@ -28580,6 +33290,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "来源"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
           }
         }
       }
@@ -28617,6 +33333,12 @@
             "state": "translated",
             "value": "手动"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuel"
+          }
         }
       }
     },
@@ -28652,6 +33374,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "更新 MAC 厂商数据库"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour la base de données des fournisseurs MAC"
           }
         }
       }
@@ -28689,6 +33417,12 @@
             "state": "translated",
             "value": "正在校验…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validation…"
+          }
         }
       }
     },
@@ -28724,6 +33458,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "文件校验"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validation des fichiers"
           }
         }
       }
@@ -28761,6 +33501,12 @@
             "state": "translated",
             "value": "四个注册表均有效（共 %@ 条记录）。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les quatre registres sont valides (%@ enregistrements au total)."
+          }
         }
       }
     },
@@ -28796,6 +33542,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "四个注册表文件均有效"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les quatre fichiers de registre sont valides"
           }
         }
       }
@@ -28833,6 +33585,12 @@
             "state": "translated",
             "value": "更新时间"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis à jour"
+          }
         }
       }
     },
@@ -28868,6 +33626,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Desktop 配置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration Claude Desktop"
           }
         }
       }
@@ -28905,6 +33669,12 @@
             "state": "translated",
             "value": "将当前 Wi-Fi 扫描数据暴露为本地 HTTP API，供 Codex Desktop、Claude Desktop 等 MCP 兼容 AI 工具查询。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expose les données de scan Wi-Fi actuelles sous forme d'API HTTP locale pour les outils IA compatibles MCP tels que Codex Desktop et Claude Desktop."
+          }
         }
       }
     },
@@ -28941,6 +33711,12 @@
             "state": "translated",
             "value": "开启 MCP 服务"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le serveur MCP"
+          }
         }
       }
     },
@@ -28973,6 +33749,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MCP"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "MCP"
@@ -29013,6 +33795,12 @@
             "state": "translated",
             "value": "端口："
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port :"
+          }
         }
       }
     },
@@ -29048,6 +33836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅在开启蓝牙分析时请求。用于发现附近的 BLE 设备并分析其信号强度。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demandée uniquement lorsque l'analyse Bluetooth est activée. Permet de découvrir les appareils BLE proches et d'analyser leur puissance de signal."
           }
         }
       }
@@ -29085,6 +33879,12 @@
             "state": "translated",
             "value": "开启蓝牙分析功能后可管理此权限。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active l'analyse Bluetooth pour gérer cette autorisation."
+          }
         }
       }
     },
@@ -29120,6 +33920,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "蓝牙"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth"
           }
         }
       }
@@ -29157,6 +33963,12 @@
             "state": "translated",
             "value": "权限"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations"
+          }
         }
       }
     },
@@ -29192,6 +34004,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WiFi Lens 使用位置服务来读取 Wi-Fi 网络名称（SSID）。如果被拒绝，网络名称将显示为 \"n/a\"，但信号强度和信道数据仍然完全可用。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens utilise les services de localisation pour lire les noms des réseaux Wi-Fi (SSID). En cas de refus, les noms de réseaux apparaissent comme « n/a », mais la puissance du signal et les données de canal restent entièrement disponibles."
           }
         }
       }
@@ -29229,6 +34047,12 @@
             "state": "translated",
             "value": "定位服务"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Services de localisation"
+          }
         }
       }
     },
@@ -29264,6 +34088,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "隐私"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confidentialité"
           }
         }
       }
@@ -29301,6 +34131,12 @@
             "state": "translated",
             "value": "查看隐私政策…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir la politique de confidentialité…"
+          }
         }
       }
     },
@@ -29336,6 +34172,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "自动检测"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détection automatique"
           }
         }
       }
@@ -29373,6 +34215,12 @@
             "state": "translated",
             "value": "中国 (SRRC)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chine (SRRC)"
+          }
         }
       }
     },
@@ -29408,6 +34256,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道推荐经过地区法规过滤。自动检测使用系统区域、硬件能力及附近 AP 信息。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les recommandations de canaux sont filtrées par les réglementations régionales. La détection automatique utilise la langue système, les capacités matérielles et les informations sur les AP proches."
           }
         }
       }
@@ -29445,6 +34299,12 @@
             "state": "translated",
             "value": "欧盟 (ETSI)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Union européenne (ETSI)"
+          }
         }
       }
     },
@@ -29480,6 +34340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "法规区域"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Région réglementaire"
           }
         }
       }
@@ -29517,6 +34383,12 @@
             "state": "translated",
             "value": "日本 (MIC)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japon (MIC)"
+          }
         }
       }
     },
@@ -29552,6 +34424,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "美国 (FCC)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "États-Unis (FCC)"
           }
         }
       }
@@ -29589,6 +34467,12 @@
             "state": "translated",
             "value": "扫描间隔"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalle de scan"
+          }
         }
       }
     },
@@ -29624,6 +34508,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 秒"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 seconde"
           }
         }
       }
@@ -29661,6 +34551,12 @@
             "state": "translated",
             "value": "2 秒"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 secondes"
+          }
         }
       }
     },
@@ -29696,6 +34592,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 秒"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 secondes"
           }
         }
       }
@@ -29733,6 +34635,12 @@
             "state": "translated",
             "value": "5 秒"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 secondes"
+          }
         }
       }
     },
@@ -29768,6 +34676,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "10 秒"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 secondes"
           }
         }
       }
@@ -29805,6 +34719,12 @@
             "state": "translated",
             "value": "适用于实时频谱视图。录制始终使用 1 秒间隔以确保最大细节。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'applique à la vue spectre en direct. L'enregistrement utilise toujours un intervalle de 1 seconde pour un maximum de détails."
+          }
         }
       }
     },
@@ -29840,6 +34760,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "刷新间隔"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervalle d'actualisation"
           }
         }
       }
@@ -29877,6 +34803,12 @@
             "state": "translated",
             "value": "数据"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Données"
+          }
         }
       }
     },
@@ -29912,6 +34844,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "功能"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionnalités"
           }
         }
       }
@@ -29949,6 +34887,12 @@
             "state": "translated",
             "value": "功能与权限"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionnalités et autorisations"
+          }
         }
       }
     },
@@ -29985,6 +34929,12 @@
             "state": "translated",
             "value": "系统权限"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations système"
+          }
         }
       }
     },
@@ -30019,6 +34969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "支持"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistance"
           }
         }
       }
@@ -30055,6 +35011,12 @@
             "state": "translated",
             "value": "评价 WiFi Lens Pro"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Évaluer WiFi Lens Pro"
+          }
         }
       }
     },
@@ -30089,6 +35051,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "发送反馈"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyer un commentaire"
           }
         }
       }
@@ -30126,6 +35094,12 @@
             "state": "translated",
             "value": "自动检查更新"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier automatiquement les mises à jour"
+          }
         }
       }
     },
@@ -30161,6 +35135,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "更新"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour"
           }
         }
       }
@@ -30198,6 +35178,12 @@
             "state": "translated",
             "value": "需要Wi‑Fi"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessite le Wi‑Fi"
+          }
         }
       }
     },
@@ -30232,6 +35218,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "分析"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse"
           }
         }
       }
@@ -30269,6 +35261,12 @@
             "state": "translated",
             "value": "调试"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Débogage"
+          }
         }
       }
     },
@@ -30304,6 +35302,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "洞察"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyses"
           }
         }
       }
@@ -30341,6 +35345,12 @@
             "state": "translated",
             "value": "概览"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vue d'ensemble"
+          }
         }
       }
     },
@@ -30376,6 +35386,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "应用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
           }
         }
       }
@@ -30413,6 +35429,12 @@
             "state": "translated",
             "value": "工具"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outils"
+          }
         }
       }
     },
@@ -30447,6 +35469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wi-Fi 频谱图"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique du spectre Wi-Fi"
           }
         }
       }
@@ -30484,6 +35512,12 @@
             "state": "translated",
             "value": "频谱图, %lld 个网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique du spectre, %lld réseaux"
+          }
         }
       }
     },
@@ -30520,6 +35554,12 @@
             "state": "translated",
             "value": "关闭展开的图表"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer le graphique agrandi"
+          }
         }
       }
     },
@@ -30554,6 +35594,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道占用热力图"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carte de chaleur d'occupation des canaux"
           }
         }
       }
@@ -30591,6 +35637,12 @@
             "state": "translated",
             "value": "RSSI 趋势：从 %1$d 下降到 %2$d dBm（变化 %3$d dB，%4$d 个采样点）"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance RSSI : en baisse de %1$d à %2$d dBm (variation %3$d dB, %4$d échantillons)"
+          }
         }
       }
     },
@@ -30626,6 +35678,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "RSSI 趋势：从 %1$d 改善到 %2$d dBm（变化 +%3$d dB，%4$d 个采样点）"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance RSSI : en hausse de %1$d à %2$d dBm (variation +%3$d dB, %4$d échantillons)"
           }
         }
       }
@@ -30663,6 +35721,12 @@
             "state": "translated",
             "value": "RSSI 趋势：在 %1$d dBm 附近保持稳定（%2$d 个采样点）"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance RSSI : stable autour de %1$d dBm (%2$d échantillons)"
+          }
         }
       }
     },
@@ -30698,6 +35762,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "无信道数据"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune donnée de canal disponible"
           }
         }
       }
@@ -30735,6 +35805,12 @@
             "state": "translated",
             "value": "导出 %@ 为 CSV"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter %@ au format CSV"
+          }
         }
       }
     },
@@ -30769,6 +35845,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "清除筛选"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer le filtre"
           }
         }
       }
@@ -30806,6 +35888,12 @@
             "state": "translated",
             "value": "隐藏无名称网络"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer les réseaux masqués"
+          }
         }
       }
     },
@@ -30841,6 +35929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "按 SSID 或 MAC 地址过滤"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer par SSID ou MAC/BSSID"
           }
         }
       }
@@ -30878,6 +35972,12 @@
             "state": "translated",
             "value": "按 SSID 或 BSSID 过滤…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer par SSID ou BSSID…"
+          }
         }
       }
     },
@@ -30913,6 +36013,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示："
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher :"
           }
         }
       }
@@ -30950,6 +36056,12 @@
             "state": "translated",
             "value": "频谱模式"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode spectre"
+          }
         }
       }
     },
@@ -30985,6 +36097,12 @@
             "state": "translated",
             "value": "实时"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En direct"
+          }
         }
       }
     },
@@ -31019,6 +36137,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "录制"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement"
           }
         }
       }
@@ -31131,6 +36255,12 @@
             "state": "translated",
             "value": "图表类型"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type de graphique"
+          }
         }
       }
     },
@@ -31166,6 +36296,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "筛选…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer..."
           }
         }
       }
@@ -31203,6 +36339,12 @@
             "state": "translated",
             "value": "选择网络以查看趋势"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne un réseau pour voir la tendance"
+          }
         }
       }
     },
@@ -31238,6 +36380,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "趋势"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance"
           }
         }
       }
@@ -31275,6 +36423,12 @@
             "state": "translated",
             "value": "正在扫描 (%lld 个设备)"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan (%lld appareils)"
+          }
         }
       }
     },
@@ -31310,6 +36464,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在扫描 Wi-Fi 网络…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche de réseaux Wi-Fi..."
           }
         }
       }
@@ -31347,6 +36507,12 @@
             "state": "translated",
             "value": "%lld 个 AP"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld AP"
+          }
         }
       }
     },
@@ -31379,6 +36545,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AP"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "AP"
@@ -31419,6 +36591,12 @@
             "state": "translated",
             "value": "%lld 行"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld lignes"
+          }
         }
       }
     },
@@ -31454,6 +36632,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 个网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld réseaux"
           }
         }
       }
@@ -31512,6 +36696,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "·"
@@ -31576,6 +36766,12 @@
             "state": "translated",
             "value": "切换网络锁定"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basculer le verrouillage du réseau"
+          }
         }
       }
     },
@@ -31611,6 +36807,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "切换网络可见性"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basculer la visibilité du réseau"
           }
         }
       }
@@ -31648,6 +36850,12 @@
             "state": "translated",
             "value": "带宽"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BW"
+          }
         }
       }
     },
@@ -31683,6 +36891,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ch"
           }
         }
       }
@@ -31720,6 +36934,12 @@
             "state": "translated",
             "value": "国家"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CC"
+          }
         }
       }
     },
@@ -31752,6 +36972,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "k"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "k"
@@ -31792,6 +37018,12 @@
             "state": "translated",
             "value": "r"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "r"
+          }
         }
       }
     },
@@ -31824,6 +37056,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "v"
@@ -31864,6 +37102,12 @@
             "state": "translated",
             "value": "H"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "H"
+          }
         }
       }
     },
@@ -31900,6 +37144,12 @@
             "state": "translated",
             "value": "锁定"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verrou"
+          }
         }
       }
     },
@@ -31932,6 +37182,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MCS"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "MCS"
@@ -31972,6 +37228,12 @@
             "state": "translated",
             "value": "NSS"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NSS"
+          }
         }
       }
     },
@@ -32007,6 +37269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "安全"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sécu"
           }
         }
       }
@@ -32044,6 +37312,12 @@
             "state": "translated",
             "value": "最后出现"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vu"
+          }
         }
       }
     },
@@ -32076,6 +37350,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSID"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "SSID"
@@ -32115,6 +37395,12 @@
             "state": "translated",
             "value": "厂商"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fournisseur"
+          }
         }
       }
     },
@@ -32151,6 +37437,12 @@
             "state": "translated",
             "value": "可见性"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visible"
+          }
         }
       }
     },
@@ -32185,6 +37477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "数值"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valeur"
           }
         }
       }
@@ -32221,6 +37519,12 @@
             "state": "translated",
             "value": "变更前"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De"
+          }
         }
       }
     },
@@ -32255,6 +37559,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网络"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réseau"
           }
         }
       }
@@ -32291,6 +37601,12 @@
             "state": "translated",
             "value": "时间"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heure"
+          }
         }
       }
     },
@@ -32325,6 +37641,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "变更后"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vers"
           }
         }
       }
@@ -32362,6 +37684,12 @@
             "state": "translated",
             "value": "新的 Wi-Fi 事件会在记录后显示在这里"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les nouveaux événements Wi-Fi apparaîtront ici au fur et à mesure de leur enregistrement"
+          }
         }
       }
     },
@@ -32398,6 +37726,12 @@
             "state": "translated",
             "value": "暂无事件"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement pour l'instant"
+          }
         }
       }
     },
@@ -32433,6 +37767,12 @@
             "state": "translated",
             "value": "信道 %lld"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ch %lld"
+          }
         }
       }
     },
@@ -32464,6 +37804,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ → %@"
@@ -32503,6 +37849,12 @@
             "state": "translated",
             "value": "信道切换"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canal changé"
+          }
         }
       }
     },
@@ -32537,6 +37889,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "在线"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En ligne"
           }
         }
       }
@@ -32573,6 +37931,12 @@
             "state": "translated",
             "value": "到 %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vers %@"
+          }
         }
       }
     },
@@ -32607,6 +37971,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "已连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
           }
         }
       }
@@ -32643,6 +38013,12 @@
             "state": "translated",
             "value": "离线"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hors ligne"
+          }
         }
       }
     },
@@ -32677,6 +38053,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "从 %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depuis %@"
           }
         }
       }
@@ -32713,6 +38095,12 @@
             "state": "translated",
             "value": "连接断开"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion perdue"
+          }
         }
       }
     },
@@ -32744,6 +38132,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@"
@@ -32783,6 +38177,12 @@
             "state": "translated",
             "value": "%@ → %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
         }
       }
     },
@@ -32817,6 +38217,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "网关延迟飙升"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pic de latence de la passerelle"
           }
         }
       }
@@ -32853,6 +38259,12 @@
             "state": "translated",
             "value": "漫游"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance"
+          }
         }
       }
     },
@@ -32884,6 +38296,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ → %@"
@@ -32923,6 +38341,12 @@
             "state": "translated",
             "value": "在 AP 之间漫游"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance entre points d'accès"
+          }
         }
       }
     },
@@ -32954,6 +38378,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld dBm"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "%lld dBm"
@@ -32993,6 +38423,12 @@
             "state": "translated",
             "value": "%lld dBm → %lld dBm"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld dBm → %lld dBm"
+          }
         }
       }
     },
@@ -33027,6 +38463,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号减弱"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signal affaibli"
           }
         }
       }
@@ -33063,6 +38505,12 @@
             "state": "translated",
             "value": "所选证据前后的事件，供参考上下文。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événements avant et après la preuve sélectionnée, affichés pour contexte."
+          }
         }
       }
     },
@@ -33097,6 +38545,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "周边事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événements environnants"
           }
         }
       }
@@ -33133,6 +38587,12 @@
             "state": "translated",
             "value": "WiFi Lens 在此时间范围内进行过观测，但没有与所选网络和事件类型匹配的事件。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WiFi Lens observait pendant cette période, mais aucun événement ne correspond au réseau et au type d'événement sélectionnés."
+          }
         }
       }
     },
@@ -33167,6 +38627,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有匹配的事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun événement correspondant"
           }
         }
       }
@@ -33203,6 +38669,12 @@
             "state": "translated",
             "value": "该见解的支持事件在所选时间范围和网络中均不存在。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun des événements de soutien pour cette analyse n'existe dans la période et le réseau sélectionnés."
+          }
         }
       }
     },
@@ -33237,6 +38709,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "未找到支持事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Événements de soutien introuvables"
           }
         }
       }
@@ -33273,6 +38751,12 @@
             "state": "translated",
             "value": "所选时间范围和网络中仅存在该见解的 %lld 个支持事件（共 %lld 个）。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuls %lld événements de soutien sur %lld pour cette analyse existent dans la période et le réseau sélectionnés."
+          }
         }
       }
     },
@@ -33307,6 +38791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "部分支持事件缺失"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certains événements de soutien manquent"
           }
         }
       }
@@ -33343,6 +38833,12 @@
             "state": "translated",
             "value": "无法读取支持结论的时间线历史，因此不显示事件，而不是显示不完整的证据。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique de chronologie de soutien n'a pas pu être lu, aucun événement n'est donc affiché au lieu de preuves incomplètes."
+          }
         }
       }
     },
@@ -33377,6 +38873,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "证据查询失败"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la requête de preuve"
           }
         }
       }
@@ -33413,6 +38915,12 @@
             "state": "translated",
             "value": "无法读取本地时间线历史，因此无法验证支持事件。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'historique local de chronologie n'a pas pu être lu, les événements de soutien ne peuvent donc pas être vérifiés."
+          }
         }
       }
     },
@@ -33447,6 +38955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "历史记录存储不可用"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage de l'historique indisponible"
           }
         }
       }
@@ -33483,6 +38997,12 @@
             "state": "translated",
             "value": "日期范围"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plage de dates"
+          }
         }
       }
     },
@@ -33517,6 +39037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "事件类型"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Types d'événements"
           }
         }
       }
@@ -33553,6 +39079,12 @@
             "state": "translated",
             "value": "从"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De"
+          }
         }
       }
     },
@@ -33588,6 +39120,12 @@
             "state": "translated",
             "value": "搜索事件…"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des événements…"
+          }
         }
       }
     },
@@ -33622,6 +39160,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "到"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À"
           }
         }
       }
@@ -33659,6 +39203,12 @@
             "state": "translated",
             "value": "全部"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous"
+          }
         }
       }
     },
@@ -33693,6 +39243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "自定义"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisé"
           }
         }
       }
@@ -33729,6 +39285,12 @@
             "state": "translated",
             "value": "从"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De"
+          }
         }
       }
     },
@@ -33763,6 +39325,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "到"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À"
           }
         }
       }
@@ -33800,6 +39368,12 @@
             "state": "translated",
             "value": "本周"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette semaine"
+          }
         }
       }
     },
@@ -33836,6 +39410,12 @@
             "state": "translated",
             "value": "今天"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aujourd'hui"
+          }
         }
       }
     },
@@ -33870,6 +39450,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信道变更"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changement de canal"
           }
         }
       }
@@ -33906,6 +39492,12 @@
             "state": "translated",
             "value": "连接"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion"
+          }
         }
       }
     },
@@ -33940,6 +39532,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "断开连接"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnexion"
           }
         }
       }
@@ -33976,6 +39574,12 @@
             "state": "translated",
             "value": "延迟尖峰"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pic de latence"
+          }
         }
       }
     },
@@ -34011,6 +39615,12 @@
             "state": "translated",
             "value": "漫游"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itinérance"
+          }
         }
       }
     },
@@ -34045,6 +39655,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "信号衰减"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chute de signal"
           }
         }
       }
@@ -34082,6 +39698,12 @@
             "state": "translated",
             "value": "昨天"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier"
+          }
         }
       }
     },
@@ -34117,6 +39739,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "搜索事件"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des événements"
           }
         }
       }
@@ -34154,6 +39782,12 @@
             "state": "translated",
             "value": "查看 Wi-Fi 连接相关事件的时间线"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulte les événements de connexion Wi-Fi sur une seule chronologie"
+          }
         }
       }
     },
@@ -34189,6 +39823,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timeline（时间线）"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chronologie"
           }
         }
       }
@@ -34229,6 +39869,12 @@
             "state": "translated",
             "value": "5 GHz"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 GHz"
+          }
         }
       }
     },
@@ -34261,6 +39907,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "6 GHz"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "6 GHz"
@@ -34301,6 +39953,12 @@
             "state": "translated",
             "value": "2.4 GHz"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2,4 GHz"
+          }
         }
       }
     },
@@ -34333,6 +39991,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi‑Fi 4"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Wi‑Fi 4"
@@ -34373,6 +40037,12 @@
             "state": "translated",
             "value": "Wi‑Fi 5"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi‑Fi 5"
+          }
         }
       }
     },
@@ -34405,6 +40075,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi‑Fi 6"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Wi‑Fi 6"
@@ -34445,6 +40121,12 @@
             "state": "translated",
             "value": "Wi‑Fi 7"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi‑Fi 7"
+          }
         }
       }
     },
@@ -34480,6 +40162,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "高置信度"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance élevée"
           }
         }
       }
@@ -34517,6 +40205,12 @@
             "state": "translated",
             "value": "低置信度"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance faible"
+          }
         }
       }
     },
@@ -34552,6 +40246,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "中置信度"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confiance moyenne"
           }
         }
       }
@@ -34589,6 +40289,12 @@
             "state": "translated",
             "value": "请在系统设置中打开 Wi-Fi 以开始扫描。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active le Wi-Fi dans Réglages Système pour commencer le scan."
+          }
         }
       }
     },
@@ -34625,6 +40331,12 @@
             "state": "translated",
             "value": "Wi-Fi 已关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le Wi-Fi est désactivé"
+          }
         }
       }
     },
@@ -34657,6 +40369,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11a"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "802.11a"
@@ -34697,6 +40415,12 @@
             "state": "translated",
             "value": "802.11ac"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11ac"
+          }
         }
       }
     },
@@ -34729,6 +40453,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11ax"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "802.11ax"
@@ -34769,6 +40499,12 @@
             "state": "translated",
             "value": "802.11b"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11b"
+          }
         }
       }
     },
@@ -34801,6 +40537,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11be"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "802.11be"
@@ -34841,6 +40583,12 @@
             "state": "translated",
             "value": "802.11g"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11g"
+          }
         }
       }
     },
@@ -34873,6 +40621,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "802.11n"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "802.11n"
@@ -34913,6 +40667,12 @@
             "state": "translated",
             "value": "动态 WEP"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WEP dynamique"
+          }
         }
       }
     },
@@ -34948,6 +40708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "企业"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entreprise"
           }
         }
       }
@@ -34985,6 +40751,12 @@
             "state": "translated",
             "value": "开放"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvert"
+          }
         }
       }
     },
@@ -35021,6 +40793,12 @@
             "state": "translated",
             "value": "个人"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnel"
+          }
         }
       }
     },
@@ -35053,6 +40831,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WEP"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "WEP"
@@ -35093,6 +40877,12 @@
             "state": "translated",
             "value": "WPA 企业"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA Entreprise"
+          }
         }
       }
     },
@@ -35128,6 +40918,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WPA 个人"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA Personnel"
           }
         }
       }
@@ -35165,6 +40961,12 @@
             "state": "translated",
             "value": "WPA/WPA2 企业"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA/WPA2 Entreprise"
+          }
         }
       }
     },
@@ -35200,6 +41002,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WPA/WPA2 个人"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA/WPA2 Personnel"
           }
         }
       }
@@ -35237,6 +41045,12 @@
             "state": "translated",
             "value": "WPA2 企业"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA2 Entreprise"
+          }
         }
       }
     },
@@ -35272,6 +41086,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WPA2 个人"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA2 Personnel"
           }
         }
       }
@@ -35309,6 +41129,12 @@
             "state": "translated",
             "value": "WPA3 企业"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA3 Entreprise"
+          }
         }
       }
     },
@@ -35344,6 +41170,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "WPA3 个人"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WPA3 Personnel"
           }
         }
       }
@@ -35381,6 +41213,12 @@
             "state": "translated",
             "value": "WPA3 过渡"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transition WPA3"
+          }
         }
       }
     },
@@ -35415,6 +41253,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "复制 AI 设置提示词"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le prompt de configuration IA"
           }
         }
       }
@@ -35451,6 +41295,12 @@
             "state": "translated",
             "value": "手动配置"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration manuelle"
+          }
         }
       }
     },
@@ -35485,6 +41335,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示手动配置"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la configuration manuelle"
           }
         }
       }
@@ -35521,6 +41377,12 @@
             "state": "translated",
             "value": "Codex TOML"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TOML Codex"
+          }
         }
       }
     },
@@ -35552,6 +41414,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[mcp_servers.wifi-lens]\nurl = \"http://127.0.0.1:%ld/\""
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "[mcp_servers.wifi-lens]\nurl = \"http://127.0.0.1:%ld/\""
@@ -35591,6 +41459,12 @@
             "state": "translated",
             "value": "{\n  \"mcpServers\": {\n    \"wifi-lens\": {\n      \"url\": \"http://127.0.0.1:%ld/\"\n    }\n  }\n}"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "{\n  \"mcpServers\": {\n    \"wifi-lens\": {\n      \"url\": \"http://127.0.0.1:%ld/\"\n    }\n  }\n}"
+          }
         }
       }
     },
@@ -35622,6 +41496,12 @@
           }
         },
         "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord"
+          }
+        },
+        "fr": {
           "stringUnit": {
             "state": "translated",
             "value": "Discord"
@@ -35667,6 +41547,12 @@
             "state": "translated",
             "value": "关闭"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
+          }
         }
       }
     },
@@ -35707,6 +41593,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "完成"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminé"
           }
         }
       }
@@ -35749,6 +41641,12 @@
             "state": "translated",
             "value": "更新说明不可用。"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes de version indisponibles."
+          }
         }
       }
     },
@@ -35789,6 +41687,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "更新内容"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveautés"
           }
         }
       }
@@ -35831,6 +41735,12 @@
             "state": "translated",
             "value": "更新内容"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveautés"
+          }
         }
       }
     },
@@ -35871,6 +41781,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新阅读更新内容"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consulter les nouveautés"
           }
         }
       }

--- a/WiFiLens/Sources/WiFiLens/Resources/WhatsNew/fr.md
+++ b/WiFiLens/Sources/WiFiLens/Resources/WhatsNew/fr.md
@@ -1,0 +1,5 @@
+# Nouveautés de la version 1.6.0
+
+### Pour commencer
+
+Bienvenue dans WiFi Lens ! Il s'agit de la première version avec des annonces de mise à jour intégrées.

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -1850,6 +1850,7 @@
 				"zh-Hans",
 				es,
 				de,
+				fr,
 				ja,
 			);
 			mainGroup = 1D3644357E3565223E7F160A;


### PR DESCRIPTION
Add French (`fr`) support to the App.

- Add `fr` localizations for all 986 translatable keys in `Localizable.xcstrings`.
- Register `fr` in `knownRegions` in `project.pbxproj`.
- Add French What's New release notes (`Resources/WhatsNew/fr.md`).
- Add a French section to the localization terminology guide (`LOCALIZATION_TERMS.md`).
- Bump the `Pro` submodule for the locale-aware percent formatting change (see wifi-lens-pro PR).