### PR TITLE
feat(links,guidance): split Pro preview campaign attribution and add local insight feedback

### DIFF
--- a/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
+++ b/WiFiLens/Sources/WiFiLens/App/OSSEditionComposition.swift
@@ -80,6 +80,7 @@ enum EditionComposition {
                 featureName: String(localized: "pro.timeline.title", comment: "Pro timeline feature title"),
                 featureDescription: String(localized: "pro.timeline.description", comment: "Pro timeline feature description"),
                 featureIcon: SidebarPage.timeline.icon,
+                campaign: .appStoreCampaignPreviewTimeline,
                 customSkeleton: { TimelineSkeletonView() }
             )
             .accessibilityIdentifier("page-timeline")
@@ -88,6 +89,7 @@ enum EditionComposition {
                 featureName: String(localized: "pro.statistics.title", comment: "Pro Statistics feature title"),
                 featureDescription: String(localized: "pro.statistics.description", comment: "Pro Statistics feature description"),
                 featureIcon: SidebarPage.statistics.icon,
+                campaign: .appStoreCampaignPreviewStatistics,
                 customSkeleton: { StatisticsSkeletonView() }
             )
             .accessibilityIdentifier("page-statistics")
@@ -96,6 +98,7 @@ enum EditionComposition {
                 featureName: String(localized: "pro.insights.title", comment: "Pro Insights feature title"),
                 featureDescription: String(localized: "pro.insights.description", comment: "Pro Insights feature description"),
                 featureIcon: SidebarPage.insights.icon,
+                campaign: .appStoreCampaignPreviewInsights,
                 customSkeleton: { InsightsSkeletonView() }
             )
             .accessibilityIdentifier("page-insights")

--- a/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/ProFeaturePlaceholderView.swift
@@ -33,8 +33,23 @@ struct ProFeaturePlaceholderView<CustomSkeleton: View>: View {
     let featureName: String
     let featureDescription: String
     let featureIcon: String
+    let campaign: ExternalDestination
     @ViewBuilder var customSkeleton: () -> CustomSkeleton
     @Environment(\.colorScheme) private var colorScheme
+
+    init(
+        featureName: String,
+        featureDescription: String,
+        featureIcon: String,
+        campaign: ExternalDestination = .appStoreCampaignPreviewLock,
+        @ViewBuilder customSkeleton: @escaping () -> CustomSkeleton
+    ) {
+        self.featureName = featureName
+        self.featureDescription = featureDescription
+        self.featureIcon = featureIcon
+        self.campaign = campaign
+        self.customSkeleton = customSkeleton
+    }
     
     var body: some View {
         GeometryReader { geometry in
@@ -106,16 +121,22 @@ struct ProFeaturePlaceholderView<CustomSkeleton: View>: View {
     }
     
     private func openAppStore() {
-        guard let url = ExternalLinks.url(for: .appStoreCampaignPreviewLock) else { return }
+        guard let url = ExternalLinks.url(for: campaign) else { return }
         NSWorkspace.shared.open(url)
     }
 }
 
 extension ProFeaturePlaceholderView where CustomSkeleton == ProFeatureScreenshotPlaceholder {
-    init(featureName: String, featureDescription: String, featureIcon: String) {
+    init(
+        featureName: String,
+        featureDescription: String,
+        featureIcon: String,
+        campaign: ExternalDestination = .appStoreCampaignPreviewLock
+    ) {
         self.featureName = featureName
         self.featureDescription = featureDescription
         self.featureIcon = featureIcon
+        self.campaign = campaign
         self.customSkeleton = { ProFeatureScreenshotPlaceholder(systemImage: featureIcon) }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/App/SettingsView.swift
+++ b/WiFiLens/Sources/WiFiLens/App/SettingsView.swift
@@ -355,7 +355,7 @@ struct SettingsView: View {
 
                         Divider()
 
-                        aboutLinkRow(icon: "bag.fill", title: String(localized: "settings.about.app_store", comment: "App Store link"), destination: .appStore)
+                        aboutLinkRow(icon: "bag.fill", title: String(localized: "settings.about.app_store", comment: "App Store link"), destination: .appStoreCampaignSettingsAbout)
                         aboutLinkRow(icon: "safari", title: String(localized: "settings.about.website", comment: "Product website link"), destination: .website)
                         aboutLinkRow(icon: "chevron.left.forwardslash.chevron.right", title: String(localized: "settings.about.github", comment: "GitHub repository link"), destination: .github)
                         aboutLinkRow(icon: "bubble.left.and.bubble.right.fill", title: String(localized: "settings.about.x", comment: "X (formerly Twitter) account link"), destination: .xAccount)

--- a/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
+++ b/WiFiLens/Sources/WiFiLens/Guidance/GuidanceCoordinator.swift
@@ -164,6 +164,19 @@ final class GuidanceCoordinator {
         return decision
     }
 
+    /// Records a lightweight, privacy-safe Insight feedback signal through the
+    /// same local event sink as other guidance events. Metadata carries only
+    /// the rating and rule identifier; never network identity or device data.
+    func recordInsightFeedback(rating: String, ruleID: String) {
+        emit(
+            "analysis.insight_feedback",
+            metadata: [
+                "rating": rating,
+                "rule": ruleID,
+            ]
+        )
+    }
+
     func recordAppActive() {
         var state = stateStore.load()
         if state.firstLaunchDate == nil {

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -3633,6 +3633,47 @@
         }
       }
     },
+    "analysis.readiness.remaining_time_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aufzeichnung läuft. Noch etwa %@, bis die Analyse bereit ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recording... about %@ until analysis is ready."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grabando... queda aproximadamente %@ para que el análisis esté listo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement... environ %@ avant que l'analyse soit prête."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記録中...分析が準備できるまで約%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在记录…约%@后分析即可就绪。"
+          }
+        }
+      }
+    },
     "analysis.readiness.rule_unavailable_format" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -40126,6 +40126,468 @@
         }
       }
     },
+    "timeline.export.button" : {
+      "comment" : "Timeline export button label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き出す"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出"
+          }
+        }
+      }
+    },
+    "timeline.export.events" : {
+      "comment" : "Timeline export events heading",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ereignisse"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Events"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eventos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Événements"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イベント"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事件"
+          }
+        }
+      }
+    },
+    "timeline.export.exported_time" : {
+      "comment" : "Timeline export time label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportzeitpunkt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exported"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de exportación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporté"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き出し日時"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出时间"
+          }
+        }
+      }
+    },
+    "timeline.export.from" : {
+      "comment" : "Timeline export from value label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Von"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "From"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更前"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变更前"
+          }
+        }
+      }
+    },
+    "timeline.export.header" : {
+      "comment" : "Timeline export header title",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitachsenbericht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeline Report"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informe de la cronología"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapport de la chronologie"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムライン レポート"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时间线报告"
+          }
+        }
+      }
+    },
+    "timeline.export.network" : {
+      "comment" : "Timeline export network label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerk"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réseau"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网络"
+          }
+        }
+      }
+    },
+    "timeline.export.no_events" : {
+      "comment" : "Timeline export empty message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Ereignisse vorhanden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No events available."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay eventos disponibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun événement disponible."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イベントがありません。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的事件。"
+          }
+        }
+      }
+    },
+    "timeline.export.range" : {
+      "comment" : "Timeline export range label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitraum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Range"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Période"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期間"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "范围"
+          }
+        }
+      }
+    },
+    "timeline.export.report.title" : {
+      "comment" : "Timeline report main title",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — Zeitachsenbericht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — Timeline Report"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — Informe de la cronología"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — Rapport de la chronologie"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — タイムライン レポート"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WiFi Lens — 时间线报告"
+          }
+        }
+      }
+    },
+    "timeline.export.saved_message" : {
+      "comment" : "Timeline report saved message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitachsenbericht erfolgreich exportiert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeline report exported successfully."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informe de la cronología exportado correctamente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapport de la chronologie exporté avec succès."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムライン レポートを書き出しました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时间线报告已成功导出。"
+          }
+        }
+      }
+    },
+    "timeline.export.to" : {
+      "comment" : "Timeline export to value label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hasta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更後"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变更后"
+          }
+        }
+      }
+    },
     "timeline.search.placeholder" : {
       "comment" : "Timeline search field placeholder",
       "extractionState" : "manual",

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -41767,6 +41767,88 @@
           }
         }
       }
+    },
+    "analysis.insight.action.run_self_check" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run Network Self-Check"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerk-Selbsttest ausführen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar autocomprobación de red"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter l'auto-vérification du réseau"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク自己診断を実行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行网络自检"
+          }
+        }
+      }
+    },
+    "analysis.insight.action.open_timeline" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Timeline"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeline öffnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Timeline"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir la chronologie"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムラインを開く"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 Timeline"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -42352,6 +42352,170 @@
           }
         }
       }
+    },
+    "analysis.insight.feedback.prompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "War dieser Hinweis hilfreich?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Was this insight helpful?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Fue útil esta información?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette information a-t-elle été utile ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このインサイトは役に立ちましたか？"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这条洞察有帮助吗？"
+          }
+        }
+      }
+    },
+    "analysis.insight.feedback.helpful" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hilfreich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Helpful"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Útil"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utile"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "役に立った"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有帮助"
+          }
+        }
+      }
+    },
+    "analysis.insight.feedback.not_helpful" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht hilfreich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not helpful"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No útil"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas utile"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "役に立たなかった"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有帮助"
+          }
+        }
+      }
+    },
+    "analysis.insight.feedback.misleading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Irreführend"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Misleading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engañoso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trompeur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "誤解を招く"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有误导性"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -37988,6 +37988,416 @@
         }
       }
     },
+    "timeline.detail.bssid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BSSID"
+          }
+        }
+      }
+    },
+    "timeline.detail.channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kanal"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canal"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信道"
+          }
+        }
+      }
+    },
+    "timeline.detail.channel_value_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kanal %@ (%@)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ch %@ (%@)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canal %@ (%@)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canal %@ (%@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル %@ (%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信道 %@（%@）"
+          }
+        }
+      }
+    },
+    "timeline.detail.rssi" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSSI"
+          }
+        }
+      }
+    },
+    "timeline.detail.rssi_value_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dBm"
+          }
+        }
+      }
+    },
+    "timeline.detail.security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sicherheit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguridad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sécurité"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全"
+          }
+        }
+      }
+    },
+    "timeline.detail.phy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHY"
+          }
+        }
+      }
+    },
+    "timeline.detail.interface" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnittstelle"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interfaz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interface"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターフェース"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接口"
+          }
+        }
+      }
+    },
+    "timeline.detail.to" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hasta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更後"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变更后"
+          }
+        }
+      }
+    },
+    "timeline.detail.network" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerk"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réseau"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网络"
+          }
+        }
+      }
+    },
     "timeline.detail.time" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
+++ b/WiFiLens/Sources/WiFiLens/Utilities/ExternalLinks.swift
@@ -8,6 +8,10 @@ enum ExternalDestination {
     case appStoreCampaignDiagnosis
     case appStoreCampaignExport
     case appStoreCampaignPreviewLock
+    case appStoreCampaignPreviewTimeline
+    case appStoreCampaignPreviewStatistics
+    case appStoreCampaignPreviewInsights
+    case appStoreCampaignSettingsAbout
     case website
     case github
     case xAccount
@@ -39,6 +43,14 @@ enum ExternalLinks {
             "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_export&mt=8"
         case .appStoreCampaignPreviewLock:
             "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_lock&mt=8"
+        case .appStoreCampaignPreviewTimeline:
+            "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_timeline&mt=8"
+        case .appStoreCampaignPreviewStatistics:
+            "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_statistics&mt=8"
+        case .appStoreCampaignPreviewInsights:
+            "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_insights&mt=8"
+        case .appStoreCampaignSettingsAbout:
+            "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_settings_about&mt=8"
         case .website:
             "https://wifi-lens.shiinalabs.com"
         case .github:

--- a/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/ExternalLinksTests.swift
@@ -39,6 +39,34 @@ struct ExternalLinksTests {
             ExternalLinks.url(for: .appStoreCampaignPreviewLock)?.absoluteString
                 == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_lock&mt=8"
         )
+        #expect(
+            ExternalLinks.url(for: .appStoreCampaignPreviewTimeline)?.absoluteString
+                == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_timeline&mt=8"
+        )
+        #expect(
+            ExternalLinks.url(for: .appStoreCampaignPreviewStatistics)?.absoluteString
+                == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_statistics&mt=8"
+        )
+        #expect(
+            ExternalLinks.url(for: .appStoreCampaignPreviewInsights)?.absoluteString
+                == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_preview_insights&mt=8"
+        )
+        #expect(
+            ExternalLinks.url(for: .appStoreCampaignSettingsAbout)?.absoluteString
+                == "https://apps.apple.com/app/apple-store/id6776590746?pt=128979395&ct=oss_settings_about&mt=8"
+        )
+    }
+
+    @Test("each preview surface has a unique campaign value")
+    func previewSurfaceCampaignsAreDistinct() {
+        let timeline = ExternalLinks.url(for: .appStoreCampaignPreviewTimeline)?.absoluteString
+        let statistics = ExternalLinks.url(for: .appStoreCampaignPreviewStatistics)?.absoluteString
+        let insights = ExternalLinks.url(for: .appStoreCampaignPreviewInsights)?.absoluteString
+        let settings = ExternalLinks.url(for: .appStoreCampaignSettingsAbout)?.absoluteString
+
+        #expect(timeline != statistics)
+        #expect(statistics != insights)
+        #expect(insights != settings)
     }
 
     @Test("dependency repositories keep their current public locations")

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -156,11 +156,14 @@
 		EC20000000000000000000020 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000021 /* InsightsViewModel.swift */; };
 		EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000023 /* ProReviewRequestBridge.swift */; };
 		EC20000000000000000000026 /* FeedbackContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000025 /* FeedbackContact.swift */; };
+		EC20000000000000000000028 /* DemoAnalysisData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000027 /* DemoAnalysisData.swift */; };
 		ECCBBEBFAF59A2E2035CE1FF /* BLEViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7BA76DD3B1E6198BDAEEA7 /* BLEViewModel.swift */; };
 		ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000001 /* AnalysisSnapshotTests.swift */; };
 		ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000003 /* AnalysisSnapshot.swift */; };
 		ED2000000000000000000002 /* AnalysisNetworkScopeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */; };
 		ED3000000000000000000002 /* AnalysisWorkspaceScenarioValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */; };
+		ED4000000000000000000002 /* AnalysisReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4000000000000000000001 /* AnalysisReadinessTests.swift */; };
+		ED5000000000000000000002 /* DemoAnalysisDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5000000000000000000001 /* DemoAnalysisDataTests.swift */; };
 		EEF6495F8D90DE97D0C86ADF /* ChartViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A45AB88716DC3AC18610B /* ChartViewTests.swift */; };
 		EF1000000000000000000002 /* InsightModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1000000000000000000001 /* InsightModelTests.swift */; };
 		EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2000000000000000000001 /* InsightRuleValidationTests.swift */; };
@@ -657,10 +660,13 @@
 		EC20000000000000000000021 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
 		EC20000000000000000000023 /* ProReviewRequestBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProReviewRequestBridge.swift; sourceTree = "<group>"; };
 		EC20000000000000000000025 /* FeedbackContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContact.swift; sourceTree = "<group>"; };
+		EC20000000000000000000027 /* DemoAnalysisData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAnalysisData.swift; sourceTree = "<group>"; };
 		ED1000000000000000000001 /* AnalysisSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshotTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000003 /* AnalysisSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshot.swift; sourceTree = "<group>"; };
 		ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisNetworkScopeIntegrationTests.swift; sourceTree = "<group>"; };
 		ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisWorkspaceScenarioValidationTests.swift; sourceTree = "<group>"; };
+		ED4000000000000000000001 /* AnalysisReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisReadinessTests.swift; sourceTree = "<group>"; };
+		ED5000000000000000000001 /* DemoAnalysisDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAnalysisDataTests.swift; sourceTree = "<group>"; };
 		EDF4EDF838BA0ABB1DAFDBBB /* BLEDeviceSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEDeviceSnapshot.swift; sourceTree = "<group>"; };
 		EF1000000000000000000001 /* InsightModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightModelTests.swift; sourceTree = "<group>"; };
 		EF2000000000000000000001 /* InsightRuleValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRuleValidationTests.swift; sourceTree = "<group>"; };
@@ -1222,6 +1228,7 @@
 				EB4000000000000000000001 /* AnalysisObservationCoverage.swift */,
 				EC20000000000000000000013 /* AnalysisDataReadiness.swift */,
 				EC20000000000000000000017 /* TimelineStatistics.swift */,
+				EC20000000000000000000027 /* DemoAnalysisData.swift */,
 				ED1000000000000000000003 /* AnalysisSnapshot.swift */,
 				EC2000000000000000000001B /* Insight.swift */,
 				EC2000000000000000000001D /* InsightRuleEngine.swift */,
@@ -1294,6 +1301,8 @@
 				ED1000000000000000000001 /* AnalysisSnapshotTests.swift */,
 				ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */,
 				ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */,
+				ED4000000000000000000001 /* AnalysisReadinessTests.swift */,
+				ED5000000000000000000001 /* DemoAnalysisDataTests.swift */,
 				EF1000000000000000000001 /* InsightModelTests.swift */,
 				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
 				EB2000000000000000000005 /* Fixtures */,
@@ -2215,6 +2224,7 @@
 				EC20000000000000000000014 /* AnalysisDataReadiness.swift in Sources */,
 				EC20000000000000000000016 /* TimelineStatistics.swift in Sources */,
 				ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */,
+				EC20000000000000000000028 /* DemoAnalysisData.swift in Sources */,
 				EC20000000000000000000018 /* StatisticsViewModel.swift in Sources */,
 				EC2000000000000000000001A /* Insight.swift in Sources */,
 				EC2000000000000000000001C /* InsightRuleEngine.swift in Sources */,
@@ -2379,6 +2389,8 @@
 				ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */,
 				ED2000000000000000000002 /* AnalysisNetworkScopeIntegrationTests.swift in Sources */,
 				ED3000000000000000000002 /* AnalysisWorkspaceScenarioValidationTests.swift in Sources */,
+				ED4000000000000000000002 /* AnalysisReadinessTests.swift in Sources */,
+				ED5000000000000000000002 /* DemoAnalysisDataTests.swift in Sources */,
 				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		EC20000000000000000000028 /* DemoAnalysisData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000027 /* DemoAnalysisData.swift */; };
 		E8A1B534D16CB1175560A807 /* TimelineReportExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */; };
 		78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */; };
+		721C59AB6DD7BE47D87FAE98 /* InsightFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */; };
 		ECCBBEBFAF59A2E2035CE1FF /* BLEViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7BA76DD3B1E6198BDAEEA7 /* BLEViewModel.swift */; };
 		ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000001 /* AnalysisSnapshotTests.swift */; };
 		ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000003 /* AnalysisSnapshot.swift */; };
@@ -665,6 +666,7 @@
 		EC20000000000000000000027 /* DemoAnalysisData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAnalysisData.swift; sourceTree = "<group>"; };
 		0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporter.swift; sourceTree = "<group>"; };
 		1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporterTests.swift; sourceTree = "<group>"; };
+		5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightFeedbackTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000001 /* AnalysisSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshotTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000003 /* AnalysisSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshot.swift; sourceTree = "<group>"; };
 		ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisNetworkScopeIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1308,6 +1310,7 @@
 				ED4000000000000000000001 /* AnalysisReadinessTests.swift */,
 				ED5000000000000000000001 /* DemoAnalysisDataTests.swift */,
 				1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */,
+				5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */,
 				EF1000000000000000000001 /* InsightModelTests.swift */,
 				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
 				EB2000000000000000000005 /* Fixtures */,
@@ -2399,6 +2402,7 @@
 				ED4000000000000000000002 /* AnalysisReadinessTests.swift in Sources */,
 				ED5000000000000000000002 /* DemoAnalysisDataTests.swift in Sources */,
 				78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */,
+				721C59AB6DD7BE47D87FAE98 /* InsightFeedbackTests.swift in Sources */,
 				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		EC20000000000000000000024 /* ProReviewRequestBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000023 /* ProReviewRequestBridge.swift */; };
 		EC20000000000000000000026 /* FeedbackContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000025 /* FeedbackContact.swift */; };
 		EC20000000000000000000028 /* DemoAnalysisData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC20000000000000000000027 /* DemoAnalysisData.swift */; };
+		E8A1B534D16CB1175560A807 /* TimelineReportExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */; };
+		78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */; };
 		ECCBBEBFAF59A2E2035CE1FF /* BLEViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7BA76DD3B1E6198BDAEEA7 /* BLEViewModel.swift */; };
 		ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000001 /* AnalysisSnapshotTests.swift */; };
 		ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000003 /* AnalysisSnapshot.swift */; };
@@ -661,6 +663,8 @@
 		EC20000000000000000000023 /* ProReviewRequestBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProReviewRequestBridge.swift; sourceTree = "<group>"; };
 		EC20000000000000000000025 /* FeedbackContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContact.swift; sourceTree = "<group>"; };
 		EC20000000000000000000027 /* DemoAnalysisData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAnalysisData.swift; sourceTree = "<group>"; };
+		0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporter.swift; sourceTree = "<group>"; };
+		1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporterTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000001 /* AnalysisSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshotTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000003 /* AnalysisSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshot.swift; sourceTree = "<group>"; };
 		ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisNetworkScopeIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1303,6 +1307,7 @@
 				ED3000000000000000000001 /* AnalysisWorkspaceScenarioValidationTests.swift */,
 				ED4000000000000000000001 /* AnalysisReadinessTests.swift */,
 				ED5000000000000000000001 /* DemoAnalysisDataTests.swift */,
+				1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */,
 				EF1000000000000000000001 /* InsightModelTests.swift */,
 				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
 				EB2000000000000000000005 /* Fixtures */,
@@ -1371,6 +1376,7 @@
 			children = (
 				FBD0A43B2FE5BEAC003658AD /* MarkdownExportService.swift */,
 				FBD0A43C2FE5BEAC003658AD /* MarkdownReportExporter.swift */,
+				0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */,
 			);
 			path = SnapshotExport;
 			sourceTree = "<group>";
@@ -2251,6 +2257,7 @@
 				FBD0A4492FE5BEAC003658AD /* ScanSession.swift in Sources */,
 				FBD0A44A2FE5BEAC003658AD /* RecordingTimelineChart.swift in Sources */,
 				FBD0A44B2FE5BEAC003658AD /* MarkdownExportService.swift in Sources */,
+				E8A1B534D16CB1175560A807 /* TimelineReportExporter.swift in Sources */,
 				FBD0A44C2FE5BEAC003658AD /* RecordingViewModel.swift in Sources */,
 				3DC8FED8F49854F4CDFD4DD2 /* SnapshotToChartAdapter.swift in Sources */,
 				FB1E32542FC7316C009D1BDC /* ChannelQualityView.swift in Sources */,
@@ -2391,6 +2398,7 @@
 				ED3000000000000000000002 /* AnalysisWorkspaceScenarioValidationTests.swift in Sources */,
 				ED4000000000000000000002 /* AnalysisReadinessTests.swift in Sources */,
 				ED5000000000000000000002 /* DemoAnalysisDataTests.swift in Sources */,
+				78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */,
 				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		E8A1B534D16CB1175560A807 /* TimelineReportExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */; };
 		78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */; };
 		721C59AB6DD7BE47D87FAE98 /* InsightFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */; };
+		DBDF66D03BD11B7D5986B87F /* SeverityValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8408E6A12E8F18E4C2CF7 /* SeverityValidationTests.swift */; };
+		63BB596DECFDBA8763C84656 /* TimelineLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05D236E635B93825959AC92 /* TimelineLocalizationTests.swift */; };
 		ECCBBEBFAF59A2E2035CE1FF /* BLEViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7BA76DD3B1E6198BDAEEA7 /* BLEViewModel.swift */; };
 		ED1000000000000000000002 /* AnalysisSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000001 /* AnalysisSnapshotTests.swift */; };
 		ED1000000000000000000004 /* AnalysisSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1000000000000000000003 /* AnalysisSnapshot.swift */; };
@@ -667,6 +669,8 @@
 		0724F9D8C687C53E378D13E2 /* TimelineReportExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporter.swift; sourceTree = "<group>"; };
 		1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReportExporterTests.swift; sourceTree = "<group>"; };
 		5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightFeedbackTests.swift; sourceTree = "<group>"; };
+		FAB8408E6A12E8F18E4C2CF7 /* SeverityValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeverityValidationTests.swift; sourceTree = "<group>"; };
+		B05D236E635B93825959AC92 /* TimelineLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLocalizationTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000001 /* AnalysisSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshotTests.swift; sourceTree = "<group>"; };
 		ED1000000000000000000003 /* AnalysisSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisSnapshot.swift; sourceTree = "<group>"; };
 		ED2000000000000000000001 /* AnalysisNetworkScopeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisNetworkScopeIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1311,6 +1315,8 @@
 				ED5000000000000000000001 /* DemoAnalysisDataTests.swift */,
 				1D2B21285BDCF1A6FD3E42C8 /* TimelineReportExporterTests.swift */,
 				5C187307EE359A3BC6E25D44 /* InsightFeedbackTests.swift */,
+				FAB8408E6A12E8F18E4C2CF7 /* SeverityValidationTests.swift */,
+				B05D236E635B93825959AC92 /* TimelineLocalizationTests.swift */,
 				EF1000000000000000000001 /* InsightModelTests.swift */,
 				EF2000000000000000000001 /* InsightRuleValidationTests.swift */,
 				EB2000000000000000000005 /* Fixtures */,
@@ -2403,6 +2409,8 @@
 				ED5000000000000000000002 /* DemoAnalysisDataTests.swift in Sources */,
 				78D748E699F0BD72E8076BBA /* TimelineReportExporterTests.swift in Sources */,
 				721C59AB6DD7BE47D87FAE98 /* InsightFeedbackTests.swift in Sources */,
+				DBDF66D03BD11B7D5986B87F /* SeverityValidationTests.swift in Sources */,
+				63BB596DECFDBA8763C84656 /* TimelineLocalizationTests.swift in Sources */,
 				EF1000000000000000000002 /* InsightModelTests.swift in Sources */,
 				EF2000000000000000000002 /* InsightRuleValidationTests.swift in Sources */,
 				EC20000000000000000000002 /* EditionCompositionTests.swift in Sources */,


### PR DESCRIPTION
## Summary

This PR lands the public-side half of the Pro long-term value and conversion plan. It complements the private `Pro` submodule branch `codex/pro-long-term-value` (gitlink updated here) and keeps the OSS edition's public surface implementation-neutral.

## Changes

- Split Pro preview campaign attribution by surface:
  - Timeline / Statistics / Insights locked previews now use `oss_preview_timeline`, `oss_preview_statistics`, `oss_preview_insights`.
  - Settings About App Store row now uses `oss_settings_about`.
  - `oss_preview_lock` remains as the fallback.
- Added `GuidanceCoordinator.recordInsightFeedback(rating:ruleID:)`, a local privacy-safe event sink used by Pro Insights feedback. Metadata carries only rating and rule ID; no network identity or device data.
- Localization: added all new user-facing copy (Insight actions/feedback, cold-start readiness, Timeline detail labels/export) in `en`, `de`, `es`, `fr`, `ja`, `zh-Hans` with manual extraction state.
- Project wiring: registered new Pro test files in the shared Xcode project; verified `PRO.xcconfig` target wiring.
- Submodule: updated `Pro` gitlink to the private branch HEAD containing the Pro feature work (Insight action/feedback, cold-start demo, Timeline export, localization/severity fixes, docs).

## Verification

- OSS unit suite: 1129 tests / 117 suites pass.
- Pro unit suite (private submodule): 443 tests / 47 suites pass.
- Pro and OSS Debug builds pass.
- Knowledge boundary scan: PASS.
- Integrity check: PASS.

## Notes

- The public PR intentionally contains no Pro implementation details; the private work lives in the `Pro` submodule.
- The shared Xcode project registers new Pro test/source file names as required for target wiring (consistent with existing Pro file entries in the project).
