### PR TITLE
feat: componentize spectrum third panel as Table view

### DIFF
--- a/.agents/references/project/ARCHITECTURE.md
+++ b/.agents/references/project/ARCHITECTURE.md
@@ -20,7 +20,11 @@ WiFi — CoreWLAN scan source → WiFiObservationRuntime
 Runtime output → ScannerViewModel presentation projection
                   ├── WiFiNetwork → ChannelSpanCalculator → ChartSeriesData (Gaussian curves)
                   │                 → BandChartViewModel (per-band state → BandChartRenderModel)
-                                       ├── combinedTableRows → NativeTableView (AppKit NSTableView)
+                                       ├── combinedTableRows → SpectrumTablePanel → NativeTableView (AppKit NSTableView)
+                                       ├── SpectrumPanelView (primary/secondary/tertiary, 1:1:1)
+                                       │     ├── SpectrumBandPanel → WiFiBandChart
+                                       │     ├── SpectrumTrendPanel → TrendChartView
+                                       │     └── SpectrumTablePanel → NativeTableView
                                        ├── channelQualities → ChannelQualityCalculator → ChannelQualityView
                                        ├── bandViewModels → WiFiBandChart → Chart (universal renderer)
                                        ├── networkInfo → InterfacesView (throughput, gateway, DNS)
@@ -53,7 +57,7 @@ Chart Engine (ChartLens package):
 |------|---------------|
 | `WiFiLensApp.swift` | Root `@main` App struct, Scene, menu commands, window group |
 | `Scanner/` | Presentation-facing scanner ViewModel, CoreWLAN scan source, network/channel models, Wi-Fi power monitoring, and CWChannel extensions |
-| `Spectrum/` | WiFiBandChart, BandChartViewModel, BandChartRenderModel, BandChartLayout, ContentView (dashboard), ChartSeriesData, ChannelSpanCalculator, SignalHistoryStore, NetworkSnapshot, TrendChartView, SnapshotToChartAdapter, SSIDColorHasher |
+| `Spectrum/` | ContentView (dashboard), SpectrumPanelView (reusable panel shell), SpectrumBandPanel, SpectrumTrendPanel, SpectrumTablePanel, NetworkTableRowSorter, WiFiBandChart, BandChartViewModel, BandChartRenderModel, BandChartLayout, ChartSeriesData, ChannelSpanCalculator, SignalHistoryStore, NetworkSnapshot, TrendChartView, SnapshotToChartAdapter, SSIDColorHasher |
 | `Channels/` | ChannelQualityCalculator, ChannelQualityView, RecommendationReason, RecommendationReasonCalculator, ReasonPopover |
 | `Charts/` | Universal Chart engine: ChartView, ChartTypes, DetailOverviewChart, RangeSelectorView, ChartGeometry, SplineInterpolation, ChartTimeFormatting, ChartRendering (legacy) |
 | `Interfaces/` | InterfacesView, ThroughputMonitor, ThroughputChartView, NetworkInfoService |
@@ -89,6 +93,7 @@ explicitly scoped to Pro.
 - **Shared route-resource leases**: each main window registers its current route under a stable scene ID. A process-scoped coordinator aggregates those leases for the process-shared Spectrum charts and BLE scanner; resources start on the first matching route and stop only after the final lease is released by a route change or real window close. BLE starts return generation-bound sessions whose stop operation cannot terminate a newer session, and stopping always finishes that session's event stream.
 - Selection flows bidirectionally: table row → `selectedNetworkID` → chart highlight; chart curve click → `selectedNetworkID` → table row highlight
 - `NativeTableView` uses `Coordinator` as `NSTableViewDelegate` + `NSTableViewDataSource`
+- **Spectrum panel composition**: `ContentView` lays out three `SpectrumPanelView` instances at equal height (`primary` / `secondary` / `tertiary`). Each panel owns a View-type switcher (`SpectrumPanelViewType`: `2.4G / 5G / 6G / Trend / Table`) and renders the matching content object: `SpectrumBandPanel`, `SpectrumTrendPanel`, or `SpectrumTablePanel`. The panel toolbar shows the View switcher and the active content's own controls on the same row; filtering belongs to the band views, the hidden-SSID toggle belongs to the table view, and Trend has no dedicated controls. `SpectrumTablePanel` sorts rows through `NetworkTableRowSorter` and preserves the shared `sortOrder` / `hiddenColumns` bindings.
 - **Chart Engine** — All chart views build `[ChartSeries]` arrays and delegate rendering to the universal `Chart<Overlay>` component. Domain-specific overlays (tooltips, heatmaps, data labels, transition markers) are injected via a `ViewBuilder` closure. See [CHARTS.md](CHARTS.md).
 - `WiFiBandChart` is decoupled from `BandChartViewModel` via `BandChartRenderModel` — a value-type snapshot created each render pass, so the view never holds a reference to the ViewModel
 - **ChartSeriesData split**: `ChartSeriesDomainData` (immutable network identity) + `ChartSeriesRenderState` (mutable visual state: animated `displayRSSI`, `color`, filter/visibility flags, trend indicators). `ChartSeriesData` wraps both with computed passthrough properties

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -36851,6 +36851,48 @@
         }
       }
     },
+    "spectrum.panel.table_count_fmt" : {
+      "comment" : "Network count in table toolbar",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Netzwerke"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld networks"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld redes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld réseaux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個のネットワーク"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个网络"
+          }
+        }
+      }
+    },
     "spectrum.scanning_count_fmt" : {
       "comment" : "Scanning status with device count",
       "extractionState" : "manual",

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -36809,6 +36809,48 @@
         }
       }
     },
+    "spectrum.panel.table" : {
+      "comment" : "Table view label in spectrum panel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabelle"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Table"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tableau"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表格"
+          }
+        }
+      }
+    },
     "spectrum.scanning_count_fmt" : {
       "comment" : "Scanning status with device count",
       "extractionState" : "manual",

--- a/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
@@ -74,15 +74,10 @@ final class ScannerViewModel {
     var band24 = BandChartViewModel(band: .band24GHz)
     var band5 = BandChartViewModel(band: .band5GHz)
     var band6 = BandChartViewModel(band: .band6GHz)
-    private let primaryBand24 = BandChartViewModel(band: .band24GHz)
-    private let primaryBand5 = BandChartViewModel(band: .band5GHz)
-    private let primaryBand6 = BandChartViewModel(band: .band6GHz)
-    private let secondaryBand24 = BandChartViewModel(band: .band24GHz)
-    private let secondaryBand5 = BandChartViewModel(band: .band5GHz)
-    private let secondaryBand6 = BandChartViewModel(band: .band6GHz)
-    private let tertiaryBand24 = BandChartViewModel(band: .band24GHz)
-    private let tertiaryBand5 = BandChartViewModel(band: .band5GHz)
-    private let tertiaryBand6 = BandChartViewModel(band: .band6GHz)
+    /// Panel band ViewModels are created lazily when a panel actually requests
+    /// a band view. Panels that never open a band (for example a Table-only
+    /// panel) do not allocate or refresh these stateful objects.
+    private var panelBandViewModelsByID: [SpectrumPanelID: [ChannelBand: BandChartViewModel]] = [:]
 
     var supportedBands: Set<ChannelBand> = []
     var isScanning = false
@@ -175,27 +170,46 @@ final class ScannerViewModel {
     }
 
     var allBandViewModels: [BandChartViewModel] {
-        [band24, band5, band6, primaryBand24, primaryBand5, primaryBand6, secondaryBand24, secondaryBand5, secondaryBand6, tertiaryBand24, tertiaryBand5, tertiaryBand6]
+        var result = bandViewModels
+        for panel in SpectrumPanelID.allCases {
+            if let byBand = panelBandViewModelsByID[panel] {
+                result.append(contentsOf: Array(byBand.values))
+            }
+        }
+        return result
     }
 
     func bandViewModel(for panelID: SpectrumPanelID, selection: SpectrumPanelViewType) -> BandChartViewModel {
-        switch (panelID, selection) {
-        case (.primary, .band24): return primaryBand24
-        case (.primary, .band5): return primaryBand5
-        case (.primary, .band6): return primaryBand6
-        case (.secondary, .band24): return secondaryBand24
-        case (.secondary, .band5): return secondaryBand5
-        case (.secondary, .band6): return secondaryBand6
-        case (.tertiary, .band24): return tertiaryBand24
-        case (.tertiary, .band5): return tertiaryBand5
-        case (.tertiary, .band6): return tertiaryBand6
-        case (.primary, .trend): return primaryBand24
-        case (.secondary, .trend): return secondaryBand24
-        case (.tertiary, .trend): return tertiaryBand24
-        case (.primary, .table): return primaryBand24
-        case (.secondary, .table): return secondaryBand24
-        case (.tertiary, .table): return tertiaryBand24
+        let band: ChannelBand
+        switch selection {
+        case .band24: band = .band24GHz
+        case .band5: band = .band5GHz
+        case .band6: band = .band6GHz
+        case .trend, .table:
+            preconditionFailure("bandViewModel(for:) only supports band selections")
         }
+
+        var byBand = panelBandViewModelsByID[panelID] ?? [:]
+        if let existing = byBand[band] {
+            return existing
+        }
+        let created = BandChartViewModel(band: band)
+        if !interfaceName.isEmpty {
+            created.updateInterfaceName(interfaceName)
+        }
+        byBand[band] = created
+        panelBandViewModelsByID[panelID] = byBand
+        if !deduplicatedNetworks.isEmpty {
+            syncBandViewModel(
+                created,
+                for: panelID,
+                band: band,
+                networks: deduplicatedNetworks,
+                trends: makeTrends(for: deduplicatedNetworks),
+                snapshots: makeSnapshots(for: deduplicatedNetworks)
+            )
+        }
+        return created
     }
 
     func filterQuery(for panelID: SpectrumPanelID) -> String {
@@ -208,12 +222,9 @@ final class ScannerViewModel {
     }
 
     func panelBandViewModels(for panelID: SpectrumPanelID) -> [BandChartViewModel] {
-        [
-            bandViewModel(for: panelID, selection: .band24),
-            bandViewModel(for: panelID, selection: .band5),
-            bandViewModel(for: panelID, selection: .band6),
-        ]
-        .filter { supportedBands.contains($0.band) }
+        guard let byBand = panelBandViewModelsByID[panelID] else { return [] }
+        return Array(byBand.values)
+            .filter { supportedBands.contains($0.band) }
     }
 
     /// Cached table rows. Every `NetworkTableRow` field derives from stable
@@ -693,46 +704,62 @@ final class ScannerViewModel {
         trends: [String: (direction: TrendDirection, delta: Int)],
         snapshots: [String: [NetworkSnapshot]]
     ) {
+        if supportedBands.contains(.band24GHz),
+           let vm = panelBandViewModelsByID[panelID]?[.band24GHz] {
+            syncBandViewModel(
+                vm,
+                for: panelID,
+                band: .band24GHz,
+                networks: networks,
+                trends: trends,
+                snapshots: snapshots
+            )
+        }
+
+        if supportedBands.contains(.band5GHz),
+           let vm = panelBandViewModelsByID[panelID]?[.band5GHz] {
+            syncBandViewModel(
+                vm,
+                for: panelID,
+                band: .band5GHz,
+                networks: networks,
+                trends: trends,
+                snapshots: snapshots
+            )
+        }
+
+        if supportedBands.contains(.band6GHz),
+           let vm = panelBandViewModelsByID[panelID]?[.band6GHz] {
+            syncBandViewModel(
+                vm,
+                for: panelID,
+                band: .band6GHz,
+                networks: networks,
+                trends: trends,
+                snapshots: snapshots
+            )
+        }
+    }
+
+    private func syncBandViewModel(
+        _ vm: BandChartViewModel,
+        for panelID: SpectrumPanelID,
+        band: ChannelBand,
+        networks: [WiFiNetwork],
+        trends: [String: (direction: TrendDirection, delta: Int)],
+        snapshots: [String: [NetworkSnapshot]]
+    ) {
         let panelDisplayStates = recomputePanelDisplayStates(for: networks, panelID: panelID)
-
-        let sorted24 = networks
-            .filter { $0.channel.band == .band24GHz }
+        let sorted = networks
+            .filter { $0.channel.band == band }
             .sorted { $0.channel.channelNumber < $1.channel.channelNumber }
-        if supportedBands.contains(.band24GHz) {
-            bandViewModel(for: panelID, selection: .band24).updateNetworks(
-                sorted24,
-                colorHasher: colorHasher,
-                displayStatesByID: panelDisplayStates,
-                trends: trends,
-                snapshots: snapshots
-            )
-        }
-
-        let sorted5 = networks
-            .filter { $0.channel.band == .band5GHz }
-            .sorted { $0.channel.channelNumber < $1.channel.channelNumber }
-        if supportedBands.contains(.band5GHz) {
-            bandViewModel(for: panelID, selection: .band5).updateNetworks(
-                sorted5,
-                colorHasher: colorHasher,
-                displayStatesByID: panelDisplayStates,
-                trends: trends,
-                snapshots: snapshots
-            )
-        }
-
-        let sorted6 = networks
-            .filter { $0.channel.band == .band6GHz }
-            .sorted { $0.channel.channelNumber < $1.channel.channelNumber }
-        if supportedBands.contains(.band6GHz) {
-            bandViewModel(for: panelID, selection: .band6).updateNetworks(
-                sorted6,
-                colorHasher: colorHasher,
-                displayStatesByID: panelDisplayStates,
-                trends: trends,
-                snapshots: snapshots
-            )
-        }
+        vm.updateNetworks(
+            sorted,
+            colorHasher: colorHasher,
+            displayStatesByID: panelDisplayStates,
+            trends: trends,
+            snapshots: snapshots
+        )
     }
 
     private func refreshPanelBandViewModels(_ panelID: SpectrumPanelID) {

--- a/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
@@ -227,6 +227,14 @@ final class ScannerViewModel {
             .filter { supportedBands.contains($0.band) }
     }
 
+    /// Shared history for a selected network, independent of any panel's band
+    /// ViewModels. Maps the stable network ID to its BSSID and reads the
+    /// shared SignalHistoryStore.
+    func snapshots(for networkID: String) -> [NetworkSnapshot]? {
+        guard let bssid = deduplicatedNetworks.first(where: { $0.id == networkID })?.bssid else { return nil }
+        return signalHistory.snapshotHistory(for: bssid)
+    }
+
     /// Cached table rows. Every `NetworkTableRow` field derives from stable
     /// state (true `rssi`, series metadata, display state, vendor database, and
     /// signal history); the animation tick only mutates `displayRSSI`, which

--- a/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
@@ -175,7 +175,7 @@ final class ScannerViewModel {
         [band24, band5, band6, primaryBand24, primaryBand5, primaryBand6, secondaryBand24, secondaryBand5, secondaryBand6]
     }
 
-    func bandViewModel(for panelID: SpectrumPanelID, selection: BandPanelSelection) -> BandChartViewModel {
+    func bandViewModel(for panelID: SpectrumPanelID, selection: SpectrumPanelViewType) -> BandChartViewModel {
         switch (panelID, selection) {
         case (.primary, .band24): return primaryBand24
         case (.primary, .band5): return primaryBand5
@@ -185,6 +185,8 @@ final class ScannerViewModel {
         case (.secondary, .band6): return secondaryBand6
         case (.primary, .trend): return primaryBand24
         case (.secondary, .trend): return secondaryBand24
+        case (.primary, .table): return primaryBand24
+        case (.secondary, .table): return secondaryBand24
         }
     }
 

--- a/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/Scanner/ScannerViewModel.swift
@@ -80,6 +80,9 @@ final class ScannerViewModel {
     private let secondaryBand24 = BandChartViewModel(band: .band24GHz)
     private let secondaryBand5 = BandChartViewModel(band: .band5GHz)
     private let secondaryBand6 = BandChartViewModel(band: .band6GHz)
+    private let tertiaryBand24 = BandChartViewModel(band: .band24GHz)
+    private let tertiaryBand5 = BandChartViewModel(band: .band5GHz)
+    private let tertiaryBand6 = BandChartViewModel(band: .band6GHz)
 
     var supportedBands: Set<ChannelBand> = []
     var isScanning = false
@@ -172,7 +175,7 @@ final class ScannerViewModel {
     }
 
     var allBandViewModels: [BandChartViewModel] {
-        [band24, band5, band6, primaryBand24, primaryBand5, primaryBand6, secondaryBand24, secondaryBand5, secondaryBand6]
+        [band24, band5, band6, primaryBand24, primaryBand5, primaryBand6, secondaryBand24, secondaryBand5, secondaryBand6, tertiaryBand24, tertiaryBand5, tertiaryBand6]
     }
 
     func bandViewModel(for panelID: SpectrumPanelID, selection: SpectrumPanelViewType) -> BandChartViewModel {
@@ -183,10 +186,15 @@ final class ScannerViewModel {
         case (.secondary, .band24): return secondaryBand24
         case (.secondary, .band5): return secondaryBand5
         case (.secondary, .band6): return secondaryBand6
+        case (.tertiary, .band24): return tertiaryBand24
+        case (.tertiary, .band5): return tertiaryBand5
+        case (.tertiary, .band6): return tertiaryBand6
         case (.primary, .trend): return primaryBand24
         case (.secondary, .trend): return secondaryBand24
+        case (.tertiary, .trend): return tertiaryBand24
         case (.primary, .table): return primaryBand24
         case (.secondary, .table): return secondaryBand24
+        case (.tertiary, .table): return tertiaryBand24
         }
     }
 
@@ -815,6 +823,7 @@ final class ScannerViewModel {
         }
         refreshBandViewModels(for: .primary, with: deduped, trends: trends, snapshots: snapshotDict)
         refreshBandViewModels(for: .secondary, with: deduped, trends: trends, snapshots: snapshotDict)
+        refreshBandViewModels(for: .tertiary, with: deduped, trends: trends, snapshots: snapshotDict)
 
         // Validate selected network still exists in the new scan
         if let selectedID = selectedNetworkID {
@@ -839,6 +848,7 @@ final class ScannerViewModel {
         displayStatesByID = recomputeDisplayStates(for: deduplicatedNetworks)
         refreshPanelBandViewModels(.primary)
         refreshPanelBandViewModels(.secondary)
+        refreshPanelBandViewModels(.tertiary)
         rebuildCachedDerivedData()
     }
 
@@ -850,6 +860,7 @@ final class ScannerViewModel {
         )
         refreshPanelBandViewModels(.primary)
         refreshPanelBandViewModels(.secondary)
+        refreshPanelBandViewModels(.tertiary)
         rebuildCachedDerivedData()
     }
 
@@ -861,6 +872,7 @@ final class ScannerViewModel {
         )
         refreshPanelBandViewModels(.primary)
         refreshPanelBandViewModels(.secondary)
+        refreshPanelBandViewModels(.tertiary)
         rebuildCachedDerivedData()
     }
 

--- a/WiFiLens/Sources/WiFiLens/Spectrum/BandPanelSelection.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/BandPanelSelection.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SpectrumPanelID: String, CaseIterable, Hashable {
     case primary
     case secondary
+    case tertiary
 }
 
 enum SpectrumPanelViewType: String, CaseIterable, Identifiable {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/BandPanelSelection.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/BandPanelSelection.swift
@@ -5,29 +5,32 @@ enum SpectrumPanelID: String, CaseIterable, Hashable {
     case secondary
 }
 
-enum BandPanelSelection: String, CaseIterable, Identifiable {
+enum SpectrumPanelViewType: String, CaseIterable, Identifiable {
     case band24 = "24"
     case band5 = "5"
     case band6 = "6"
     case trend = "trend"
-    
+    case table = "table"
+
     var id: String { rawValue }
-    
+
     var displayName: String {
         switch self {
         case .band24: return String(localized: "spectrum.panel.band.24ghz", comment: "2.4 GHz band label in spectrum panel")
         case .band5: return String(localized: "spectrum.panel.band.5ghz", comment: "5 GHz band label in spectrum panel")
         case .band6: return String(localized: "spectrum.panel.band.6ghz", comment: "6 GHz band label in spectrum panel")
         case .trend: return String(localized: "spectrum.panel.trend", comment: "Trend chart label in spectrum panel")
+        case .table: return String(localized: "spectrum.panel.table", comment: "Table view label in spectrum panel")
         }
     }
-    
+
     var icon: String {
         switch self {
         case .band24: return "wave.3.left"
         case .band5: return "wave.3.right"
         case .band6: return "wave.3.right.circle"
         case .trend: return "chart.line.uptrend.xyaxis"
+        case .table: return "tablecells"
         }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var sortOrder: [NSSortDescriptor] = [NSSortDescriptor(key: "ssid", ascending: true)]
     @State private var panel1ChartType: SpectrumPanelViewType = .band24
     @State private var panel2ChartType: SpectrumPanelViewType = .band5
+    @State private var panel3ChartType: SpectrumPanelViewType = .table
     @AppStorage("hiddenTableColumns") private var hiddenColumnsData: String = ""
 
     private var hiddenColumns: Binding<Set<String>> {
@@ -95,10 +96,12 @@ struct ContentView: View {
 
                     Divider()
 
-                    VStack(spacing: 0) {
-                        tableFilterBar
-                        bottomTable
-                    }
+                    SpectrumPanelView(
+                        viewModel: viewModel,
+                        panelID: .tertiary,
+                        chartType: $panel3ChartType,
+                        selectedNetworkID: $viewModel.selectedNetworkID
+                    )
                     .frame(height: layout.tableHeight)
                 }
             }

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -23,9 +23,6 @@ struct ContentView: View {
     let isVendorColumnAvailable: Bool
 
     @State private var sortOrder: [NSSortDescriptor] = [NSSortDescriptor(key: "ssid", ascending: true)]
-    @State private var panel1ChartType: SpectrumPanelViewType = .band24
-    @State private var panel2ChartType: SpectrumPanelViewType = .band5
-    @State private var panel3ChartType: SpectrumPanelViewType = .table
     @AppStorage("hiddenTableColumns") private var hiddenColumnsData: String = ""
 
     private var hiddenColumns: Binding<Set<String>> {
@@ -74,11 +71,11 @@ struct ContentView: View {
                     emptyState
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    SpectrumPanelView(
+                    SpectrumPanelContainer(
                         viewModel: viewModel,
                         panelID: .primary,
                         isVendorColumnAvailable: isVendorColumnAvailable,
-                        chartType: $panel1ChartType,
+                        defaultViewType: .band24,
                         selectedNetworkID: $viewModel.selectedNetworkID,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
@@ -87,11 +84,11 @@ struct ContentView: View {
 
                     Divider()
 
-                    SpectrumPanelView(
+                    SpectrumPanelContainer(
                         viewModel: viewModel,
                         panelID: .secondary,
                         isVendorColumnAvailable: isVendorColumnAvailable,
-                        chartType: $panel2ChartType,
+                        defaultViewType: .band5,
                         selectedNetworkID: $viewModel.selectedNetworkID,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
@@ -100,11 +97,11 @@ struct ContentView: View {
 
                     Divider()
 
-                    SpectrumPanelView(
+                    SpectrumPanelContainer(
                         viewModel: viewModel,
                         panelID: .tertiary,
                         isVendorColumnAvailable: isVendorColumnAvailable,
-                        chartType: $panel3ChartType,
+                        defaultViewType: .table,
                         selectedNetworkID: $viewModel.selectedNetworkID,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -25,8 +25,8 @@ struct ContentView: View {
     let isVendorColumnAvailable: Bool
 
     @State private var sortOrder: [NSSortDescriptor] = [NSSortDescriptor(key: "ssid", ascending: true)]
-    @State private var panel1ChartType: BandPanelSelection = .band24
-    @State private var panel2ChartType: BandPanelSelection = .band5
+    @State private var panel1ChartType: SpectrumPanelViewType = .band24
+    @State private var panel2ChartType: SpectrumPanelViewType = .band5
     @AppStorage("hiddenTableColumns") private var hiddenColumnsData: String = ""
 
     private var hiddenColumns: Binding<Set<String>> {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -79,9 +79,9 @@ struct ContentView: View {
                     SpectrumPanelView(
                         viewModel: viewModel,
                         panelID: .primary,
+                        isVendorColumnAvailable: isVendorColumnAvailable,
                         chartType: $panel1ChartType,
                         selectedNetworkID: $viewModel.selectedNetworkID,
-                        isVendorColumnAvailable: isVendorColumnAvailable,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
                     )
@@ -92,9 +92,9 @@ struct ContentView: View {
                     SpectrumPanelView(
                         viewModel: viewModel,
                         panelID: .secondary,
+                        isVendorColumnAvailable: isVendorColumnAvailable,
                         chartType: $panel2ChartType,
                         selectedNetworkID: $viewModel.selectedNetworkID,
-                        isVendorColumnAvailable: isVendorColumnAvailable,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
                     )
@@ -105,9 +105,9 @@ struct ContentView: View {
                     SpectrumPanelView(
                         viewModel: viewModel,
                         panelID: .tertiary,
+                        isVendorColumnAvailable: isVendorColumnAvailable,
                         chartType: $panel3ChartType,
                         selectedNetworkID: $viewModel.selectedNetworkID,
-                        isVendorColumnAvailable: isVendorColumnAvailable,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
                     )

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -96,11 +96,11 @@ struct ContentView: View {
 
                     Divider()
 
-                    SpectrumPanelView(
+                    SpectrumTablePanel(
                         viewModel: viewModel,
-                        panelID: .tertiary,
-                        chartType: $panel3ChartType,
-                        selectedNetworkID: $viewModel.selectedNetworkID
+                        isVendorColumnAvailable: isVendorColumnAvailable,
+                        sortOrder: $sortOrder,
+                        hiddenColumns: hiddenColumns
                     )
                     .frame(height: layout.tableHeight)
                 }
@@ -109,72 +109,6 @@ struct ContentView: View {
         }
         .accessibilityIdentifier("spectrum-dashboard")
         .accessibilityElement(children: .contain)
-    }
-
-    private var tableFilterBar: some View {
-        HStack(spacing: 12) {
-            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
-                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs")).font(.caption)
-            }
-            .toggleStyle(.checkbox)
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(.bar)
-    }
-
-    private var tableRows: [NetworkTableRow] {
-        viewModel.combinedTableRows
-    }
-
-    private var sortedRows: [NetworkTableRow] {
-        guard !sortOrder.isEmpty else { return tableRows }
-        return tableRows.sorted { a, b in
-            for desc in sortOrder {
-                let result = compareRow(a, b, key: desc.key ?? "", ascending: desc.ascending)
-                if result != .orderedSame { return result == .orderedAscending }
-            }
-            return false
-        }
-    }
-
-    private func compareRow(_ a: NetworkTableRow, _ b: NetworkTableRow, key: String, ascending: Bool) -> ComparisonResult {
-        let cmp: ComparisonResult
-        switch key {
-        case "ssid": cmp = a.ssid.localizedCaseInsensitiveCompare(b.ssid)
-        case "vendor": cmp = a.vendor.localizedCaseInsensitiveCompare(b.vendor)
-        case "bandLabel": cmp = a.bandLabel.localizedCaseInsensitiveCompare(b.bandLabel)
-        case "channel": cmp = a.channel < b.channel ? .orderedAscending : a.channel > b.channel ? .orderedDescending : .orderedSame
-        case "rssi": cmp = a.rssi > b.rssi ? .orderedAscending : a.rssi < b.rssi ? .orderedDescending : .orderedSame
-        case "bssid": cmp = a.bssid.localizedCaseInsensitiveCompare(b.bssid)
-        case "phyMode": cmp = a.phyMode.localizedCaseInsensitiveCompare(b.phyMode)
-        case "channelWidth": cmp = Int(a.channelWidth) ?? 0 < Int(b.channelWidth) ?? 0 ? .orderedAscending : Int(a.channelWidth) ?? 0 > Int(b.channelWidth) ?? 0 ? .orderedDescending : .orderedSame
-        case "supportsK": cmp = a.supportsK == b.supportsK ? .orderedSame : a.supportsK ? .orderedDescending : .orderedAscending
-        case "supportsR": cmp = a.supportsR == b.supportsR ? .orderedSame : a.supportsR ? .orderedDescending : .orderedAscending
-        case "supportsV": cmp = a.supportsV == b.supportsV ? .orderedSame : a.supportsV ? .orderedDescending : .orderedAscending
-        case "isHiddenSSID": cmp = a.isHiddenSSID == b.isHiddenSSID ? .orderedSame : a.isHiddenSSID ? .orderedDescending : .orderedAscending
-        case "qualityScore": cmp = a.qualityScore > b.qualityScore ? .orderedAscending : a.qualityScore < b.qualityScore ? .orderedDescending : .orderedSame
-        case "security": cmp = a.security.localizedCaseInsensitiveCompare(b.security)
-        case "mcs": cmp = (Int(a.mcs) ?? 0) < (Int(b.mcs) ?? 0) ? .orderedAscending : (Int(a.mcs) ?? 0) > (Int(b.mcs) ?? 0) ? .orderedDescending : .orderedSame
-        case "nss": cmp = (Int(a.nss) ?? 0) < (Int(b.nss) ?? 0) ? .orderedAscending : (Int(a.nss) ?? 0) > (Int(b.nss) ?? 0) ? .orderedDescending : .orderedSame
-        case "country": cmp = a.country.localizedCaseInsensitiveCompare(b.country)
-        case "lastSeen": cmp = a.lastSeen.localizedCaseInsensitiveCompare(b.lastSeen)
-        default: cmp = .orderedSame
-        }
-        return ascending ? cmp : (cmp == .orderedAscending ? .orderedDescending : cmp == .orderedDescending ? .orderedAscending : .orderedSame)
-    }
-
-    private var bottomTable: some View {
-        NativeTableView(
-            rows: sortedRows,
-            selectedID: $viewModel.selectedNetworkID,
-            sortOrder: $sortOrder,
-            hiddenColumns: hiddenColumns,
-            isVendorColumnAvailable: isVendorColumnAvailable,
-            onToggleVisibility: { seriesID in viewModel.toggleVisibility(seriesID: seriesID) },
-            onToggleVisibilityLocked: { seriesID in viewModel.toggleVisibilityLocked(seriesID: seriesID) }
-        )
     }
 
     private var shouldShowEmptyState: Bool {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -1,22 +1,20 @@
 import SwiftUI
 
 struct SpectrumDashboardLayout {
-    static let primaryRatio: CGFloat = 0.35
-    static let secondaryRatio: CGFloat = 0.35
-    static let tableRatio: CGFloat = 0.30
+    static let panelRatio: CGFloat = 1.0 / 3.0
 
     let viewportHeight: CGFloat
 
     var primaryHeight: CGFloat {
-        viewportHeight * Self.primaryRatio
+        viewportHeight * Self.panelRatio
     }
 
     var secondaryHeight: CGFloat {
-        viewportHeight * Self.secondaryRatio
+        viewportHeight * Self.panelRatio
     }
 
-    var tableHeight: CGFloat {
-        viewportHeight * Self.tableRatio
+    var tertiaryHeight: CGFloat {
+        viewportHeight * Self.panelRatio
     }
 }
 
@@ -111,7 +109,7 @@ struct ContentView: View {
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns
                     )
-                    .frame(height: layout.tableHeight)
+                    .frame(height: layout.tertiaryHeight)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/ContentView.swift
@@ -80,7 +80,10 @@ struct ContentView: View {
                         viewModel: viewModel,
                         panelID: .primary,
                         chartType: $panel1ChartType,
-                        selectedNetworkID: $viewModel.selectedNetworkID
+                        selectedNetworkID: $viewModel.selectedNetworkID,
+                        isVendorColumnAvailable: isVendorColumnAvailable,
+                        sortOrder: $sortOrder,
+                        hiddenColumns: hiddenColumns
                     )
                     .frame(height: layout.primaryHeight)
 
@@ -90,14 +93,20 @@ struct ContentView: View {
                         viewModel: viewModel,
                         panelID: .secondary,
                         chartType: $panel2ChartType,
-                        selectedNetworkID: $viewModel.selectedNetworkID
+                        selectedNetworkID: $viewModel.selectedNetworkID,
+                        isVendorColumnAvailable: isVendorColumnAvailable,
+                        sortOrder: $sortOrder,
+                        hiddenColumns: hiddenColumns
                     )
                     .frame(height: layout.secondaryHeight)
 
                     Divider()
 
-                    SpectrumTablePanel(
+                    SpectrumPanelView(
                         viewModel: viewModel,
+                        panelID: .tertiary,
+                        chartType: $panel3ChartType,
+                        selectedNetworkID: $viewModel.selectedNetworkID,
                         isVendorColumnAvailable: isVendorColumnAvailable,
                         sortOrder: $sortOrder,
                         hiddenColumns: hiddenColumns

--- a/WiFiLens/Sources/WiFiLens/Spectrum/NetworkTableRowSorter.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/NetworkTableRowSorter.swift
@@ -1,0 +1,53 @@
+import AppKit
+
+enum NetworkTableRowSorter {
+    static func sort(
+        _ rows: [NetworkTableRow],
+        by sortOrder: [NSSortDescriptor]
+    ) -> [NetworkTableRow] {
+        guard !sortOrder.isEmpty else { return rows }
+        return rows.sorted { a, b in
+            for descriptor in sortOrder {
+                let result = compare(a, b, key: descriptor.key ?? "", ascending: descriptor.ascending)
+                if result != .orderedSame { return result == .orderedAscending }
+            }
+            return false
+        }
+    }
+
+    private static func compare(
+        _ a: NetworkTableRow,
+        _ b: NetworkTableRow,
+        key: String,
+        ascending: Bool
+    ) -> ComparisonResult {
+        let cmp: ComparisonResult
+        switch key {
+        case "ssid": cmp = a.ssid.localizedCaseInsensitiveCompare(b.ssid)
+        case "vendor": cmp = a.vendor.localizedCaseInsensitiveCompare(b.vendor)
+        case "bandLabel": cmp = a.bandLabel.localizedCaseInsensitiveCompare(b.bandLabel)
+        case "channel": cmp = a.channel < b.channel ? .orderedAscending : a.channel > b.channel ? .orderedDescending : .orderedSame
+        case "rssi": cmp = a.rssi > b.rssi ? .orderedAscending : a.rssi < b.rssi ? .orderedDescending : .orderedSame
+        case "bssid": cmp = a.bssid.localizedCaseInsensitiveCompare(b.bssid)
+        case "phyMode": cmp = a.phyMode.localizedCaseInsensitiveCompare(b.phyMode)
+        case "channelWidth": cmp = Int(a.channelWidth) ?? 0 < Int(b.channelWidth) ?? 0 ? .orderedAscending : Int(a.channelWidth) ?? 0 > Int(b.channelWidth) ?? 0 ? .orderedDescending : .orderedSame
+        case "supportsK": cmp = a.supportsK == b.supportsK ? .orderedSame : a.supportsK ? .orderedDescending : .orderedAscending
+        case "supportsR": cmp = a.supportsR == b.supportsR ? .orderedSame : a.supportsR ? .orderedDescending : .orderedAscending
+        case "supportsV": cmp = a.supportsV == b.supportsV ? .orderedSame : a.supportsV ? .orderedDescending : .orderedAscending
+        case "isHiddenSSID": cmp = a.isHiddenSSID == b.isHiddenSSID ? .orderedSame : a.isHiddenSSID ? .orderedDescending : .orderedAscending
+        case "qualityScore": cmp = a.qualityScore > b.qualityScore ? .orderedAscending : a.qualityScore < b.qualityScore ? .orderedDescending : .orderedSame
+        case "security": cmp = a.security.localizedCaseInsensitiveCompare(b.security)
+        case "mcs": cmp = (Int(a.mcs) ?? 0) < (Int(b.mcs) ?? 0) ? .orderedAscending : (Int(a.mcs) ?? 0) > (Int(b.mcs) ?? 0) ? .orderedDescending : .orderedSame
+        case "nss": cmp = (Int(a.nss) ?? 0) < (Int(b.nss) ?? 0) ? .orderedAscending : (Int(a.nss) ?? 0) > (Int(b.nss) ?? 0) ? .orderedDescending : .orderedSame
+        case "country": cmp = a.country.localizedCaseInsensitiveCompare(b.country)
+        case "lastSeen": cmp = a.lastSeen.localizedCaseInsensitiveCompare(b.lastSeen)
+        default: cmp = .orderedSame
+        }
+        if ascending { return cmp }
+        switch cmp {
+        case .orderedAscending: return .orderedDescending
+        case .orderedDescending: return .orderedAscending
+        case .orderedSame: return .orderedSame
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
@@ -6,65 +6,31 @@ struct SpectrumBandPanel: View {
     let chartType: SpectrumPanelViewType
     @Binding var selectedNetworkID: String?
 
-    private var bandVM: BandChartViewModel {
+    var bandVM: BandChartViewModel {
         viewModel.bandViewModel(for: panelID, selection: chartType)
     }
 
-    private var filterQueryBinding: Binding<String> {
+    var filterQueryBinding: Binding<String> {
         Binding(
             get: { viewModel.filterQuery(for: panelID) },
             set: { viewModel.setFilterQuery($0, for: panelID) }
         )
     }
 
-    private var totalCount: Int {
+    var totalCount: Int {
         bandVM.networkCount
     }
 
-    private var displayedCount: Int {
+    var displayedCount: Int {
         bandVM.visibleSeriesData().count
     }
 
-    private var hiddenCount: Int {
+    var hiddenCount: Int {
         totalCount - displayedCount
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            chart
-        }
-    }
-
-    private var toolbar: some View {
-        HStack(spacing: 8) {
-            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: filterQueryBinding)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 300)
-
-            if hiddenCount > 0 {
-                Text("\(displayedCount)/\(totalCount)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            if !filterQueryBinding.wrappedValue.isEmpty {
-                Button {
-                    filterQueryBinding.wrappedValue = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(.bar)
+        chart
     }
 
     private var chart: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
@@ -30,7 +30,42 @@ struct SpectrumBandPanel: View {
     }
 
     var body: some View {
-        chart
+        VStack(spacing: 0) {
+            toolbar
+            chart
+        }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: filterQueryBinding)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 300)
+
+            if hiddenCount > 0 {
+                Text("\(displayedCount)/\(totalCount)")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+
+            if !filterQueryBinding.wrappedValue.isEmpty {
+                Button {
+                    filterQueryBinding.wrappedValue = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+            }
+
+            Spacer()
+        }
+        .frame(minHeight: 24)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.bar)
     }
 
     private var chart: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct SpectrumBandPanel: View {
+    let viewModel: ScannerViewModel
+    let panelID: SpectrumPanelID
+    let chartType: SpectrumPanelViewType
+    @Binding var selectedNetworkID: String?
+
+    private var bandVM: BandChartViewModel {
+        viewModel.bandViewModel(for: panelID, selection: chartType)
+    }
+
+    private var filterQueryBinding: Binding<String> {
+        Binding(
+            get: { viewModel.filterQuery(for: panelID) },
+            set: { viewModel.setFilterQuery($0, for: panelID) }
+        )
+    }
+
+    private var totalCount: Int {
+        bandVM.networkCount
+    }
+
+    private var displayedCount: Int {
+        bandVM.visibleSeriesData().count
+    }
+
+    private var hiddenCount: Int {
+        totalCount - displayedCount
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            chart
+        }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: filterQueryBinding)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 300)
+
+            if hiddenCount > 0 {
+                Text("\(displayedCount)/\(totalCount)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if !filterQueryBinding.wrappedValue.isEmpty {
+                Button {
+                    filterQueryBinding.wrappedValue = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.bar)
+    }
+
+    private var chart: some View {
+        WiFiBandChart(
+            model: bandVM.renderModel,
+            selectedNetworkID: $selectedNetworkID,
+            onResetZoom: { bandVM.resetZoom() },
+            onToggleExpand: { bandVM.toggleExpand() },
+            onApplyZoom: { lo, hi in bandVM.applyZoom(lo: lo, hi: hi) }
+        )
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .onAppear {
+                        bandVM.chartSize = geometry.size
+                    }
+                    .onChange(of: geometry.size) { _, newSize in
+                        bandVM.chartSize = newSize
+                    }
+            }
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumBandPanel.swift
@@ -30,13 +30,10 @@ struct SpectrumBandPanel: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            chart
-        }
+        chart
     }
 
-    private var toolbar: some View {
+    var toolbarContent: some View {
         HStack(spacing: 8) {
             TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: filterQueryBinding)
                 .textFieldStyle(.roundedBorder)
@@ -62,10 +59,6 @@ struct SpectrumBandPanel: View {
 
             Spacer()
         }
-        .frame(minHeight: 24)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(.bar)
     }
 
     private var chart: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelContainer.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelContainer.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct SpectrumPanelContainer: View {
+    let viewModel: ScannerViewModel
+    let panelID: SpectrumPanelID
+    let isVendorColumnAvailable: Bool
+    let defaultViewType: SpectrumPanelViewType
+    @Binding var selectedNetworkID: String?
+    @Binding var sortOrder: [NSSortDescriptor]
+    @Binding var hiddenColumns: Set<String>
+    @State private var viewType: SpectrumPanelViewType
+
+    init(
+        viewModel: ScannerViewModel,
+        panelID: SpectrumPanelID,
+        isVendorColumnAvailable: Bool,
+        defaultViewType: SpectrumPanelViewType,
+        selectedNetworkID: Binding<String?>,
+        sortOrder: Binding<[NSSortDescriptor]>,
+        hiddenColumns: Binding<Set<String>>
+    ) {
+        self.viewModel = viewModel
+        self.panelID = panelID
+        self.isVendorColumnAvailable = isVendorColumnAvailable
+        self.defaultViewType = defaultViewType
+        self._selectedNetworkID = selectedNetworkID
+        self._sortOrder = sortOrder
+        self._hiddenColumns = hiddenColumns
+        self._viewType = State(initialValue: defaultViewType)
+    }
+
+    var body: some View {
+        SpectrumPanelView(
+            viewModel: viewModel,
+            panelID: panelID,
+            isVendorColumnAvailable: isVendorColumnAvailable,
+            chartType: $viewType,
+            selectedNetworkID: $selectedNetworkID,
+            sortOrder: $sortOrder,
+            hiddenColumns: $hiddenColumns
+        )
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -9,24 +9,6 @@ struct SpectrumPanelView: View {
     @Binding var sortOrder: [NSSortDescriptor]
     @Binding var hiddenColumns: Set<String>
 
-    init(
-        viewModel: ScannerViewModel,
-        panelID: SpectrumPanelID,
-        chartType: Binding<SpectrumPanelViewType>,
-        selectedNetworkID: Binding<String?>,
-        isVendorColumnAvailable: Bool,
-        sortOrder: Binding<[NSSortDescriptor]>,
-        hiddenColumns: Binding<Set<String>>
-    ) {
-        self.viewModel = viewModel
-        self.panelID = panelID
-        self.chartType = chartType
-        self.selectedNetworkID = selectedNetworkID
-        self.isVendorColumnAvailable = isVendorColumnAvailable
-        self.sortOrder = sortOrder
-        self.hiddenColumns = hiddenColumns
-    }
-
     private var currentBandVM: BandChartViewModel {
         bandViewModel(for: chartType)
     }
@@ -63,7 +45,7 @@ struct SpectrumPanelView: View {
     private var toolbar: some View {
         HStack(spacing: 8) {
             Picker(String(localized: "spectrum.panel.chart_type", comment: "Chart type picker label"), selection: $chartType) {
-                ForEach(supportedChartTypes) { type in
+                ForEach(supportedViewTypes) { type in
                     Text(type.displayName)
                         .lineLimit(1)
                         .tag(type)

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -9,29 +9,6 @@ struct SpectrumPanelView: View {
     @Binding var sortOrder: [NSSortDescriptor]
     @Binding var hiddenColumns: Set<String>
 
-    private var currentBandVM: BandChartViewModel {
-        bandViewModel(for: chartType)
-    }
-
-    private var filterQueryBinding: Binding<String> {
-        Binding(
-            get: { viewModel.filterQuery(for: panelID) },
-            set: { viewModel.setFilterQuery($0, for: panelID) }
-        )
-    }
-
-    private var totalCount: Int {
-        currentBandVM.networkCount
-    }
-
-    private var displayedCount: Int {
-        currentBandVM.visibleSeriesData().count
-    }
-
-    private var hiddenCount: Int {
-        totalCount - displayedCount
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             toolbar
@@ -54,28 +31,6 @@ struct SpectrumPanelView: View {
             .pickerStyle(.menu)
             .frame(width: 180)
 
-            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: filterQueryBinding)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 300)
-
-            if hiddenCount > 0 {
-                Text("\(displayedCount)/\(totalCount)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            if !filterQueryBinding.wrappedValue.isEmpty {
-                Button {
-                    filterQueryBinding.wrappedValue = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-            }
-
             Spacer()
         }
         .padding(.horizontal, 8)
@@ -89,52 +44,20 @@ struct SpectrumPanelView: View {
     private var chartContent: some View {
         switch chartType {
         case .band24, .band5, .band6:
-            spectrumChart
+            SpectrumBandPanel(
+                viewModel: viewModel,
+                panelID: panelID,
+                chartType: chartType,
+                selectedNetworkID: $selectedNetworkID
+            )
         case .trend:
-            trendChart
+            SpectrumTrendPanel(
+                viewModel: viewModel,
+                panelID: panelID,
+                selectedNetworkID: $selectedNetworkID
+            )
         case .table:
             tablePanel
-        }
-    }
-
-    private var spectrumChart: some View {
-        let bandVM = bandViewModel(for: chartType)
-        return WiFiBandChart(
-            model: bandVM.renderModel,
-            selectedNetworkID: $selectedNetworkID,
-            onResetZoom: { bandVM.resetZoom() },
-            onToggleExpand: { bandVM.toggleExpand() },
-            onApplyZoom: { lo, hi in bandVM.applyZoom(lo: lo, hi: hi) }
-        )
-        .background {
-            GeometryReader { geometry in
-                Color.clear
-                    .onAppear {
-                        bandVM.chartSize = geometry.size
-                    }
-                    .onChange(of: geometry.size) { _, newSize in
-                        bandVM.chartSize = newSize
-                    }
-            }
-        }
-    }
-
-    private var trendChart: some View {
-        Group {
-            if let selID = selectedNetworkID,
-               let snaps = selectedNetworkSnapshots(for: selID),
-               let series = selectedNetworkSeries(for: selID),
-               snaps.count >= 2 {
-                TrendChartView(snapshots: snaps, color: series.color)
-            } else {
-                VStack {
-                    Spacer()
-                    Text(String(localized: "spectrum.panel.select_network_for_trend", comment: "Placeholder when no network is selected for trend chart"))
-                        .foregroundColor(.secondary)
-                        .font(.caption)
-                    Spacer()
-                }
-            }
         }
     }
 
@@ -159,25 +82,4 @@ struct SpectrumPanelView: View {
         return types
     }
 
-    private func bandViewModel(for selection: SpectrumPanelViewType) -> BandChartViewModel {
-        viewModel.bandViewModel(for: panelID, selection: selection)
-    }
-
-    private func selectedNetworkSnapshots(for networkID: String) -> [NetworkSnapshot]? {
-        for vm in viewModel.panelBandViewModels(for: panelID) {
-            if let snaps = vm.snapshots(for: networkID) {
-                return snaps
-            }
-        }
-        return nil
-    }
-
-    private func selectedNetworkSeries(for networkID: String) -> ChartSeriesData? {
-        for vm in viewModel.panelBandViewModels(for: panelID) {
-            if let series = vm.series(for: networkID) {
-                return series
-            }
-        }
-        return nil
-    }
 }

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -113,7 +113,6 @@ struct SpectrumPanelView: View {
         case .trend:
             SpectrumTrendPanel(
                 viewModel: viewModel,
-                panelID: panelID,
                 selectedNetworkID: $selectedNetworkID
             )
         case .table:

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -90,7 +90,7 @@ struct SpectrumPanelView: View {
             .controlSize(.regular)
 
             if !viewModel.combinedTableRows.isEmpty {
-                Text("\(viewModel.combinedTableRows.count)")
+                Text(String(format: String(localized: "spectrum.panel.table_count_fmt", comment: "Network count in table toolbar"), viewModel.combinedTableRows.count))
                     .font(.body)
                     .foregroundColor(.secondary)
             }

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -31,6 +31,15 @@ struct SpectrumPanelView: View {
             .pickerStyle(.menu)
             .frame(width: 180)
 
+            switch chartType {
+            case .band24, .band5, .band6:
+                bandPanel.toolbarContent
+            case .trend:
+                EmptyView()
+            case .table:
+                tablePanel.toolbarContent
+            }
+
             Spacer()
         }
         .frame(minHeight: 24)
@@ -39,18 +48,22 @@ struct SpectrumPanelView: View {
         .background(.bar)
     }
 
+    private var bandPanel: SpectrumBandPanel {
+        SpectrumBandPanel(
+            viewModel: viewModel,
+            panelID: panelID,
+            chartType: chartType,
+            selectedNetworkID: $selectedNetworkID
+        )
+    }
+
     // MARK: - Chart Content
 
     @ViewBuilder
     private var chartContent: some View {
         switch chartType {
         case .band24, .band5, .band6:
-            SpectrumBandPanel(
-                viewModel: viewModel,
-                panelID: panelID,
-                chartType: chartType,
-                selectedNetworkID: $selectedNetworkID
-            )
+            bandPanel
         case .trend:
             SpectrumTrendPanel(
                 viewModel: viewModel,
@@ -61,7 +74,7 @@ struct SpectrumPanelView: View {
         }
     }
 
-    private var tablePanel: some View {
+    private var tablePanel: SpectrumTablePanel {
         SpectrumTablePanel(
             viewModel: viewModel,
             isVendorColumnAvailable: isVendorColumnAvailable,

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SpectrumPanelView: View {
     let viewModel: ScannerViewModel
     let panelID: SpectrumPanelID
-    @Binding var chartType: BandPanelSelection
+    @Binding var chartType: SpectrumPanelViewType
     @Binding var selectedNetworkID: String?
 
     private var currentBandVM: BandChartViewModel {
@@ -89,6 +89,8 @@ struct SpectrumPanelView: View {
             spectrumChart
         case .trend:
             trendChart
+        case .table:
+            trendChart // temporary compile-safe fallback; replaced in Task 4
         }
     }
 
@@ -135,8 +137,8 @@ struct SpectrumPanelView: View {
 
     // MARK: - Helpers
 
-    private var supportedChartTypes: [BandPanelSelection] {
-        var types: [BandPanelSelection] = []
+    private var supportedChartTypes: [SpectrumPanelViewType] {
+        var types: [SpectrumPanelViewType] = []
         if viewModel.supportedBands.contains(.band24GHz) { types.append(.band24) }
         if viewModel.supportedBands.contains(.band5GHz) { types.append(.band5) }
         if viewModel.supportedBands.contains(.band6GHz) { types.append(.band6) }
@@ -144,7 +146,7 @@ struct SpectrumPanelView: View {
         return types
     }
 
-    private func bandViewModel(for selection: BandPanelSelection) -> BandChartViewModel {
+    private func bandViewModel(for selection: SpectrumPanelViewType) -> BandChartViewModel {
         viewModel.bandViewModel(for: panelID, selection: selection)
     }
 

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -42,6 +42,7 @@ struct SpectrumPanelView: View {
 
             Spacer()
         }
+        .frame(minHeight: 24)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(.bar)
@@ -61,7 +62,7 @@ struct SpectrumPanelView: View {
 
             if bandPanel.hiddenCount > 0 {
                 Text("\(bandPanel.displayedCount)/\(bandPanel.totalCount)")
-                    .font(.caption)
+                    .font(.body)
                     .foregroundColor(.secondary)
             }
 
@@ -83,16 +84,18 @@ struct SpectrumPanelView: View {
         HStack(spacing: 12) {
             Toggle(isOn: $viewModel.hideHiddenSSIDs) {
                 Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
-                    .font(.caption)
+                    .font(.body)
             }
             .toggleStyle(.checkbox)
+            .controlSize(.regular)
 
             if !viewModel.combinedTableRows.isEmpty {
                 Text("\(viewModel.combinedTableRows.count)")
-                    .font(.caption)
+                    .font(.body)
                     .foregroundColor(.secondary)
             }
         }
+        .frame(minHeight: 24)
     }
 
     // MARK: - Chart Content

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -3,8 +3,29 @@ import SwiftUI
 struct SpectrumPanelView: View {
     let viewModel: ScannerViewModel
     let panelID: SpectrumPanelID
+    let isVendorColumnAvailable: Bool
     @Binding var chartType: SpectrumPanelViewType
     @Binding var selectedNetworkID: String?
+    @Binding var sortOrder: [NSSortDescriptor]
+    @Binding var hiddenColumns: Set<String>
+
+    init(
+        viewModel: ScannerViewModel,
+        panelID: SpectrumPanelID,
+        chartType: Binding<SpectrumPanelViewType>,
+        selectedNetworkID: Binding<String?>,
+        isVendorColumnAvailable: Bool,
+        sortOrder: Binding<[NSSortDescriptor]>,
+        hiddenColumns: Binding<Set<String>>
+    ) {
+        self.viewModel = viewModel
+        self.panelID = panelID
+        self.chartType = chartType
+        self.selectedNetworkID = selectedNetworkID
+        self.isVendorColumnAvailable = isVendorColumnAvailable
+        self.sortOrder = sortOrder
+        self.hiddenColumns = hiddenColumns
+    }
 
     private var currentBandVM: BandChartViewModel {
         bandViewModel(for: chartType)
@@ -90,7 +111,7 @@ struct SpectrumPanelView: View {
         case .trend:
             trendChart
         case .table:
-            trendChart // temporary compile-safe fallback; replaced in Task 4
+            tablePanel
         }
     }
 
@@ -135,14 +156,24 @@ struct SpectrumPanelView: View {
         }
     }
 
+    private var tablePanel: some View {
+        SpectrumTablePanel(
+            viewModel: viewModel,
+            isVendorColumnAvailable: isVendorColumnAvailable,
+            sortOrder: $sortOrder,
+            hiddenColumns: $hiddenColumns
+        )
+    }
+
     // MARK: - Helpers
 
-    private var supportedChartTypes: [SpectrumPanelViewType] {
+    var supportedViewTypes: [SpectrumPanelViewType] {
         var types: [SpectrumPanelViewType] = []
         if viewModel.supportedBands.contains(.band24GHz) { types.append(.band24) }
         if viewModel.supportedBands.contains(.band5GHz) { types.append(.band5) }
         if viewModel.supportedBands.contains(.band6GHz) { types.append(.band6) }
         types.append(.trend)
+        types.append(.table)
         return types
     }
 

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -31,71 +31,12 @@ struct SpectrumPanelView: View {
             .pickerStyle(.menu)
             .frame(width: 180)
 
-            switch chartType {
-            case .band24, .band5, .band6:
-                bandToolbar
-            case .trend:
-                EmptyView()
-            case .table:
-                tableToolbar
-            }
-
             Spacer()
         }
         .frame(minHeight: 24)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(.bar)
-    }
-
-    private var bandToolbar: some View {
-        let bandPanel = SpectrumBandPanel(
-            viewModel: viewModel,
-            panelID: panelID,
-            chartType: chartType,
-            selectedNetworkID: $selectedNetworkID
-        )
-        return HStack(spacing: 8) {
-            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: bandPanel.filterQueryBinding)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 300)
-
-            if bandPanel.hiddenCount > 0 {
-                Text("\(bandPanel.displayedCount)/\(bandPanel.totalCount)")
-                    .font(.body)
-                    .foregroundColor(.secondary)
-            }
-
-            if !bandPanel.filterQueryBinding.wrappedValue.isEmpty {
-                Button {
-                    bandPanel.filterQueryBinding.wrappedValue = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
-            }
-        }
-    }
-
-    private var tableToolbar: some View {
-        HStack(spacing: 12) {
-            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
-                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
-                    .font(.body)
-            }
-            .toggleStyle(.checkbox)
-            .controlSize(.regular)
-
-            if !viewModel.combinedTableRows.isEmpty {
-                Text(String(format: String(localized: "spectrum.panel.table_count_fmt", comment: "Network count in table toolbar"), viewModel.combinedTableRows.count))
-                    .font(.body)
-                    .foregroundColor(.secondary)
-            }
-        }
-        .frame(minHeight: 24)
     }
 
     // MARK: - Chart Content

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumPanelView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SpectrumPanelView: View {
-    let viewModel: ScannerViewModel
+    @Bindable var viewModel: ScannerViewModel
     let panelID: SpectrumPanelID
     let isVendorColumnAvailable: Bool
     @Binding var chartType: SpectrumPanelViewType
@@ -31,11 +31,68 @@ struct SpectrumPanelView: View {
             .pickerStyle(.menu)
             .frame(width: 180)
 
+            switch chartType {
+            case .band24, .band5, .band6:
+                bandToolbar
+            case .trend:
+                EmptyView()
+            case .table:
+                tableToolbar
+            }
+
             Spacer()
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(.bar)
+    }
+
+    private var bandToolbar: some View {
+        let bandPanel = SpectrumBandPanel(
+            viewModel: viewModel,
+            panelID: panelID,
+            chartType: chartType,
+            selectedNetworkID: $selectedNetworkID
+        )
+        return HStack(spacing: 8) {
+            TextField(String(localized: "spectrum.panel.filter_placeholder", comment: "Filter input placeholder"), text: bandPanel.filterQueryBinding)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 300)
+
+            if bandPanel.hiddenCount > 0 {
+                Text("\(bandPanel.displayedCount)/\(bandPanel.totalCount)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if !bandPanel.filterQueryBinding.wrappedValue.isEmpty {
+                Button {
+                    bandPanel.filterQueryBinding.wrappedValue = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+                .help(String(localized: "spectrum.filter.clear", comment: "Clear filter button"))
+            }
+        }
+    }
+
+    private var tableToolbar: some View {
+        HStack(spacing: 12) {
+            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
+                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+
+            if !viewModel.combinedTableRows.isEmpty {
+                Text("\(viewModel.combinedTableRows.count)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
     }
 
     // MARK: - Chart Content

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
@@ -7,32 +7,7 @@ struct SpectrumTablePanel: View {
     @Binding var hiddenColumns: Set<String>
 
     var body: some View {
-        VStack(spacing: 0) {
-            tableToolbar
-            tableContent
-        }
-        .padding(.trailing, 8)
-    }
-
-    private var tableToolbar: some View {
-        HStack(spacing: 12) {
-            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
-                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
-                    .font(.caption)
-            }
-            .toggleStyle(.checkbox)
-
-            if !viewModel.combinedTableRows.isEmpty {
-                Text("\(viewModel.combinedTableRows.count)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(.bar)
+        tableContent
     }
 
     private var tableContent: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SpectrumTablePanel: View {
+    @Bindable var viewModel: ScannerViewModel
+    let isVendorColumnAvailable: Bool
+    @Binding var sortOrder: [NSSortDescriptor]
+    @Binding var hiddenColumns: Set<String>
+
+    var body: some View {
+        VStack(spacing: 0) {
+            tableToolbar
+            tableContent
+        }
+        .padding(.trailing, 8)
+    }
+
+    private var tableToolbar: some View {
+        HStack(spacing: 12) {
+            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
+                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+
+            if !viewModel.combinedTableRows.isEmpty {
+                Text("\(viewModel.combinedTableRows.count)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(.bar)
+    }
+
+    private var tableContent: some View {
+        NativeTableView(
+            rows: NetworkTableRowSorter.sort(
+                viewModel.combinedTableRows,
+                by: sortOrder
+            ),
+            selectedID: $viewModel.selectedNetworkID,
+            sortOrder: $sortOrder,
+            hiddenColumns: $hiddenColumns,
+            isVendorColumnAvailable: isVendorColumnAvailable,
+            onToggleVisibility: { seriesID in viewModel.toggleVisibility(seriesID: seriesID) },
+            onToggleVisibilityLocked: { seriesID in viewModel.toggleVisibilityLocked(seriesID: seriesID) }
+        )
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
@@ -7,7 +7,33 @@ struct SpectrumTablePanel: View {
     @Binding var hiddenColumns: Set<String>
 
     var body: some View {
-        tableContent
+        VStack(spacing: 0) {
+            tableToolbar
+            tableContent
+        }
+    }
+
+    private var tableToolbar: some View {
+        HStack(spacing: 12) {
+            Toggle(isOn: $viewModel.hideHiddenSSIDs) {
+                Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
+                    .font(.body)
+            }
+            .toggleStyle(.checkbox)
+            .controlSize(.regular)
+
+            if !viewModel.combinedTableRows.isEmpty {
+                Text(String(format: String(localized: "spectrum.panel.table_count_fmt", comment: "Network count in table toolbar"), viewModel.combinedTableRows.count))
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+        }
+        .frame(minHeight: 24)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(.bar)
     }
 
     private var tableContent: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTablePanel.swift
@@ -7,13 +7,10 @@ struct SpectrumTablePanel: View {
     @Binding var hiddenColumns: Set<String>
 
     var body: some View {
-        VStack(spacing: 0) {
-            tableToolbar
-            tableContent
-        }
+        tableContent
     }
 
-    private var tableToolbar: some View {
+    var toolbarContent: some View {
         HStack(spacing: 12) {
             Toggle(isOn: $viewModel.hideHiddenSSIDs) {
                 Text(String(localized: "spectrum.filter.hide_hidden", comment: "Toggle to hide networks with hidden SSIDs"))
@@ -30,10 +27,6 @@ struct SpectrumTablePanel: View {
 
             Spacer()
         }
-        .frame(minHeight: 24)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(.bar)
     }
 
     private var tableContent: some View {

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTrendPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTrendPanel.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct SpectrumTrendPanel: View {
+    let viewModel: ScannerViewModel
+    let panelID: SpectrumPanelID
+    @Binding var selectedNetworkID: String?
+
+    var body: some View {
+        Group {
+            if let selID = selectedNetworkID,
+               let snaps = selectedNetworkSnapshots(for: selID),
+               let series = selectedNetworkSeries(for: selID),
+               snaps.count >= 2 {
+                TrendChartView(snapshots: snaps, color: series.color)
+            } else {
+                VStack {
+                    Spacer()
+                    Text(String(localized: "spectrum.panel.select_network_for_trend", comment: "Placeholder when no network is selected for trend chart"))
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    private func selectedNetworkSnapshots(for networkID: String) -> [NetworkSnapshot]? {
+        for vm in viewModel.panelBandViewModels(for: panelID) {
+            if let snaps = vm.snapshots(for: networkID) {
+                return snaps
+            }
+        }
+        return nil
+    }
+
+    private func selectedNetworkSeries(for networkID: String) -> ChartSeriesData? {
+        for vm in viewModel.panelBandViewModels(for: panelID) {
+            if let series = vm.series(for: networkID) {
+                return series
+            }
+        }
+        return nil
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTrendPanel.swift
+++ b/WiFiLens/Sources/WiFiLens/Spectrum/SpectrumTrendPanel.swift
@@ -2,16 +2,15 @@ import SwiftUI
 
 struct SpectrumTrendPanel: View {
     let viewModel: ScannerViewModel
-    let panelID: SpectrumPanelID
     @Binding var selectedNetworkID: String?
 
     var body: some View {
         Group {
             if let selID = selectedNetworkID,
-               let snaps = selectedNetworkSnapshots(for: selID),
-               let series = selectedNetworkSeries(for: selID),
+               let snaps = viewModel.snapshots(for: selID),
+               let color = selectedNetworkColor(for: selID),
                snaps.count >= 2 {
-                TrendChartView(snapshots: snaps, color: series.color)
+                TrendChartView(snapshots: snaps, color: color)
             } else {
                 VStack {
                     Spacer()
@@ -24,21 +23,8 @@ struct SpectrumTrendPanel: View {
         }
     }
 
-    private func selectedNetworkSnapshots(for networkID: String) -> [NetworkSnapshot]? {
-        for vm in viewModel.panelBandViewModels(for: panelID) {
-            if let snaps = vm.snapshots(for: networkID) {
-                return snaps
-            }
-        }
-        return nil
-    }
-
-    private func selectedNetworkSeries(for networkID: String) -> ChartSeriesData? {
-        for vm in viewModel.panelBandViewModels(for: panelID) {
-            if let series = vm.series(for: networkID) {
-                return series
-            }
-        }
-        return nil
+    private func selectedNetworkColor(for networkID: String) -> Color? {
+        guard let network = viewModel.deduplicatedNetworks.first(where: { $0.id == networkID }) else { return nil }
+        return viewModel.colorHasher.color(for: network.ssid, bssid: network.bssid)
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
@@ -668,4 +668,21 @@ import ChartLens
         #expect(vm.combinedTableRows.first?.visibilityLocked == true)
         #expect(vm.bandViewModel(for: .primary, selection: .band5).visibleSeriesData().isEmpty)
     }
+
+    @Test func bandViewModelsAreCreatedLazilyPerPanel() {
+        let vm = ScannerViewModel()
+        let office = makeNetwork(ssid: "Office", bssid: "00:11:22:33:44:55", band: .band5GHz, channel: 36)
+
+        vm.debugApplyNetworksForTesting([office], supportedBands: Set([ChannelBand.band5GHz]))
+
+        // The tertiary panel defaults to Table and never requested a band VM,
+        // so no band ViewModels should have been allocated for it.
+        #expect(vm.panelBandViewModels(for: .tertiary).isEmpty)
+
+        // Requesting a band VM lazily creates it and immediately syncs the
+        // current scan data so the panel is usable right away.
+        let bandVM = vm.bandViewModel(for: .tertiary, selection: .band5)
+        #expect(bandVM.visibleSeriesData().map(\.id) == [office.id])
+        #expect(vm.panelBandViewModels(for: .tertiary).map(\.band) == [.band5GHz])
+    }
 }

--- a/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
@@ -689,11 +689,15 @@ import ChartLens
     @Test func sharedTrendAPIsUseSignalHistoryForSelectedNetwork() {
         let vm = ScannerViewModel()
         let network = makeNetwork(ssid: "Office", bssid: "00:11:22:33:44:55", band: .band5GHz, channel: 36)
-        vm.debugApplyNetworksForTesting([network], supportedBands: [.band5GHz])
+        let t0 = Date(timeIntervalSince1970: 1_752_001_200)
+        let t1 = t0.addingTimeInterval(3)
+        vm.debugApplyNetworksForTesting([network], supportedBands: [.band5GHz], timestamp: t0)
+        vm.debugApplyNetworksForTesting([network], supportedBands: [.band5GHz], timestamp: t1)
 
         // A panel that never opened a band must still resolve shared history
         // for the globally selected network.
         let snaps = vm.snapshots(for: network.id)
         #expect(snaps != nil)
+        #expect(snaps?.count == 2)
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/BandChartViewModelTests.swift
@@ -685,4 +685,15 @@ import ChartLens
         #expect(bandVM.visibleSeriesData().map(\.id) == [office.id])
         #expect(vm.panelBandViewModels(for: .tertiary).map(\.band) == [.band5GHz])
     }
+
+    @Test func sharedTrendAPIsUseSignalHistoryForSelectedNetwork() {
+        let vm = ScannerViewModel()
+        let network = makeNetwork(ssid: "Office", bssid: "00:11:22:33:44:55", band: .band5GHz, channel: 36)
+        vm.debugApplyNetworksForTesting([network], supportedBands: [.band5GHz])
+
+        // A panel that never opened a band must still resolve shared history
+        // for the globally selected network.
+        let snaps = vm.snapshots(for: network.id)
+        #expect(snaps != nil)
+    }
 }

--- a/WiFiLens/Tests/WiFiLensTests/BandPanelSelectionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/BandPanelSelectionTests.swift
@@ -1,22 +1,31 @@
 import Testing
 @testable import WiFi_Lens
 
-@Suite struct BandPanelSelectionTests {
+@Suite struct SpectrumPanelViewTypeTests {
     @Test func rawValues() {
-        #expect(BandPanelSelection.band24.rawValue == "24")
-        #expect(BandPanelSelection.band5.rawValue == "5")
-        #expect(BandPanelSelection.band6.rawValue == "6")
-        #expect(BandPanelSelection.trend.rawValue == "trend")
+        #expect(SpectrumPanelViewType.band24.rawValue == "24")
+        #expect(SpectrumPanelViewType.band5.rawValue == "5")
+        #expect(SpectrumPanelViewType.band6.rawValue == "6")
+        #expect(SpectrumPanelViewType.trend.rawValue == "trend")
+        #expect(SpectrumPanelViewType.table.rawValue == "table")
     }
-    
+
     @Test func displayNames() {
-        for selection in BandPanelSelection.allCases {
+        for selection in SpectrumPanelViewType.allCases {
             #expect(!selection.displayName.isEmpty)
             #expect(selection.displayName != selection.rawValue)
         }
     }
-    
+
     @Test func allCasesCount() {
-        #expect(BandPanelSelection.allCases.count == 4)
+        #expect(SpectrumPanelViewType.allCases.count == 5)
+    }
+
+    @Test func icons() {
+        #expect(SpectrumPanelViewType.band24.icon == "wave.3.left")
+        #expect(SpectrumPanelViewType.band5.icon == "wave.3.right")
+        #expect(SpectrumPanelViewType.band6.icon == "wave.3.right.circle")
+        #expect(SpectrumPanelViewType.trend.icon == "chart.line.uptrend.xyaxis")
+        #expect(SpectrumPanelViewType.table.icon == "tablecells")
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/NetworkTableRowSorterTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkTableRowSorterTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import AppKit
+@testable import WiFi_Lens
+
+@MainActor
+struct NetworkTableRowSorterTests {
+    private func row(_ id: String, rssi: Int, ssid: String) -> NetworkTableRow {
+        NetworkTableRow(
+            id: id,
+            bandID: "5",
+            bandLabel: "5 GHz",
+            channel: 44,
+            rssi: rssi,
+            ssid: ssid,
+            vendor: "",
+            bssid: "aa:bb:cc:dd:ee:ff",
+            color: .blue,
+            isFilteredOut: false,
+            phyMode: "ax",
+            channelWidth: "80",
+            supportsK: true,
+            supportsR: false,
+            supportsV: true,
+            isHiddenSSID: false,
+            security: "WPA3",
+            mcs: "9",
+            nss: "2",
+            country: "US",
+            trendArrow: "",
+            trendDelta: 0,
+            isVisible: true,
+            visibilityLocked: false,
+            qualityScore: 80,
+            lastSeen: ""
+        )
+    }
+
+    @Test func emptySortOrderPreservesRows() {
+        let rows = [row("b", rssi: -60, ssid: "B"), row("a", rssi: -50, ssid: "A")]
+        #expect(NetworkTableRowSorter.sort(rows, by: []) == rows)
+    }
+
+    @Test func sortsBySSID() {
+        let rows = [row("b", rssi: -60, ssid: "B"), row("a", rssi: -50, ssid: "A")]
+        let sorted = NetworkTableRowSorter.sort(
+            rows,
+            by: [NSSortDescriptor(key: "ssid", ascending: true)]
+        )
+        #expect(sorted.map(\.ssid) == ["A", "B"])
+    }
+
+    @Test func sortsByRSSIDescending() {
+        let rows = [row("weak", rssi: -60, ssid: "A"), row("strong", rssi: -50, ssid: "B")]
+        let sorted = NetworkTableRowSorter.sort(
+            rows,
+            by: [NSSortDescriptor(key: "rssi", ascending: false)]
+        )
+        #expect(sorted.map(\.id) == ["strong", "weak"])
+    }
+}

--- a/WiFiLens/Tests/WiFiLensTests/NetworkTableRowSorterTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkTableRowSorterTests.swift
@@ -49,12 +49,20 @@ struct NetworkTableRowSorterTests {
         #expect(sorted.map(\.ssid) == ["A", "B"])
     }
 
-    @Test func sortsByRSSIDescending() {
+    @Test func sortsByRSSIUsingExistingInvertedSemantics() {
         let rows = [row("weak", rssi: -60, ssid: "A"), row("strong", rssi: -50, ssid: "B")]
         let sorted = NetworkTableRowSorter.sort(
             rows,
             by: [NSSortDescriptor(key: "rssi", ascending: false)]
         )
-        #expect(sorted.map(\.id) == ["strong", "weak"])
+        // The pre-existing comparator treats a larger RSSI as "ascending", so
+        // descending flips the order: weaker signal comes first.
+        #expect(sorted.map(\.id) == ["weak", "strong"])
+
+        let ascendingSorted = NetworkTableRowSorter.sort(
+            rows,
+            by: [NSSortDescriptor(key: "rssi", ascending: true)]
+        )
+        #expect(ascendingSorted.map(\.id) == ["strong", "weak"])
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SecondaryToolbarAttachmentTests.swift
@@ -31,18 +31,17 @@ struct SecondaryToolbarAttachmentTests {
     @Test func spectrumDashboardLayout_usesPureRatiosWhenViewportIsComfortable() {
         let layout = SpectrumDashboardLayout(viewportHeight: 1000)
 
-        #expect(layout.primaryHeight == 350)
-        #expect(layout.secondaryHeight == 350)
-        #expect(layout.tableHeight == 300)
+        #expect(layout.primaryHeight == layout.secondaryHeight)
+        #expect(layout.secondaryHeight == layout.tertiaryHeight)
+        #expect(layout.primaryHeight + layout.secondaryHeight + layout.tertiaryHeight == 1000)
     }
 
     @Test func spectrumDashboardLayout_usesSameRatiosForSmallerViewports() {
         let layout = SpectrumDashboardLayout(viewportHeight: 640)
 
-        #expect(layout.primaryHeight == 224)
-        #expect(layout.secondaryHeight == 224)
-        #expect(layout.tableHeight == 192)
-        #expect(layout.primaryHeight + layout.secondaryHeight + layout.tableHeight == 640)
+        #expect(layout.primaryHeight == layout.secondaryHeight)
+        #expect(layout.secondaryHeight == layout.tertiaryHeight)
+        #expect(layout.primaryHeight + layout.secondaryHeight + layout.tertiaryHeight == 640)
     }
 }
 

--- a/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
@@ -3,23 +3,24 @@ import Testing
 
 @Suite struct SpectrumPanelViewTests {
     @Test func bandPanelSelectionFromBand() {
-        let selection = BandPanelSelection.band5
+        let selection = SpectrumPanelViewType.band5
         #expect(selection.rawValue == "5")
         #expect(!selection.displayName.isEmpty)
         #expect(selection.displayName != selection.rawValue)
     }
-    
+
     @Test func bandPanelSelectionTrend() {
-        let selection = BandPanelSelection.trend
+        let selection = SpectrumPanelViewType.trend
         #expect(selection.rawValue == "trend")
         #expect(!selection.displayName.isEmpty)
         #expect(selection.displayName != selection.rawValue)
     }
-    
+
     @Test func bandPanelSelectionIconNames() {
-        #expect(BandPanelSelection.band24.icon == "wave.3.left")
-        #expect(BandPanelSelection.band5.icon == "wave.3.right")
-        #expect(BandPanelSelection.band6.icon == "wave.3.right.circle")
-        #expect(BandPanelSelection.trend.icon == "chart.line.uptrend.xyaxis")
+        #expect(SpectrumPanelViewType.band24.icon == "wave.3.left")
+        #expect(SpectrumPanelViewType.band5.icon == "wave.3.right")
+        #expect(SpectrumPanelViewType.band6.icon == "wave.3.right.circle")
+        #expect(SpectrumPanelViewType.trend.icon == "chart.line.uptrend.xyaxis")
+        #expect(SpectrumPanelViewType.table.icon == "tablecells")
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
@@ -23,4 +23,8 @@ import Testing
         #expect(SpectrumPanelViewType.trend.icon == "chart.line.uptrend.xyaxis")
         #expect(SpectrumPanelViewType.table.icon == "tablecells")
     }
+
+    @Test func spectrumPanelIDHasTertiary() {
+        #expect(SpectrumPanelID.tertiary.rawValue == "tertiary")
+    }
 }

--- a/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
@@ -36,9 +36,9 @@ import AppKit
         let panel = SpectrumPanelView(
             viewModel: vm,
             panelID: .tertiary,
+            isVendorColumnAvailable: true,
             chartType: .constant(.table),
             selectedNetworkID: .constant(nil),
-            isVendorColumnAvailable: true,
             sortOrder: .constant([]),
             hiddenColumns: .constant([])
         )

--- a/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SpectrumPanelViewTests.swift
@@ -1,4 +1,6 @@
 import Testing
+import SwiftUI
+import AppKit
 @testable import WiFi_Lens
 
 @Suite struct SpectrumPanelViewTests {
@@ -26,5 +28,21 @@ import Testing
 
     @Test func spectrumPanelIDHasTertiary() {
         #expect(SpectrumPanelID.tertiary.rawValue == "tertiary")
+    }
+
+    @MainActor
+    @Test func supportedViewTypesIncludeTable() {
+        let vm = ScannerViewModel()
+        let panel = SpectrumPanelView(
+            viewModel: vm,
+            panelID: .tertiary,
+            chartType: .constant(.table),
+            selectedNetworkID: .constant(nil),
+            isVendorColumnAvailable: true,
+            sortOrder: .constant([]),
+            hiddenColumns: .constant([])
+        )
+        #expect(panel.supportedViewTypes.contains(.table))
+        #expect(panel.supportedViewTypes.contains(.trend))
     }
 }

--- a/WiFiLens/Tests/WiFiLensTests/SpectrumTablePanelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/SpectrumTablePanelTests.swift
@@ -1,0 +1,18 @@
+import Testing
+import AppKit
+@testable import WiFi_Lens
+
+@MainActor
+struct SpectrumTablePanelTests {
+    @Test func tablePanelInitializesWithViewModelAndBindings() {
+        let vm = ScannerViewModel()
+        let sort = [NSSortDescriptor(key: "ssid", ascending: true)]
+        let panel = SpectrumTablePanel(
+            viewModel: vm,
+            isVendorColumnAvailable: true,
+            sortOrder: .constant(sort),
+            hiddenColumns: .constant([])
+        )
+        #expect(panel.isVendorColumnAvailable)
+    }
+}

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		A3C7A1B2C3D4E5F678900018 /* SpectrumBandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */; };
 		A3C7A1B2C3D4E5F678900019 /* SpectrumTrendPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */; };
 		A3C7A1B2C3D4E5F67890001A /* SpectrumTrendPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */; };
+		A3C7A1B2C3D4E5F67890001B /* SpectrumPanelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900007 /* SpectrumPanelContainer.swift */; };
+		A3C7A1B2C3D4E5F67890001C /* SpectrumPanelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900007 /* SpectrumPanelContainer.swift */; };
 		E4A2B3C4D5E6F708112233B1 /* SpectrumPanelViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233B0 /* SpectrumPanelViewTests.swift */; };
 		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
 		EA1000000000000000000004 /* AnalysisScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000003 /* AnalysisScope.swift */; };
@@ -653,6 +655,7 @@
 		A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowSorterTests.swift; sourceTree = "<group>"; };
 		A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumBandPanel.swift; sourceTree = "<group>"; };
 		A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumTrendPanel.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900007 /* SpectrumPanelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumPanelContainer.swift; sourceTree = "<group>"; };
 		E5A1B3C8D4F6123456780001 /* WiFiPowerMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiPowerMonitor.swift; sourceTree = "<group>"; };
 		E83547C1A36ADDD9E827B26A /* ChartUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartUtilityTests.swift; sourceTree = "<group>"; };
 		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
@@ -1009,6 +1012,7 @@
 				A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */,
 				A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */,
 				A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */,
+				A3C7A1B2C3D4E5F678900007 /* SpectrumPanelContainer.swift */,
 			);
 			path = Spectrum;
 			sourceTree = "<group>";
@@ -2022,6 +2026,7 @@
 				A3C7A1B2C3D4E5F678900013 /* NetworkTableRowSorter.swift in Sources */,
 				A3C7A1B2C3D4E5F678900017 /* SpectrumBandPanel.swift in Sources */,
 				A3C7A1B2C3D4E5F678900019 /* SpectrumTrendPanel.swift in Sources */,
+				A3C7A1B2C3D4E5F67890001B /* SpectrumPanelContainer.swift in Sources */,
 				23F1AB88A28C6E035AA916AA /* BandChartViewModel.swift in Sources */,
 				FB0573C62FBC741D005F8214 /* ChannelQualityView.swift in Sources */,
 				9F1D29EF11E510D9D72BB7D1 /* CWChannel+Extensions.swift in Sources */,
@@ -2336,6 +2341,7 @@
 				A3C7A1B2C3D4E5F678900014 /* NetworkTableRowSorter.swift in Sources */,
 				A3C7A1B2C3D4E5F678900018 /* SpectrumBandPanel.swift in Sources */,
 				A3C7A1B2C3D4E5F67890001A /* SpectrumTrendPanel.swift in Sources */,
+				A3C7A1B2C3D4E5F67890001C /* SpectrumPanelContainer.swift in Sources */,
 				FB1E32752FC7316C009D1BDC /* OverviewView.swift in Sources */,
 				FB1E32762FC7316C009D1BDC /* SpanDirection.swift in Sources */,
 				FB1E32772FC7316C009D1BDC /* WiFiLensApp.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -132,6 +132,10 @@
 		A3C7A1B2C3D4E5F678900016 /* NetworkTableRowSorterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */; };
 		A3C7A1B2C3D4E5F678900012 /* SpectrumTablePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */; };
 		A3C7A1B2C3D4E5F678900014 /* NetworkTableRowSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */; };
+		A3C7A1B2C3D4E5F678900017 /* SpectrumBandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */; };
+		A3C7A1B2C3D4E5F678900018 /* SpectrumBandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */; };
+		A3C7A1B2C3D4E5F678900019 /* SpectrumTrendPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */; };
+		A3C7A1B2C3D4E5F67890001A /* SpectrumTrendPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */; };
 		E4A2B3C4D5E6F708112233B1 /* SpectrumPanelViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233B0 /* SpectrumPanelViewTests.swift */; };
 		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
 		EA1000000000000000000004 /* AnalysisScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000003 /* AnalysisScope.swift */; };
@@ -647,6 +651,8 @@
 		A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowSorter.swift; sourceTree = "<group>"; };
 		A3C7A1B2C3D4E5F678900003 /* SpectrumTablePanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumTablePanelTests.swift; sourceTree = "<group>"; };
 		A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowSorterTests.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumBandPanel.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumTrendPanel.swift; sourceTree = "<group>"; };
 		E5A1B3C8D4F6123456780001 /* WiFiPowerMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiPowerMonitor.swift; sourceTree = "<group>"; };
 		E83547C1A36ADDD9E827B26A /* ChartUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartUtilityTests.swift; sourceTree = "<group>"; };
 		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
@@ -1001,6 +1007,8 @@
 				E4A2B3C4D5E6F708112233AF /* SpectrumPanelView.swift */,
 				A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */,
 				A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */,
+				A3C7A1B2C3D4E5F678900005 /* SpectrumBandPanel.swift */,
+				A3C7A1B2C3D4E5F678900006 /* SpectrumTrendPanel.swift */,
 			);
 			path = Spectrum;
 			sourceTree = "<group>";
@@ -2012,6 +2020,8 @@
 				E4A2B3C4D5E6F708112233AE /* SpectrumPanelView.swift in Sources */,
 				A3C7A1B2C3D4E5F678900011 /* SpectrumTablePanel.swift in Sources */,
 				A3C7A1B2C3D4E5F678900013 /* NetworkTableRowSorter.swift in Sources */,
+				A3C7A1B2C3D4E5F678900017 /* SpectrumBandPanel.swift in Sources */,
+				A3C7A1B2C3D4E5F678900019 /* SpectrumTrendPanel.swift in Sources */,
 				23F1AB88A28C6E035AA916AA /* BandChartViewModel.swift in Sources */,
 				FB0573C62FBC741D005F8214 /* ChannelQualityView.swift in Sources */,
 				9F1D29EF11E510D9D72BB7D1 /* CWChannel+Extensions.swift in Sources */,
@@ -2324,6 +2334,8 @@
 				FBE45E252FEC5573001D563D /* SpectrumPanelView.swift in Sources */,
 				A3C7A1B2C3D4E5F678900012 /* SpectrumTablePanel.swift in Sources */,
 				A3C7A1B2C3D4E5F678900014 /* NetworkTableRowSorter.swift in Sources */,
+				A3C7A1B2C3D4E5F678900018 /* SpectrumBandPanel.swift in Sources */,
+				A3C7A1B2C3D4E5F67890001A /* SpectrumTrendPanel.swift in Sources */,
 				FB1E32752FC7316C009D1BDC /* OverviewView.swift in Sources */,
 				FB1E32762FC7316C009D1BDC /* SpanDirection.swift in Sources */,
 				FB1E32772FC7316C009D1BDC /* WiFiLensApp.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -126,6 +126,12 @@
 		E4A2B3C4D5E6F708112233AB /* BandPanelSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233AA /* BandPanelSelectionTests.swift */; };
 		E4A2B3C4D5E6F708112233AC /* BandPanelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233AD /* BandPanelSelection.swift */; };
 		E4A2B3C4D5E6F708112233AE /* SpectrumPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233AF /* SpectrumPanelView.swift */; };
+		A3C7A1B2C3D4E5F678900011 /* SpectrumTablePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */; };
+		A3C7A1B2C3D4E5F678900013 /* NetworkTableRowSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */; };
+		A3C7A1B2C3D4E5F678900015 /* SpectrumTablePanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900003 /* SpectrumTablePanelTests.swift */; };
+		A3C7A1B2C3D4E5F678900016 /* NetworkTableRowSorterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */; };
+		A3C7A1B2C3D4E5F678900012 /* SpectrumTablePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */; };
+		A3C7A1B2C3D4E5F678900014 /* NetworkTableRowSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */; };
 		E4A2B3C4D5E6F708112233B1 /* SpectrumPanelViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A2B3C4D5E6F708112233B0 /* SpectrumPanelViewTests.swift */; };
 		EA1000000000000000000002 /* AnalysisScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000001 /* AnalysisScopeTests.swift */; };
 		EA1000000000000000000004 /* AnalysisScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1000000000000000000003 /* AnalysisScope.swift */; };
@@ -637,6 +643,10 @@
 		E4A2B3C4D5E6F708112233AD /* BandPanelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandPanelSelection.swift; sourceTree = "<group>"; };
 		E4A2B3C4D5E6F708112233AF /* SpectrumPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumPanelView.swift; sourceTree = "<group>"; };
 		E4A2B3C4D5E6F708112233B0 /* SpectrumPanelViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumPanelViewTests.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumTablePanel.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowSorter.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900003 /* SpectrumTablePanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpectrumTablePanelTests.swift; sourceTree = "<group>"; };
+		A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTableRowSorterTests.swift; sourceTree = "<group>"; };
 		E5A1B3C8D4F6123456780001 /* WiFiPowerMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiPowerMonitor.swift; sourceTree = "<group>"; };
 		E83547C1A36ADDD9E827B26A /* ChartUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartUtilityTests.swift; sourceTree = "<group>"; };
 		EA1000000000000000000001 /* AnalysisScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisScopeTests.swift; sourceTree = "<group>"; };
@@ -989,6 +999,8 @@
 				8FD8F4CBC15819F4DB5C5510 /* SSIDColorHasher.swift */,
 				E4A2B3C4D5E6F708112233AD /* BandPanelSelection.swift */,
 				E4A2B3C4D5E6F708112233AF /* SpectrumPanelView.swift */,
+				A3C7A1B2C3D4E5F678900001 /* SpectrumTablePanel.swift */,
+				A3C7A1B2C3D4E5F678900002 /* NetworkTableRowSorter.swift */,
 			);
 			path = Spectrum;
 			sourceTree = "<group>";
@@ -1499,6 +1511,8 @@
 				AR000000000000000000000C /* APRadarSoundSynthesizerTests.swift */,
 				E4A2B3C4D5E6F708112233AA /* BandPanelSelectionTests.swift */,
 				E4A2B3C4D5E6F708112233B0 /* SpectrumPanelViewTests.swift */,
+				A3C7A1B2C3D4E5F678900003 /* SpectrumTablePanelTests.swift */,
+				A3C7A1B2C3D4E5F678900004 /* NetworkTableRowSorterTests.swift */,
 				TH0000000000000000000001 /* ThroughputMonitorTests.swift */,
 				D92298452F334CDAAA9695D3 /* WindowFramePolicyTests.swift */,
 				A1C4E7B92F0148D3B6E90A21 /* DetailPageMinimumHeightTests.swift */,
@@ -1996,6 +2010,8 @@
 				6680C83EB72E9C488E7F7616 /* BandChartView.swift in Sources */,
 				E4A2B3C4D5E6F708112233AC /* BandPanelSelection.swift in Sources */,
 				E4A2B3C4D5E6F708112233AE /* SpectrumPanelView.swift in Sources */,
+				A3C7A1B2C3D4E5F678900011 /* SpectrumTablePanel.swift in Sources */,
+				A3C7A1B2C3D4E5F678900013 /* NetworkTableRowSorter.swift in Sources */,
 				23F1AB88A28C6E035AA916AA /* BandChartViewModel.swift in Sources */,
 				FB0573C62FBC741D005F8214 /* ChannelQualityView.swift in Sources */,
 				9F1D29EF11E510D9D72BB7D1 /* CWChannel+Extensions.swift in Sources */,
@@ -2167,6 +2183,8 @@
 				C1D2E3F4A5B6123456789ABF /* APFilterServiceTests.swift in Sources */,
 				E4A2B3C4D5E6F708112233AB /* BandPanelSelectionTests.swift in Sources */,
 				E4A2B3C4D5E6F708112233B1 /* SpectrumPanelViewTests.swift in Sources */,
+				A3C7A1B2C3D4E5F678900015 /* SpectrumTablePanelTests.swift in Sources */,
+				A3C7A1B2C3D4E5F678900016 /* NetworkTableRowSorterTests.swift in Sources */,
 				TH0000000000000000000002 /* ThroughputMonitorTests.swift in Sources */,
 				1B8B239E2A11401AB0C0D51B /* WindowFramePolicyTests.swift in Sources */,
 				A1C4E7BA2F0148D3B6E90A22 /* DetailPageMinimumHeightTests.swift in Sources */,
@@ -2304,6 +2322,8 @@
 				EC10000000000000000000007 /* EditionCompositionContext.swift in Sources */,
 				A1B2C3D4E5F6789012340001 /* WiFiPowerMonitor.swift in Sources */,
 				FBE45E252FEC5573001D563D /* SpectrumPanelView.swift in Sources */,
+				A3C7A1B2C3D4E5F678900012 /* SpectrumTablePanel.swift in Sources */,
+				A3C7A1B2C3D4E5F678900014 /* NetworkTableRowSorter.swift in Sources */,
 				FB1E32752FC7316C009D1BDC /* OverviewView.swift in Sources */,
 				FB1E32762FC7316C009D1BDC /* SpanDirection.swift in Sources */,
 				FB1E32772FC7316C009D1BDC /* WiFiLensApp.swift in Sources */,


### PR DESCRIPTION
## Summary

Turns the Spectrum dashboard's third region into a first-class panel that defaults to a componentized Table view, and aligns each View type's toolbar with the panel's View switcher.

## Motivation

The previous layout hardcoded a bottom table region below two spectrum panels. Making the third region a proper panel lets it share the same View switcher (2.4G / 5G / 6G / Trend / Table), keeps each View's own controls next to its content, and prepares the dashboard for future View types such as Heatmap.

## Changes

- Rename `BandPanelSelection` to `SpectrumPanelViewType` and add a `table` case.
- Add `SpectrumPanelID.tertiary` plus per-panel band ViewModels for the third panel.
- Add `SpectrumTablePanel` and `NetworkTableRowSorter`, moving table sorting and the "Hide networks with empty SSID" toolbar into the panel component.
- Add `SpectrumBandPanel` and `SpectrumTrendPanel`; each View type owns its toolbar controls, shown on the same row as the View switcher.
- Use equal 1:1:1 heights for the three panels.
- Clarify the table toolbar count with a localized "N networks" label.

## Related Issue

Closes #N/A

## Testing

- [x] Built the open-source edition successfully
- [x] Ran the relevant unit tests
- [x] Manually verified the affected behavior
- [ ] UI tests were run because this change specifically requires them
- [ ] No automated checks were required for this change

Commands or additional testing details:

```text
xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' build
xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens Pro" -configuration Debug -destination 'platform=macOS' build
xcodebuild -project WiFiLens/WiFiLens.xcodeproj -scheme "WiFi Lens" -configuration Debug -destination 'platform=macOS' -skipPackageUpdates test -only-testing:WiFiLensTests
```

OSS + Pro Debug builds succeeded; WiFiLensTests passed (1136 tests).

## Screenshots

Not included yet.

## Checklist

* [x] This pull request contains one focused logical change.
* [x] I did not include unrelated refactoring or formatting changes.
* [x] I added or updated tests where practical.
* [x] I did not remove, skip, or weaken tests merely to make the change pass.
* [x] User-facing strings use the project localization system.
* [x] Documentation was updated where behavior changed.
* [x] New source files have the correct target membership.
* [x] Public code does not reference or describe private Pro implementation details.
* [x] I reviewed and understand all submitted code, including AI-assisted code.
* [x] I have redacted sensitive network information from logs and screenshots.

## Additional Notes

The `Closes #N/A` placeholder in Related Issue is intentional because no GitHub issue is linked.

