### PR TITLE
Harden network self-check diagnostics

### DIFF
--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DNSResolutionCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DNSResolutionCheck.swift
@@ -50,10 +50,15 @@ struct SystemDNSResolver: DNSResolving {
                 )
                 context.install(serviceRef: serviceRef)
 
-                Task {
-                    try? await Task.sleep(for: timeout)
-                    context.finish(.indeterminate)
+                let timeoutTask = Task { [context] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                        context.finish(.indeterminate)
+                    } catch {
+                        // The DNS callback completed or the caller cancelled.
+                    }
                 }
+                context.install(timeoutTask: timeoutTask)
             }
         } onCancel: {
             context.cancel()
@@ -66,10 +71,12 @@ private final class DNSResolutionContext: @unchecked Sendable {
     private var continuation: CheckedContinuation<DNSResolutionOutcome, Never>?
     private var serviceRef: DNSServiceRef?
     private var cancellationRequested = false
+    private var didFinish = false
+    private var timeoutTask: Task<Void, Never>?
 
     func install(continuation: CheckedContinuation<DNSResolutionOutcome, Never>) -> Bool {
         lock.lock()
-        guard !cancellationRequested else {
+        guard !cancellationRequested, !didFinish else {
             lock.unlock()
             continuation.resume(returning: .indeterminate)
             return false
@@ -81,7 +88,7 @@ private final class DNSResolutionContext: @unchecked Sendable {
 
     func install(serviceRef: DNSServiceRef) {
         lock.lock()
-        if continuation == nil {
+        if didFinish || continuation == nil {
             lock.unlock()
             DNSServiceRefDeallocate(serviceRef)
             return
@@ -90,21 +97,37 @@ private final class DNSResolutionContext: @unchecked Sendable {
         lock.unlock()
     }
 
+    func install(timeoutTask: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        self.timeoutTask = timeoutTask
+        lock.unlock()
+    }
+
     func finish(_ outcome: DNSResolutionOutcome) {
         lock.lock()
-        guard let continuation else {
+        guard !didFinish else {
             lock.unlock()
             return
         }
+        didFinish = true
+        let continuation = self.continuation
         self.continuation = nil
         let serviceRef = self.serviceRef
         self.serviceRef = nil
+        let timeoutTask = self.timeoutTask
+        self.timeoutTask = nil
         lock.unlock()
 
         if let serviceRef {
             DNSServiceRefDeallocate(serviceRef)
         }
-        continuation.resume(returning: outcome)
+        timeoutTask?.cancel()
+        continuation?.resume(returning: outcome)
     }
 
     func cancel() {
@@ -140,26 +163,38 @@ struct DNSResolutionCheck: DiagnosticCheck {
     }
 
     func run() async -> NetworkDiagnosticResult {
-        let outcomes = await withTaskGroup(of: DNSResolutionOutcome.self, returning: [DNSResolutionOutcome].self) { group in
-            for host in probeTargets {
+        let outcomes = await withTaskGroup(of: (index: Int, outcome: DNSResolutionOutcome).self, returning: [DNSResolutionOutcome].self) { group in
+            for (index, host) in probeTargets.enumerated() {
                 group.addTask {
                     let firstOutcome = await resolver.resolve(host: host, timeout: timeout)
+                    let outcome: DNSResolutionOutcome
                     if firstOutcome == .indeterminate, !Task.isCancelled {
-                        return await resolver.resolve(host: host, timeout: timeout)
+                        outcome = await resolver.resolve(host: host, timeout: timeout)
+                    } else {
+                        outcome = firstOutcome
                     }
-                    return firstOutcome
+                    return (index, outcome)
                 }
             }
-            var outcomes: [DNSResolutionOutcome] = []
-            for await outcome in group {
-                outcomes.append(outcome)
+            var outcomes = Array(
+                repeating: DNSResolutionOutcome.indeterminate,
+                count: probeTargets.count
+            )
+            for await sample in group {
+                outcomes[sample.index] = sample.outcome
             }
             return outcomes
         }
         let successCount = outcomes.count { $0 == .resolved }
         let failureCount = outcomes.count { $0 == .failed }
         let indeterminateCount = outcomes.count { $0 == .indeterminate }
-        let evidence = [
+        let sampleEvidence = probeTargets.enumerated().map { index, host in
+            NetworkDiagnosticEvidence(
+                code: "dns.sample.\(Self.sampleID(for: host, index: index))",
+                value: Self.evidenceValue(for: outcomes[index])
+            )
+        }
+        let evidence = sampleEvidence + [
             NetworkDiagnosticEvidence(code: "dns.success-count", value: "\(successCount)/\(probeTargets.count)"),
             NetworkDiagnosticEvidence(code: "dns.failure-count", value: "\(failureCount)/\(probeTargets.count)"),
             NetworkDiagnosticEvidence(code: "dns.indeterminate-count", value: "\(indeterminateCount)/\(probeTargets.count)"),
@@ -195,5 +230,22 @@ struct DNSResolutionCheck: DiagnosticCheck {
             summary: String(localized: "network_diagnostics.dns.inconsistent.summary", comment: "Network self-check DNS test names had mixed outcomes"),
             evidence: evidence
         )
+    }
+
+    private static func sampleID(for host: String, index: Int) -> String {
+        switch host.lowercased() {
+        case "www.apple.com": "apple"
+        case "www.microsoft.com": "microsoft"
+        case "www.msftconnecttest.com": "msft-connect-test"
+        default: "sample-\(index + 1)"
+        }
+    }
+
+    private static func evidenceValue(for outcome: DNSResolutionOutcome) -> String {
+        switch outcome {
+        case .resolved: "resolved"
+        case .failed: "failed"
+        case .indeterminate: "indeterminate"
+        }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticGatewayTarget.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticGatewayTarget.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct DiagnosticGatewayTarget: Equatable, Sendable {
+    let interfaceName: String
+    let interfaceIndex: UInt32
+    let address: String
+}
+
+enum DiagnosticRouteSelection: Equatable, Sendable {
+    case selected(DiagnosticGatewayTarget)
+    case unavailable
+    case ambiguous
+    case unsupported
+}
+
+protocol DiagnosticRouteSourcing: Sendable {
+    func currentRoute(timeout: Duration) async -> DiagnosticRouteSelection
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticNetworkContext.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticNetworkContext.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct DiagnosticNetworkContext: Sendable {
+    let runID: UUID
+    let capturedAt: Date
+    let pathState: NetworkPathState?
+    let route: DiagnosticRouteSelection
+    let interfaces: NetworkInterfaceSnapshot
+}
+
+protocol DiagnosticNetworkContextSourcing: Sendable {
+    func capture(runID: UUID, timeout: Duration) async -> DiagnosticNetworkContext?
+}
+
+struct SystemDiagnosticNetworkContextSource: DiagnosticNetworkContextSourcing {
+    private let routeSource: any DiagnosticRouteSourcing
+    private let pathSource: any NetworkPathChecking
+    private let interfaceSource: any NetworkInterfaceSnapshotSourcing
+
+    init(
+        routeSource: any DiagnosticRouteSourcing = SystemDiagnosticRouteSource(),
+        pathSource: any NetworkPathChecking = SystemNetworkPathChecker(),
+        interfaceSource: any NetworkInterfaceSnapshotSourcing = SystemNetworkInterfaceSnapshotSource()
+    ) {
+        self.routeSource = routeSource
+        self.pathSource = pathSource
+        self.interfaceSource = interfaceSource
+    }
+
+    func capture(runID: UUID, timeout: Duration) async -> DiagnosticNetworkContext? {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        var lastPathState: NetworkPathState?
+        var lastInterfaces = NetworkInterfaceSnapshot(
+            cycleID: runID,
+            capturedAt: Date(),
+            interfaces: []
+        )
+
+        for attempt in 0..<2 {
+            let before = await routeSource.currentRoute(timeout: deadline.remainingDuration())
+            let pathState = await pathSource.currentState(timeout: deadline.remainingDuration())
+            let interfaces = await interfaceSource.capture(cycleID: runID)
+            let after = await routeSource.currentRoute(timeout: deadline.remainingDuration())
+            lastPathState = pathState
+            lastInterfaces = interfaces
+
+            if before == after {
+                return DiagnosticNetworkContext(
+                    runID: runID,
+                    capturedAt: Date(),
+                    pathState: pathState,
+                    route: before,
+                    interfaces: interfaces
+                )
+            }
+            if attempt == 0 { continue }
+        }
+
+        return DiagnosticNetworkContext(
+            runID: runID,
+            capturedAt: Date(),
+            pathState: lastPathState,
+            route: .ambiguous,
+            interfaces: lastInterfaces
+        )
+    }
+}
+
+private extension ContinuousClock.Instant {
+    func remainingDuration() -> Duration {
+        max(.zero, ContinuousClock.now.duration(to: self))
+    }
+}
+
+enum DiagnosticPingArguments {
+    static func make(target: DiagnosticGatewayTarget) -> [String] {
+        ["-b", target.interfaceName, "-c", "1", "-W", "1000", target.address]
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunOutcome.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunOutcome.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum DiagnosticRunEndReason: Equatable, Sendable {
+    case completed
+    case timedOut
+    case cancelled
+    case superseded
+}
+
+enum DiagnosticRestartReason: String, CaseIterable, Sendable {
+    case route
+    case address
+    case dns
+    case proxy
+    case path
+}
+
+struct DiagnosticRunOutcome: Equatable, Sendable {
+    let runID: UUID
+    let results: [NetworkDiagnosticResult]
+    let pendingIDs: [NetworkDiagnosticCheckID]
+    let endReason: DiagnosticRunEndReason
+
+    init(
+        runID: UUID,
+        results: [NetworkDiagnosticResult],
+        pendingIDs: [NetworkDiagnosticCheckID] = [],
+        endReason: DiagnosticRunEndReason
+    ) {
+        self.runID = runID
+        self.results = results
+        self.pendingIDs = pendingIDs
+        self.endReason = endReason
+    }
+}
+
+struct DiagnosticPublicationGate: Sendable {
+    var activeRunID: UUID?
+
+    func accepts(_ runID: UUID) -> Bool {
+        activeRunID == runID
+    }
+}
+
+protocol DiagnosticClock: Sendable {
+    func now() async -> ContinuousClock.Instant
+    func sleep(until deadline: ContinuousClock.Instant) async throws
+}
+
+struct ContinuousDiagnosticClock: DiagnosticClock {
+    private let clock = ContinuousClock()
+
+    func now() async -> ContinuousClock.Instant {
+        clock.now
+    }
+
+    func sleep(until deadline: ContinuousClock.Instant) async throws {
+        try await clock.sleep(until: deadline)
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunner.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunner.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 enum DiagnosticCheckRerunPolicy: Equatable, Sendable {
     case networkSensitive
     case configurationOnly
@@ -20,22 +22,100 @@ private struct DiagnosticDependency {
     let blockingStatuses: Set<NetworkDiagnosticStatus>
 }
 
+private struct DiagnosticCheckRunResult: Sendable {
+    let result: NetworkDiagnosticResult?
+    let endReason: DiagnosticRunEndReason?
+}
+
+private final class DiagnosticCheckCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<DiagnosticCheckRunResult, Never>?
+    private var operation: Task<Void, Never>?
+    private var timeout: Task<Void, Never>?
+    private var didFinish = false
+
+    func install(continuation: CheckedContinuation<DiagnosticCheckRunResult, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            continuation.resume(returning: .init(result: nil, endReason: .cancelled))
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func install(
+        operation: Task<Void, Never>,
+        timeout: Task<Void, Never>
+    ) {
+        lock.lock()
+        self.operation = operation
+        self.timeout = timeout
+        let shouldCancel = didFinish
+        lock.unlock()
+        if shouldCancel {
+            operation.cancel()
+            timeout.cancel()
+        }
+    }
+
+    func finish(_ result: DiagnosticCheckRunResult) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        didFinish = true
+        let continuation = self.continuation
+        self.continuation = nil
+        let operation = self.operation
+        let timeout = self.timeout
+        self.operation = nil
+        self.timeout = nil
+        lock.unlock()
+
+        operation?.cancel()
+        timeout?.cancel()
+        continuation?.resume(returning: result)
+    }
+
+    func cancel() {
+        finish(.init(result: nil, endReason: .cancelled))
+    }
+}
+
 struct DiagnosticRunner: Sendable {
     let checks: [any DiagnosticCheck]
     var minimumStepDuration: Duration = .zero
     var sessionBudget: Duration = .seconds(30)
+    var clock: any DiagnosticClock = ContinuousDiagnosticClock()
 
     func run(
+        runID: UUID = UUID(),
         retaining retainedResults: [NetworkDiagnosticResult] = [],
+        deadline: ContinuousClock.Instant? = nil,
+        onCheckStarted: (@Sendable (NetworkDiagnosticCheckID) async -> Void)? = nil,
         onResult: @escaping @Sendable (NetworkDiagnosticResult) async -> Void
-    ) async -> [NetworkDiagnosticResult] {
+    ) async -> DiagnosticRunOutcome {
         var results: [NetworkDiagnosticResult] = []
         let retainedByID = Dictionary(uniqueKeysWithValues: retainedResults.map { ($0.id, $0) })
-        let clock = ContinuousClock()
-        let sessionDeadline = clock.now.advanced(by: sessionBudget)
+        let sessionDeadline: ContinuousClock.Instant = if let deadline {
+            deadline
+        } else {
+            (await clock.now()).advanced(by: sessionBudget)
+        }
+        var endReason: DiagnosticRunEndReason = .completed
 
         for check in checks {
-            guard !Task.isCancelled else { break }
+            guard !Task.isCancelled else {
+                endReason = .cancelled
+                break
+            }
+            guard await clock.now() < sessionDeadline else {
+                endReason = .timedOut
+                break
+            }
             if let retainedResult = retainedByID[check.id] {
                 results.append(retainedResult)
                 continue
@@ -52,42 +132,98 @@ struct DiagnosticRunner: Sendable {
                 await onResult(result)
                 continue
             }
-            let started = clock.now
-            guard let result = await run(check, until: sessionDeadline) else { break }
-            let presentationDeadline = started.advanced(by: minimumStepDuration)
-            try? await clock.sleep(until: min(presentationDeadline, sessionDeadline))
-            guard !Task.isCancelled else { break }
+            await onCheckStarted?(check.id)
+            let checkResult = await run(check, until: sessionDeadline)
+            guard !Task.isCancelled else {
+                endReason = .cancelled
+                break
+            }
+            guard let result = checkResult.result else {
+                endReason = checkResult.endReason ?? .timedOut
+                break
+            }
             results.append(result)
             await onResult(result)
+
+            if let checkEndReason = checkResult.endReason {
+                endReason = checkEndReason
+                break
+            }
+
+            if await clock.now() >= sessionDeadline {
+                endReason = .timedOut
+                break
+            }
         }
 
-        return results
+        if Task.isCancelled {
+            endReason = .cancelled
+        } else if endReason == .completed, results.count < checks.count {
+            endReason = .timedOut
+        }
+        let resultIDs = Set(results.map(\.id))
+        return DiagnosticRunOutcome(
+            runID: runID,
+            results: results,
+            pendingIDs: checks.map(\.id).filter { !resultIDs.contains($0) },
+            endReason: endReason
+        )
     }
 
     private func run(
         _ check: any DiagnosticCheck,
         until deadline: ContinuousClock.Instant
-    ) async -> NetworkDiagnosticResult? {
-        let clock = ContinuousClock()
-        let remaining = clock.now.duration(to: deadline)
-        guard remaining > .zero else { return nil }
-        let task = Task { try await check.run() }
-        return await withTaskGroup(of: NetworkDiagnosticResult?.self) { group in
-            group.addTask {
-                do {
-                    return try await task.value
-                } catch {
-                    return nil
+    ) async -> DiagnosticCheckRunResult {
+        let remaining = (await clock.now()).duration(to: deadline)
+        guard remaining > .zero else {
+            return .init(result: nil, endReason: .timedOut)
+        }
+        let gate = DiagnosticCheckCompletionGate()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                gate.install(continuation: continuation)
+                let operation = Task {
+                    do {
+                        gate.finish(.init(result: try await check.run(), endReason: nil))
+                    } catch {
+                        if Task.isCancelled {
+                            gate.finish(.init(result: nil, endReason: .cancelled))
+                        } else {
+                            gate.finish(.init(
+                                result: NetworkDiagnosticResult(
+                                    id: check.id,
+                                    status: .indeterminate,
+                                    summary: "The check could not complete.",
+                                    evidence: [.init(code: "check.failed", value: nil)]
+                                ),
+                                endReason: nil
+                            ))
+                        }
+                    }
                 }
+                let timeout = Task {
+                    do {
+                        try await clock.sleep(until: deadline)
+                        gate.finish(.init(
+                            result: NetworkDiagnosticResult(
+                                id: check.id,
+                                status: .indeterminate,
+                                summary: String(
+                                    localized: "network_diagnostics.check.timed_out",
+                                    comment: "Network self-check individual check timeout summary"
+                                ),
+                                evidence: [.init(code: "check.timeout", value: nil)]
+                            ),
+                            endReason: .timedOut
+                        ))
+                    } catch {
+                        // The operation completed or the parent cancelled.
+                    }
+                }
+                gate.install(operation: operation, timeout: timeout)
             }
-            group.addTask {
-                try? await clock.sleep(for: remaining)
-                task.cancel()
-                return nil
-            }
-            let result = await group.next() ?? nil
-            group.cancelAll()
-            return result
+        } onCancel: {
+            gate.cancel()
         }
     }
 
@@ -104,10 +240,7 @@ struct DiagnosticRunner: Sendable {
         case .dns:
             [.init(id: .path, blockingStatuses: hardFailureStatuses)]
         case .internet, .ipv6:
-            [
-                .init(id: .path, blockingStatuses: hardFailureStatuses),
-                .init(id: .dns, blockingStatuses: hardFailureStatuses),
-            ]
+            [.init(id: .path, blockingStatuses: hardFailureStatuses)]
         case .proxy:
             [.init(id: .path, blockingStatuses: hardFailureStatuses)]
         }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunner.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/DiagnosticRunner.swift
@@ -87,7 +87,6 @@ private final class DiagnosticCheckCompletionGate: @unchecked Sendable {
 
 struct DiagnosticRunner: Sendable {
     let checks: [any DiagnosticCheck]
-    var minimumStepDuration: Duration = .zero
     var sessionBudget: Duration = .seconds(30)
     var clock: any DiagnosticClock = ContinuousDiagnosticClock()
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/IPv6ControlEndpointCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/IPv6ControlEndpointCheck.swift
@@ -225,10 +225,15 @@ struct SystemIPv6AddressResolver: IPv6AddressResolving {
                     }
                 )
 
-                Task {
-                    try? await Task.sleep(for: timeout)
-                    context.finish()
+                let timeoutTask = Task { [context] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                        context.finish()
+                    } catch {
+                        // The DNS callback completed or the caller cancelled.
+                    }
                 }
+                context.install(timeoutTask: timeoutTask)
             }
         } onCancel: {
             context.cancel()
@@ -272,10 +277,12 @@ private final class IPv6ResolutionContext: @unchecked Sendable {
     private var serviceRef: DNSServiceRef?
     private var addresses: [String] = []
     private var cancellationRequested = false
+    private var didFinish = false
+    private var timeoutTask: Task<Void, Never>?
 
     func install(continuation: CheckedContinuation<[String], Never>) -> Bool {
         lock.lock()
-        guard !cancellationRequested else {
+        guard !cancellationRequested, !didFinish else {
             lock.unlock()
             continuation.resume(returning: [])
             return false
@@ -287,12 +294,23 @@ private final class IPv6ResolutionContext: @unchecked Sendable {
 
     func install(serviceRef: DNSServiceRef) {
         lock.lock()
-        if continuation == nil {
+        if didFinish || continuation == nil {
             lock.unlock()
             DNSServiceRefDeallocate(serviceRef)
             return
         }
         self.serviceRef = serviceRef
+        lock.unlock()
+    }
+
+    func install(timeoutTask: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        self.timeoutTask = timeoutTask
         lock.unlock()
     }
 
@@ -307,20 +325,25 @@ private final class IPv6ResolutionContext: @unchecked Sendable {
 
     func finish() {
         lock.lock()
-        guard let continuation else {
+        guard !didFinish else {
             lock.unlock()
             return
         }
+        didFinish = true
+        let continuation = self.continuation
         self.continuation = nil
         let serviceRef = self.serviceRef
         self.serviceRef = nil
         let addresses = self.addresses
+        let timeoutTask = self.timeoutTask
+        self.timeoutTask = nil
         lock.unlock()
 
         if let serviceRef {
             DNSServiceRefDeallocate(serviceRef)
         }
-        continuation.resume(returning: addresses)
+        timeoutTask?.cancel()
+        continuation?.resume(returning: addresses)
     }
 
     func cancel() {
@@ -373,10 +396,15 @@ struct NetworkIPv6HTTPSConnector: IPv6HTTPSConnecting {
                 connection.start(queue: DispatchQueue(
                     label: "io.github.kaoru.wifi-lens.network-diagnostics.ipv6-https"
                 ))
-                Task {
-                    try? await Task.sleep(for: timeout)
-                    context.finish(false)
+                let timeoutTask = Task { [context] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                        context.finish(false)
+                    } catch {
+                        // The connection completed or the caller cancelled.
+                    }
                 }
+                context.install(timeoutTask: timeoutTask)
             }
         } onCancel: {
             context.cancel()
@@ -402,6 +430,8 @@ private final class IPv6HTTPSConnectionContext: @unchecked Sendable {
     private var response = Data()
     private var requestSent = false
     private var cancellationRequested = false
+    private var didFinish = false
+    private var timeoutTask: Task<Void, Never>?
 
     init(
         connection: NWConnection,
@@ -413,7 +443,7 @@ private final class IPv6HTTPSConnectionContext: @unchecked Sendable {
 
     func install(continuation: CheckedContinuation<Bool, Never>) -> Bool {
         lock.lock()
-        guard !cancellationRequested else {
+        guard !cancellationRequested, !didFinish else {
             lock.unlock()
             connection.cancel()
             continuation.resume(returning: false)
@@ -422,6 +452,17 @@ private final class IPv6HTTPSConnectionContext: @unchecked Sendable {
         self.continuation = continuation
         lock.unlock()
         return true
+    }
+
+    func install(timeoutTask: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        self.timeoutTask = timeoutTask
+        lock.unlock()
     }
 
     func sendRequest() {
@@ -445,14 +486,20 @@ private final class IPv6HTTPSConnectionContext: @unchecked Sendable {
 
     func finish(_ succeeded: Bool) {
         lock.lock()
-        guard let continuation else {
+        guard !didFinish else {
             lock.unlock()
             return
         }
+        didFinish = true
+        let continuation = self.continuation
         self.continuation = nil
+        let timeoutTask = self.timeoutTask
+        self.timeoutTask = nil
         lock.unlock()
+        timeoutTask?.cancel()
+        connection.stateUpdateHandler = nil
         connection.cancel()
-        continuation.resume(returning: succeeded)
+        continuation?.resume(returning: succeeded)
     }
 
     func cancel() {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkConnectivityCheck.swift
@@ -67,23 +67,34 @@ struct SystemNetworkPathChecker: NetworkPathChecking {
             continuation.onTermination = { _ in monitor.cancel() }
             monitor.start(queue: DispatchQueue(label: "io.github.kaoru.wifi-lens.network-diagnostics.path-evidence"))
         }
-        defer { monitor.cancel() }
-        for await path in stream {
-            let activeInterface = path.availableInterfaces
-                .filter { path.usesInterfaceType($0.type) }
-                .sorted { $0.name < $1.name }
-                .first
-            guard let activeInterface else { return [] }
-            var evidence = [
-                NetworkDiagnosticEvidence(code: "path.interface-type", value: activeInterface.type.pathEvidenceName),
-                NetworkDiagnosticEvidence(code: "path.interface-name", value: activeInterface.name),
-            ]
-            if ["utun", "ipsec", "ppp"].contains(where: { activeInterface.name.hasPrefix($0) }) {
-                evidence.append(.init(code: "path.routed-tunnel", value: activeInterface.name))
+        return await withTaskGroup(of: [NetworkDiagnosticEvidence]?.self) { group in
+            group.addTask {
+                for await path in stream {
+                    let activeInterface = path.availableInterfaces
+                        .filter { path.usesInterfaceType($0.type) }
+                        .sorted { $0.name < $1.name }
+                        .first
+                    guard let activeInterface else { return [] }
+                    var evidence = [
+                        NetworkDiagnosticEvidence(code: "path.interface-type", value: activeInterface.type.pathEvidenceName),
+                        NetworkDiagnosticEvidence(code: "path.interface-name", value: activeInterface.name),
+                    ]
+                    if ["utun", "ipsec", "ppp"].contains(where: { activeInterface.name.hasPrefix($0) }) {
+                        evidence.append(.init(code: "path.routed-tunnel", value: activeInterface.name))
+                    }
+                    return evidence
+                }
+                return []
             }
-            return evidence
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+            let evidence = await group.next() ?? nil
+            group.cancelAll()
+            monitor.cancel()
+            return evidence ?? []
         }
-        return []
     }
 }
 
@@ -96,6 +107,7 @@ struct NetworkConnectivityCheck: DiagnosticCheck {
     private let pathSource: any NetworkPathChecking
     private let interfaceSource: any NetworkInterfaceInfoSourcing
     private let timeout: Duration
+    private let context: DiagnosticNetworkContext?
 
     init(
         pathSource: any NetworkPathChecking = SystemNetworkPathChecker(),
@@ -105,14 +117,70 @@ struct NetworkConnectivityCheck: DiagnosticCheck {
         self.pathSource = pathSource
         self.interfaceSource = interfaceSource
         self.timeout = timeout
+        self.context = nil
+    }
+
+    init(context: DiagnosticNetworkContext) {
+        self.pathSource = SystemNetworkPathChecker()
+        self.interfaceSource = SystemNetworkInterfaceInfoSource()
+        self.timeout = .seconds(3)
+        self.context = context
     }
 
     func run() async -> NetworkDiagnosticResult {
+        if let context {
+            return contextResult(context)
+        }
         let state = await pathSource.currentState(timeout: timeout)
         let pathEvidence = await pathSource.diagnosticEvidence(timeout: timeout)
         let interface = await interfaceSource.currentInterface()
         let evidence = pathEvidence + self.pathEvidence(interface: interface)
         return switch state {
+        case .satisfied:
+            NetworkDiagnosticResult(
+                id: id,
+                status: .normal,
+                summary: String(
+                    localized: "network_diagnostics.path.normal.summary",
+                    comment: "Network self-check system path success summary"
+                ),
+                detail: String(
+                    localized: "network_diagnostics.path.normal.summary",
+                    comment: "Network self-check system path success detail"
+                ),
+                evidence: evidence
+            )
+        case .unsatisfied:
+            NetworkDiagnosticResult(
+                id: id,
+                status: .abnormal,
+                summary: String(localized: "network_diagnostics.path.abnormal.summary", comment: "Network self-check system path failure summary"),
+                evidence: evidence
+            )
+        case .requiresConnection, nil:
+            NetworkDiagnosticResult(
+                id: id,
+                status: .indeterminate,
+                summary: String(localized: "network_diagnostics.path.indeterminate.summary", comment: "Network self-check system path indeterminate summary"),
+                evidence: evidence
+            )
+        }
+    }
+
+    private func contextResult(_ context: DiagnosticNetworkContext) -> NetworkDiagnosticResult {
+        let selectedInterface: NetworkInterfaceInfo? = switch context.route {
+        case .selected(let target):
+            context.interfaces.interfaces.first { $0.interfaceName == target.interfaceName }
+        case .unavailable, .ambiguous, .unsupported:
+            nil
+        }
+        var evidence = pathEvidence(interface: selectedInterface)
+        if case .selected(let target) = context.route {
+            evidence.append(.init(code: "path.interface-index", value: String(target.interfaceIndex)))
+            evidence.append(.init(code: "path.gateway", value: target.address))
+        }
+
+        return switch context.pathState {
         case .satisfied:
             NetworkDiagnosticResult(
                 id: id,
@@ -169,6 +237,9 @@ struct GatewayReachabilityCheck: DiagnosticCheck {
     let id = NetworkDiagnosticCheckID.gatewayReachability
     private let interfaceSource: any NetworkInterfaceInfoSourcing
     private let gatewayLatency: any GatewayLatencyProviding
+    private let context: DiagnosticNetworkContext?
+    private let diagnosticGatewayMeasuring: (any DiagnosticGatewayMeasuring)?
+    private let routeSource: (any DiagnosticRouteSourcing)?
 
     init(
         interfaceSource: any NetworkInterfaceInfoSourcing = SystemNetworkInterfaceInfoSource(),
@@ -176,9 +247,27 @@ struct GatewayReachabilityCheck: DiagnosticCheck {
     ) {
         self.interfaceSource = interfaceSource
         self.gatewayLatency = gatewayLatency
+        self.context = nil
+        self.diagnosticGatewayMeasuring = nil
+        self.routeSource = nil
+    }
+
+    init(
+        context: DiagnosticNetworkContext,
+        gatewayMeasuring: any DiagnosticGatewayMeasuring = GatewayLatencyProvider(),
+        routeSource: (any DiagnosticRouteSourcing)? = SystemDiagnosticRouteSource()
+    ) {
+        self.interfaceSource = SystemNetworkInterfaceInfoSource()
+        self.gatewayLatency = GatewayLatencyProvider()
+        self.context = context
+        self.diagnosticGatewayMeasuring = gatewayMeasuring
+        self.routeSource = routeSource
     }
 
     func run() async -> NetworkDiagnosticResult {
+        if let context {
+            return await contextResult(context)
+        }
         let interface = await interfaceSource.currentInterface()
         let gateway = await gatewayLatency.measure(routerIP: interface?.router)
 
@@ -194,6 +283,21 @@ struct GatewayReachabilityCheck: DiagnosticCheck {
             )
         }
         if let router = gateway.routerIP {
+            if case .gatewayPingFailed = gateway.error {
+                return NetworkDiagnosticResult(
+                    id: id,
+                    status: .indeterminate,
+                    summary: String(
+                        localized: "network_diagnostics.gateway.indeterminate.summary",
+                        comment: "Network self-check gateway reachability indeterminate summary"
+                    ),
+                    detail: String(
+                        localized: "network_diagnostics.gateway.no_response",
+                        comment: "Gateway did not respond to the ICMP probe"
+                    ),
+                    evidence: [.init(code: "gateway.no-response", value: router)]
+                )
+            }
             return NetworkDiagnosticResult(
                 id: id,
                 status: .abnormal,
@@ -213,6 +317,104 @@ struct GatewayReachabilityCheck: DiagnosticCheck {
             ),
             evidence: [.init(code: "gateway.unavailable", value: nil)]
         )
+    }
+
+    private func contextResult(_ context: DiagnosticNetworkContext) async -> NetworkDiagnosticResult {
+        guard case .selected(let target) = context.route,
+              let diagnosticGatewayMeasuring else {
+            let detailKey: String = switch context.route {
+            case .unsupported:
+                "network_diagnostics.gateway.unsupported"
+            default:
+                "network_diagnostics.gateway.route_changed"
+            }
+            return NetworkDiagnosticResult(
+                id: id,
+                status: .indeterminate,
+                summary: String(
+                    localized: "network_diagnostics.gateway.indeterminate.summary",
+                    comment: "Network self-check gateway reachability indeterminate summary"
+                ),
+                detail: String(
+                    localized: .init(stringLiteral: detailKey),
+                    comment: "Network self-check gateway route selection detail"
+                ),
+                evidence: [.init(code: "gateway.route-selection", value: routeSelectionCode(context.route))]
+            )
+        }
+
+        let gateway = await diagnosticGatewayMeasuring.measure(target: target)
+        if let routeSource,
+           await routeSource.currentRoute(timeout: .seconds(1)) != .selected(target) {
+            return NetworkDiagnosticResult(
+                id: id,
+                status: .indeterminate,
+                summary: String(
+                    localized: "network_diagnostics.gateway.indeterminate.summary",
+                    comment: "Network self-check gateway reachability indeterminate summary"
+                ),
+                detail: String(
+                    localized: "network_diagnostics.gateway.route_changed",
+                    comment: "Gateway route changed during the ICMP probe"
+                ),
+                evidence: [
+                    .init(code: "gateway.route-changed", value: nil),
+                    .init(code: "gateway.interface", value: target.interfaceName),
+                    .init(code: "gateway.interface-index", value: String(target.interfaceIndex)),
+                    .init(code: "gateway.address", value: target.address),
+                ]
+            )
+        }
+        let targetEvidence = [
+            NetworkDiagnosticEvidence(code: "gateway.interface", value: target.interfaceName),
+            NetworkDiagnosticEvidence(code: "gateway.interface-index", value: String(target.interfaceIndex)),
+            NetworkDiagnosticEvidence(code: "gateway.address", value: target.address),
+        ]
+
+        if let latency = gateway.latencyMs {
+            return NetworkDiagnosticResult(
+                id: id,
+                status: .normal,
+                summary: String(
+                    localized: "network_diagnostics.gateway.normal.summary",
+                    comment: "Network self-check gateway reachability success summary"
+                ),
+                evidence: targetEvidence + [.init(code: "gateway.latency-ms", value: String(latency))]
+            )
+        }
+        if case .gatewayPingFailed = gateway.error {
+            return NetworkDiagnosticResult(
+                id: id,
+                status: .indeterminate,
+                summary: String(
+                    localized: "network_diagnostics.gateway.indeterminate.summary",
+                    comment: "Network self-check gateway reachability indeterminate summary"
+                ),
+                detail: String(
+                    localized: "network_diagnostics.gateway.no_response",
+                    comment: "Gateway did not respond to the ICMP probe"
+                ),
+                evidence: targetEvidence + [.init(code: "gateway.no-response", value: target.address)]
+            )
+        }
+        return NetworkDiagnosticResult(
+            id: id,
+            status: .abnormal,
+            summary: String(
+                localized: "network_diagnostics.gateway.abnormal.summary",
+                comment: "Network self-check gateway reachability failure summary"
+            ),
+            evidence: targetEvidence + [.init(code: "gateway.unreachable", value: target.address)]
+        )
+    }
+
+    private func routeSelectionCode(_ route: DiagnosticRouteSelection) -> String {
+        switch route {
+        case .selected: "selected"
+        case .unavailable: "unavailable"
+        case .ambiguous: "ambiguous"
+        case .unsupported: "unsupported"
+        }
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticAssessment.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticAssessment.swift
@@ -80,9 +80,11 @@ struct NetworkDiagnosticAssessmentResolver: Sendable {
             return .init(stage: stage, status: .blocked, qualificationCode: nil)
         }
         if contributors.contains(where: { $0.status == .indeterminate }) {
+            let nonProxyContributors = contributors.filter { $0.id != .proxy }
             if stage == .thisMac,
                let proxy = results[.proxy],
-               isUnverifiedDirectRoute(proxy: proxy, internet: results[.internet]) {
+               isUnverifiedDirectRoute(proxy: proxy, internet: results[.internet]),
+               nonProxyContributors.allSatisfy({ $0.status == .normal }) {
                 return .init(
                     stage: stage,
                     status: .normal,
@@ -125,7 +127,7 @@ struct NetworkDiagnosticAssessmentResolver: Sendable {
            !hasDirectHTTPS(internet),
            !hasAvailableHTTPSProxy(proxy),
            internet?.evidence.contains(where: { $0.code == "https.connectivity-error" }) == true {
-            return externalSuccess ? .needsAttention : .networkUnavailable
+            return .needsAttention
         }
 
         let hasActionableIssue = [path, gateway, dns, internet, proxy]
@@ -234,6 +236,22 @@ struct NetworkDiagnosticAssessmentResolver: Sendable {
             && internet?.status == .normal
             && result.proxyFacts?.http == .unverified
             && result.proxyFacts?.https == .unverified
+            && hasExplicitDirectRouteEvidence(result)
+            && !result.evidence.contains {
+                $0.code == "proxy.http.resolution" || $0.code == "proxy.https.resolution"
+            }
+    }
+
+    private func hasExplicitDirectRouteEvidence(_ result: NetworkDiagnosticResult) -> Bool {
+        result.evidence.contains { evidence in
+            if evidence.code == "proxy.http.route-type" || evidence.code == "proxy.https.route-type" {
+                return evidence.value == "direct" || evidence.value == "tunnel"
+            }
+            if evidence.code == "proxy.http.egress-status" || evidence.code == "proxy.https.egress-status" {
+                return evidence.value == "base-check"
+            }
+            return false
+        }
     }
 
     private func isUnverifiedDirectRoute(

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticAssessment.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticAssessment.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+enum DiagnosticRouteAvailability: Equatable, Sendable {
+    case available
+    case unavailable
+    case authenticationRequired
+    case unverified
+}
+
+struct DiagnosticProxyFacts: Equatable, Sendable {
+    let http: DiagnosticRouteAvailability
+    let https: DiagnosticRouteAvailability
+}
+
+enum DiagnosticActionPriority: Int, Comparable, Sendable {
+    case pathUnavailable = 0
+    case captivePortal = 1
+    case proxyAuthentication = 2
+    case certificateTime = 3
+    case proxyRoute = 4
+    case dns = 5
+    case targetTransport = 6
+    case indeterminate = 7
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+struct DiagnosticStageAssessment: Equatable, Sendable {
+    let stage: NetworkDiagnosticStage
+    let status: NetworkDiagnosticStatus?
+    let qualificationCode: String?
+}
+
+struct NetworkDiagnosticAssessment: Equatable, Sendable {
+    let conclusion: NetworkDiagnosticConclusion?
+    let stages: [DiagnosticStageAssessment]
+    let primaryIssue: NetworkDiagnosticResult?
+}
+
+struct NetworkDiagnosticAssessmentResolver: Sendable {
+    func resolve(
+        results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult],
+        complete: Bool,
+        requiredIDs: Set<NetworkDiagnosticCheckID> = Set(NetworkDiagnosticCheckID.allCases)
+    ) -> NetworkDiagnosticAssessment {
+        let stages = NetworkDiagnosticStage.allCases.map { stage in
+            stageAssessment(stage, results: results)
+        }
+        guard complete,
+              Set(results.keys) == requiredIDs else {
+            return NetworkDiagnosticAssessment(
+                conclusion: nil,
+                stages: stages,
+                primaryIssue: primaryIssue(in: results)
+            )
+        }
+
+        let conclusion = conclusion(results: results)
+        return NetworkDiagnosticAssessment(
+            conclusion: conclusion,
+            stages: stages,
+            primaryIssue: primaryIssue(in: results)
+        )
+    }
+
+    private func stageAssessment(
+        _ stage: NetworkDiagnosticStage,
+        results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult]
+    ) -> DiagnosticStageAssessment {
+        let contributors = stage.contributingCheckIDs.compactMap { results[$0] }
+        guard contributors.count == stage.contributingCheckIDs.count else {
+            return .init(stage: stage, status: nil, qualificationCode: nil)
+        }
+        if contributors.contains(where: { $0.status == .abnormal }) {
+            return .init(stage: stage, status: .abnormal, qualificationCode: nil)
+        }
+        if contributors.contains(where: { $0.status == .blocked }) {
+            return .init(stage: stage, status: .blocked, qualificationCode: nil)
+        }
+        if contributors.contains(where: { $0.status == .indeterminate }) {
+            if stage == .thisMac,
+               let proxy = results[.proxy],
+               isUnverifiedDirectRoute(proxy: proxy, internet: results[.internet]) {
+                return .init(
+                    stage: stage,
+                    status: .normal,
+                    qualificationCode: "proxy.direct-unverified"
+                )
+            }
+            if stage == .lan,
+               let gateway = results[.gatewayReachability],
+               gateway.status == .indeterminate,
+               gateway.evidence.contains(where: { $0.code == "gateway.no-response" }),
+               hasExternalSuccess(
+                    internet: results[.internet],
+                    proxy: results[.proxy]
+               ) {
+                return .init(
+                    stage: stage,
+                    status: .indeterminate,
+                    qualificationCode: "gateway.unverified"
+                )
+            }
+            return .init(stage: stage, status: .indeterminate, qualificationCode: nil)
+        }
+        return .init(stage: stage, status: .normal, qualificationCode: nil)
+    }
+
+    private func conclusion(
+        results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult]
+    ) -> NetworkDiagnosticConclusion {
+        let path = results[.path]
+        let internet = results[.internet]
+        let gateway = results[.gatewayReachability]
+        let dns = results[.dns]
+        let proxy = results[.proxy]
+        let externalSuccess = hasExternalSuccess(internet: internet, proxy: proxy)
+
+        if path?.status == .abnormal, !externalSuccess {
+            return .networkUnavailable
+        }
+        if internet?.status == .abnormal,
+           !hasDirectHTTPS(internet),
+           !hasAvailableHTTPSProxy(proxy),
+           internet?.evidence.contains(where: { $0.code == "https.connectivity-error" }) == true {
+            return externalSuccess ? .needsAttention : .networkUnavailable
+        }
+
+        let hasActionableIssue = [path, gateway, dns, internet, proxy]
+            .compactMap { $0 }
+            .contains { result in
+                switch result.id {
+                case .path:
+                    result.status != .normal
+                case .gatewayReachability:
+                    !isNeutralGateway(result, externalSuccess: externalSuccess)
+                        && result.status != .normal
+                case .dns, .internet:
+                    result.status != .normal
+                case .proxy:
+                    !isNeutralDirectProxy(result, internet: internet)
+                        && result.status != .normal
+                case .ipv6:
+                    false
+                }
+            }
+        return hasActionableIssue ? .needsAttention : .networkNormal
+    }
+
+    private func primaryIssue(
+        in results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult]
+    ) -> NetworkDiagnosticResult? {
+        let externalSuccess = hasExternalSuccess(
+            internet: results[.internet],
+            proxy: results[.proxy]
+        )
+        let candidates = results.values.filter { result in
+            switch result.id {
+            case .path:
+                result.status == .abnormal || result.status == .indeterminate
+            case .gatewayReachability:
+                (result.status == .abnormal || result.status == .indeterminate)
+                    && !isNeutralGateway(result, externalSuccess: externalSuccess)
+            case .dns, .internet, .proxy:
+                result.status == .abnormal || result.status == .indeterminate
+            case .ipv6:
+                false
+            }
+        }
+        return candidates.min { lhs, rhs in
+            actionPriority(for: lhs).rawValue < actionPriority(for: rhs).rawValue
+        }
+    }
+
+    private func actionPriority(for result: NetworkDiagnosticResult) -> DiagnosticActionPriority {
+        let codes = Set(result.evidence.map(\.code))
+        if result.id == .path, result.status == .abnormal {
+            return .pathUnavailable
+        }
+        if codes.contains("captive-portal.redirect") || codes.contains("captive-portal.suspected") {
+            return .captivePortal
+        }
+        if result.id == .proxy,
+           let facts = result.proxyFacts,
+           facts.http == .authenticationRequired || facts.https == .authenticationRequired {
+            return .proxyAuthentication
+        }
+        if codes.contains("https.certificate-time-error") {
+            return .certificateTime
+        }
+        if result.id == .proxy,
+           codes.contains(where: { $0 == "proxy.endpoint-unavailable" || $0 == "proxy.egress-unavailable" }) {
+            return .proxyRoute
+        }
+        if result.id == .dns {
+            return .dns
+        }
+        if result.id == .internet {
+            return .targetTransport
+        }
+        return .indeterminate
+    }
+
+    private func hasExternalSuccess(
+        internet: NetworkDiagnosticResult?,
+        proxy: NetworkDiagnosticResult?
+    ) -> Bool {
+        hasDirectHTTPS(internet) || hasAvailableHTTPSProxy(proxy)
+    }
+
+    private func hasDirectHTTPS(_ result: NetworkDiagnosticResult?) -> Bool {
+        result?.evidence.contains { $0.code == "https.available" } == true
+    }
+
+    private func hasAvailableHTTPSProxy(_ result: NetworkDiagnosticResult?) -> Bool {
+        result?.proxyFacts?.https == .available
+    }
+
+    private func isNeutralGateway(
+        _ result: NetworkDiagnosticResult,
+        externalSuccess: Bool
+    ) -> Bool {
+        guard externalSuccess, result.status == .indeterminate else { return false }
+        return result.evidence.contains { $0.code == "gateway.no-response" }
+    }
+
+    private func isNeutralDirectProxy(
+        _ result: NetworkDiagnosticResult,
+        internet: NetworkDiagnosticResult?
+    ) -> Bool {
+        result.status == .indeterminate
+            && internet?.status == .normal
+            && result.proxyFacts?.http == .unverified
+            && result.proxyFacts?.https == .unverified
+    }
+
+    private func isUnverifiedDirectRoute(
+        proxy: NetworkDiagnosticResult,
+        internet: NetworkDiagnosticResult?
+    ) -> Bool {
+        isNeutralDirectProxy(proxy, internet: internet)
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticEvent.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticEvent.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum DiagnosticEventKind: Equatable, Sendable {
+    case sessionStarted
+    case runStarted
+    case checkStarted
+    case checkFinished
+    case restarted
+    case timedOut
+    case cancelled
+    case completed
+}
+
+struct NetworkDiagnosticEvent: Equatable, Sendable {
+    let runID: UUID
+    let elapsedMilliseconds: Int64
+    let kind: DiagnosticEventKind
+    let checkID: NetworkDiagnosticCheckID?
+    let reasonCode: String?
+
+    func formatted() -> String {
+        let elapsed = String(max(0, elapsedMilliseconds)) + "ms"
+        switch kind {
+        case .sessionStarted:
+            return elapsed + " · Session started"
+        case .runStarted:
+            return elapsed + " · Run started"
+        case .checkStarted:
+            return elapsed + " · Checking " + (checkID?.logTitle ?? "diagnostic") + "…"
+        case .checkFinished:
+            return elapsed + " · " + (checkID?.logTitle ?? "Diagnostic") + " finished"
+        case .restarted:
+            return elapsed + " · Network changed; restarting (" + Self.reasonTitle(reasonCode) + ")"
+        case .timedOut:
+            return elapsed + " · Check timed out"
+        case .cancelled:
+            return elapsed + " · Check cancelled"
+        case .completed:
+            return elapsed + " · Check completed"
+        }
+    }
+
+    private static func reasonTitle(_ reasonCode: String?) -> String {
+        switch reasonCode {
+        case .some("route"):
+            "route"
+        case .some("address"):
+            "address"
+        case .some("dns"):
+            "DNS"
+        case .some("proxy"):
+            "proxy"
+        case .some("path"):
+            "path"
+        case .some("network-change"):
+            "network change"
+        default:
+            "network state"
+        }
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
@@ -2,10 +2,75 @@ import Foundation
 
 enum NetworkDiagnosticStatus: String, CaseIterable, Equatable, Sendable {
     case normal, abnormal, indeterminate, blocked, skipped
+
+    var logTitle: String {
+        switch self {
+        case .normal:
+            "Normal"
+        case .abnormal:
+            "Abnormal"
+        case .indeterminate:
+            "Indeterminate"
+        case .blocked:
+            "Blocked"
+        case .skipped:
+            "Skipped"
+        }
+    }
 }
 
 enum NetworkDiagnosticCheckID: String, CaseIterable, Equatable, Hashable, Sendable {
     case path, gatewayReachability, dns, internet, ipv6, proxy
+
+    var logTitle: String {
+        switch self {
+        case .path:
+            "Network Path"
+        case .gatewayReachability:
+            "Gateway Reachability"
+        case .dns:
+            "DNS Resolution"
+        case .internet:
+            "Internet Access"
+        case .ipv6:
+            "IPv6 Connectivity"
+        case .proxy:
+            "System Proxy"
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .path:
+            String(localized: "network_diagnostics.check.path.title", comment: "Network system path check title")
+        case .gatewayReachability:
+            String(localized: "network_diagnostics.check.gateway_reachability.title", comment: "Gateway reachability check title")
+        case .dns:
+            String(localized: "network_diagnostics.check.dns.title", comment: "DNS resolution check title")
+        case .internet:
+            String(localized: "network_diagnostics.check.internet.title", comment: "Internet access check title")
+        case .ipv6:
+            String(localized: "network_diagnostics.check.ipv6.title", comment: "Optional forced IPv6 access check title")
+        case .proxy:
+            String(localized: "network_diagnostics.check.proxy.title", comment: "System proxy check title")
+        }
+    }
+}
+
+struct NetworkDiagnosticsLogStore: Equatable, Sendable {
+    private(set) var lines: [String] = []
+
+    var text: String {
+        lines.joined(separator: "\n")
+    }
+
+    mutating func append(_ line: String) {
+        lines.append(line)
+    }
+
+    mutating func reset() {
+        lines.removeAll(keepingCapacity: true)
+    }
 }
 
 enum NetworkDiagnosticStatusTone: Equatable, Sendable {
@@ -36,6 +101,13 @@ extension NetworkDiagnosticStatus {
         case .skipped:
             .init(labelKey: "network_diagnostics.status.skipped", icon: "forward.fill", tone: .muted)
         }
+    }
+
+    var localizedTitle: String {
+        String(
+            localized: .init(stringLiteral: presentation.labelKey),
+            comment: "Network self-check status title"
+        )
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticModels.swift
@@ -58,18 +58,53 @@ enum NetworkDiagnosticCheckID: String, CaseIterable, Equatable, Hashable, Sendab
 }
 
 struct NetworkDiagnosticsLogStore: Equatable, Sendable {
+    static let capacity = 500
+    static let truncationMarker = "… earlier diagnostic events omitted …"
+
     private(set) var lines: [String] = []
+    private(set) var events: [NetworkDiagnosticEvent] = []
+    private var hasTruncationMarker = false
 
     var text: String {
         lines.joined(separator: "\n")
     }
 
     mutating func append(_ line: String) {
+        appendLine(line)
+    }
+
+    mutating func append(_ event: NetworkDiagnosticEvent) {
+        appendLine(event.formatted())
+        events.append(event)
+        if events.count > Self.capacity - 1 {
+            events.removeFirst(events.count - (Self.capacity - 1))
+        }
+    }
+
+    private mutating func appendLine(_ line: String) {
+        if lines.count >= Self.capacity {
+            if hasTruncationMarker {
+                if lines.count > 1 {
+                    lines.remove(at: 1)
+                } else {
+                    lines.removeFirst()
+                }
+            } else {
+                lines.removeFirst()
+                lines.insert(Self.truncationMarker, at: 0)
+                hasTruncationMarker = true
+            }
+            if lines.count >= Self.capacity {
+                lines.removeLast()
+            }
+        }
         lines.append(line)
     }
 
     mutating func reset() {
         lines.removeAll(keepingCapacity: true)
+        events.removeAll(keepingCapacity: true)
+        hasTruncationMarker = false
     }
 }
 
@@ -123,7 +158,22 @@ struct NetworkDiagnosticRemediation: Equatable, Sendable {
     let rerunKey: String
 
     static func forResult(_ result: NetworkDiagnosticResult) -> Self {
-        let codes = Set(result.evidence.map(\.code))
+        var codes = Set(result.evidence.map(\.code))
+        if result.id == .proxy, let facts = result.proxyFacts {
+            if facts.http != .authenticationRequired && facts.https != .authenticationRequired {
+                codes.remove("proxy.authentication-required")
+                codes.remove("proxy.http.authentication-required")
+                codes.remove("proxy.https.authentication-required")
+            }
+            if facts.http != .unavailable && facts.https != .unavailable {
+                codes.remove("proxy.endpoint-unavailable")
+                codes.remove("proxy.egress-unavailable")
+                codes.remove("proxy.http.endpoint-unavailable")
+                codes.remove("proxy.https.endpoint-unavailable")
+                codes.remove("proxy.http.egress-unavailable")
+                codes.remove("proxy.https.egress-unavailable")
+            }
+        }
         let base: (String, String, String) = if codes.contains("proxy.authentication-required") {
             (
                 "network_diagnostics.remediation.proxy_authentication.detection",
@@ -185,12 +235,13 @@ struct NetworkDiagnosticRemediation: Equatable, Sendable {
 
 extension NetworkDiagnosticConclusion {
     static func primaryIssue(in results: [NetworkDiagnosticResult]) -> NetworkDiagnosticResult? {
-        let priority: [NetworkDiagnosticCheckID] = [.path, .gatewayReachability, .dns, .internet, .proxy]
-        return priority.compactMap { id in
-            results.first {
-                $0.id == id && ($0.status == .abnormal || $0.status == .indeterminate)
-            }
-        }.first
+        let resultsByID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+        return NetworkDiagnosticAssessmentResolver()
+            .resolve(
+                results: resultsByID,
+                complete: Set(resultsByID.keys) == Set(NetworkDiagnosticCheckID.allCases)
+            )
+            .primaryIssue
     }
 }
 
@@ -213,20 +264,11 @@ struct NetworkDiagnosticStageResolver: Sendable {
         for stage: NetworkDiagnosticStage,
         results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult]
     ) -> NetworkDiagnosticStatus? {
-        let contributingIDs = stage.contributingCheckIDs
-        let contributing = contributingIDs.compactMap { results[$0] }
-        guard contributing.count == contributingIDs.count else { return nil }
-
-        if contributing.contains(where: { $0.status == .abnormal }) {
-            return .abnormal
-        }
-        if contributing.contains(where: { $0.status == .indeterminate }) {
-            return .indeterminate
-        }
-        if contributing.allSatisfy({ $0.status == .blocked }) {
-            return .blocked
-        }
-        return .normal
+        NetworkDiagnosticAssessmentResolver()
+            .resolve(results: results, complete: false)
+            .stages
+            .first { $0.stage == stage }?
+            .status
     }
 }
 
@@ -236,19 +278,22 @@ struct NetworkDiagnosticResult: Equatable, Identifiable, Sendable {
     let summary: String
     let detail: String?
     let evidence: [NetworkDiagnosticEvidence]
+    let proxyFacts: DiagnosticProxyFacts?
 
     init(
         id: NetworkDiagnosticCheckID,
         status: NetworkDiagnosticStatus,
         summary: String,
         detail: String? = nil,
-        evidence: [NetworkDiagnosticEvidence] = []
+        evidence: [NetworkDiagnosticEvidence] = [],
+        proxyFacts: DiagnosticProxyFacts? = nil
     ) {
         self.id = id
         self.status = status
         self.summary = summary
         self.detail = detail
         self.evidence = evidence
+        self.proxyFacts = proxyFacts
     }
 
     static func blocked(id: NetworkDiagnosticCheckID, summary: String) -> Self {
@@ -266,54 +311,13 @@ enum NetworkDiagnosticConclusion: String, Equatable, Sendable {
         requiredIDs: Set<NetworkDiagnosticCheckID> = Set(NetworkDiagnosticCheckID.allCases)
     ) -> Self? {
         let resultsByID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
-        guard Set(resultsByID.keys) == requiredIDs else {
-            return nil
-        }
-
-        if resultsByID[.path]?.status == .abnormal {
-            return .networkUnavailable
-        }
-        if let internet = resultsByID[.internet],
-           internet.status == .abnormal,
-           !internet.evidence.contains(where: { $0.code == "https.available" }),
-           !hasAvailableHTTPSProxy(resultsByID[.proxy]),
-           internet.evidence.contains(where: { $0.code == "https.connectivity-error" }) {
-            return .networkUnavailable
-        }
-        if resultsByID.values.contains(where: { result in
-            result.status != .normal
-                && result.id != .ipv6
-                && !isUnverifiedDirectRouteNeutral(
-                    result,
-                    internet: resultsByID[.internet]
-                )
-        }) {
-            return .needsAttention
-        }
-        return .networkNormal
-    }
-
-    private static func hasAvailableHTTPSProxy(_ result: NetworkDiagnosticResult?) -> Bool {
-        guard result?.status == .normal else { return false }
-        return result?.evidence.contains { evidence in
-            guard evidence.code == "proxy.https.egress-status",
-                  let value = evidence.value,
-                  let statusCode = Int(value) else {
-                return false
-            }
-            return (200..<300).contains(statusCode)
-        } == true
-    }
-
-    private static func isUnverifiedDirectRouteNeutral(
-        _ result: NetworkDiagnosticResult,
-        internet: NetworkDiagnosticResult?
-    ) -> Bool {
-        result.id == .proxy
-            && result.status == .indeterminate
-            && internet?.status == .normal
-            && result.evidence.contains { evidence in
-                evidence.code.hasSuffix(".egress-status") && evidence.value == "base-check"
-            }
+        guard Set(resultsByID.keys) == requiredIDs else { return nil }
+        return NetworkDiagnosticAssessmentResolver()
+            .resolve(
+                results: resultsByID,
+                complete: true,
+                requiredIDs: requiredIDs
+            )
+            .conclusion
     }
 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -6,33 +6,23 @@ struct NetworkDiagnosticsView: View {
     let guidance: GuidanceCoordinator = .shared
     @State private var expandedGroupOverride: [String: Bool] = [:]
     @State private var renderedInvitationID: UUID?
+    @State private var consolePanelController = ConsolePanelController(
+        statusBarHeight: 30,
+        topMinimum: 240,
+        expandedBottom: 300
+    )
+    @State private var logExpanded = false
 
     var body: some View {
         GeometryReader { geometry in
             let layoutMode = NetworkDiagnosticsWorkbenchLayout.mode(for: geometry.size.width)
 
-            VStack(spacing: 0) {
-                commandBar
-                Divider()
-
-                if viewModel.phase == .running {
-                    progressStrip
-                    Divider()
-                } else if let conclusion = viewModel.conclusion {
-                    conclusionStrip(conclusion)
-                    Divider()
-                    if let invitation = guidance.pendingInvitation,
-                       invitation.moment == .diagnosticsCompleted {
-                        ProInvitationCard(invitation: invitation, guidance: guidance)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 12)
-                            .onAppear { renderedInvitationID = invitation.id }
-                    }
-                }
-
-                workspace(layoutMode)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
+            ConsoleSplitView(
+                content: diagnosticsContent(layoutMode),
+                bottom: diagnosticsConsole,
+                controller: consolePanelController
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .animation(reduceMotion ? nil : .snappy(duration: 0.24), value: viewModel.phase)
 #if DEBUG
@@ -51,6 +41,146 @@ struct NetworkDiagnosticsView: View {
                 guidance.endInvitationPresentation(id: id)
                 renderedInvitationID = nil
             }
+        }
+    }
+
+    @ViewBuilder
+    private func diagnosticsContent(_ layoutMode: NetworkDiagnosticsWorkbenchLayoutMode) -> some View {
+        VStack(spacing: 0) {
+            commandBar
+            Divider()
+
+            if viewModel.phase == .running {
+                progressStrip
+                Divider()
+            } else if let conclusion = viewModel.conclusion {
+                conclusionStrip(conclusion)
+                Divider()
+                if let invitation = guidance.pendingInvitation,
+                   invitation.moment == .diagnosticsCompleted {
+                    ProInvitationCard(invitation: invitation, guidance: guidance)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .onAppear { renderedInvitationID = invitation.id }
+                }
+            }
+
+            workspace(layoutMode)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private var diagnosticsConsole: some View {
+        VStack(spacing: 0) {
+            diagnosticsLogStatusBar
+            LogTextView(text: viewModel.logText)
+                .background(Color.black.opacity(0.06))
+        }
+    }
+
+    private var diagnosticsLogStatusBar: some View {
+        HStack(spacing: 10) {
+            diagnosticsStatusLeading
+            Spacer(minLength: 8)
+            if !viewModel.logText.isEmpty {
+                Text("\(viewModel.logStore.lines.count)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .background(Capsule().fill(.quaternary.opacity(0.4)))
+            }
+            if !viewModel.logText.isEmpty {
+                Button {
+                    viewModel.clearLogs()
+                } label: {
+                    Image(systemName: "trash").font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .frame(width: 26, height: 22)
+                .contentShape(Rectangle())
+                .help(String(localized: "network_diagnostics.log.clear", comment: "Clear network self-check logs action"))
+                .accessibilityLabel(String(localized: "network_diagnostics.log.clear", comment: "Clear network self-check logs action"))
+                .accessibilityIdentifier("network-diagnostics-log-clear")
+            }
+            Button {
+                toggleLogPanel()
+            } label: {
+                Image(systemName: logExpanded ? "chevron.down" : "chevron.up")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.borderless)
+            .frame(width: 30, height: 22)
+            .contentShape(Rectangle())
+            .help(
+                String(
+                    localized: logExpanded
+                        ? "network_diagnostics.log.collapse"
+                        : "network_diagnostics.log.expand",
+                    comment: "Network self-check log panel expand or collapse action"
+                )
+            )
+            .accessibilityLabel(
+                String(
+                    localized: logExpanded
+                        ? "network_diagnostics.log.collapse"
+                        : "network_diagnostics.log.expand",
+                    comment: "Network self-check log panel expand or collapse action"
+                )
+            )
+            .accessibilityIdentifier("network-diagnostics-log-toggle")
+        }
+        .padding(.horizontal, 12)
+        .frame(minHeight: 30)
+    }
+
+    @ViewBuilder
+    private var diagnosticsStatusLeading: some View {
+        switch viewModel.phase {
+        case .idle:
+            Label(
+                String(localized: "network_diagnostics.state.waiting", comment: "Network self-check waiting state"),
+                systemImage: "circle.dotted"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        case .running:
+            HStack(spacing: 7) {
+                ProgressView().controlSize(.mini)
+                Text(viewModel.logStore.lines.last ?? String(localized: "network_diagnostics.state.checking", comment: "Network self-check running state"))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        case .completed:
+            if let conclusion = viewModel.conclusion {
+                Label(conclusionTitle(conclusion), systemImage: conclusionIcon(conclusion))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(conclusionColor(conclusion))
+                    .lineLimit(1)
+            } else {
+                Label(
+                    String(localized: "network_diagnostics.state.waiting", comment: "Network self-check waiting state"),
+                    systemImage: "circle.dotted"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+        }
+    }
+
+    private func toggleLogPanel() {
+        let shouldExpand = !logExpanded
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.22)) {
+            logExpanded = shouldExpand
+        }
+        if shouldExpand {
+            consolePanelController.expandLog(animate: !reduceMotion)
+        } else {
+            consolePanelController.collapseLog(animate: !reduceMotion)
         }
     }
 
@@ -548,20 +678,7 @@ struct NetworkDiagnosticsView: View {
     }
 
     private func checkTitle(_ id: NetworkDiagnosticCheckID) -> String {
-        switch id {
-        case .path:
-            String(localized: "network_diagnostics.check.path.title", comment: "Network system path check title")
-        case .gatewayReachability:
-            String(localized: "network_diagnostics.check.gateway_reachability.title", comment: "Gateway reachability check title")
-        case .dns:
-            String(localized: "network_diagnostics.check.dns.title", comment: "DNS resolution check title")
-        case .internet:
-            String(localized: "network_diagnostics.check.internet.title", comment: "Internet access check title")
-        case .ipv6:
-            String(localized: "network_diagnostics.check.ipv6.title", comment: "Optional forced IPv6 access check title")
-        case .proxy:
-            String(localized: "network_diagnostics.check.proxy.title", comment: "System proxy check title")
-        }
+        id.localizedTitle
     }
 
     private func checkIcon(_ id: NetworkDiagnosticCheckID) -> String {
@@ -576,18 +693,7 @@ struct NetworkDiagnosticsView: View {
     }
 
     private func statusTitle(_ status: NetworkDiagnosticStatus) -> String {
-        switch status {
-        case .normal:
-            String(localized: "network_diagnostics.status.normal", comment: "Normal network self-check status")
-        case .abnormal:
-            String(localized: "network_diagnostics.status.abnormal", comment: "Abnormal network self-check status")
-        case .indeterminate:
-            String(localized: "network_diagnostics.status.indeterminate", comment: "Indeterminate network self-check status")
-        case .blocked:
-            String(localized: "network_diagnostics.status.blocked", comment: "Blocked network self-check status")
-        case .skipped:
-            String(localized: "network_diagnostics.status.skipped", comment: "Skipped network self-check status")
-        }
+        status.localizedTitle
     }
 
     private func statusIcon(_ status: NetworkDiagnosticStatus) -> String {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsView.swift
@@ -63,6 +63,9 @@ struct NetworkDiagnosticsView: View {
                         .padding(.vertical, 12)
                         .onAppear { renderedInvitationID = invitation.id }
                 }
+            } else if viewModel.phase == .completed {
+                sessionOutcomeStrip
+                Divider()
             }
 
             workspace(layoutMode)
@@ -236,7 +239,11 @@ struct NetworkDiagnosticsView: View {
         case .running:
             HStack(spacing: 7) {
                 ProgressView().controlSize(.small)
-                Text(String(localized: "network_diagnostics.state.checking", comment: "Network self-check running state"))
+                Text(
+                    viewModel.automaticRestartCount > 0
+                        ? String(localized: "network_diagnostics.session.restarting", comment: "Network self-check automatic restart state")
+                        : String(localized: "network_diagnostics.state.checking", comment: "Network self-check running state")
+                )
             }
         case .completed:
             if let conclusion = viewModel.conclusion {
@@ -286,6 +293,15 @@ struct NetworkDiagnosticsView: View {
             )
             .progressViewStyle(.linear)
             .accessibilityLabel(String(localized: "network_diagnostics.state.checking", comment: "Network self-check running state"))
+
+            if !viewModel.fingerprintMonitoringAvailable {
+                Label(
+                    String(localized: "network_diagnostics.session.monitor_unavailable", comment: "Network self-check network change monitoring unavailable state"),
+                    systemImage: "eye.slash"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
@@ -309,7 +325,7 @@ struct NetworkDiagnosticsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 if conclusion == .needsAttention,
-                   let issue = NetworkDiagnosticConclusion.primaryIssue(in: Array(viewModel.results.values)) {
+                   let issue = viewModel.assessment?.primaryIssue {
                     let remediation = NetworkDiagnosticRemediation.forResult(issue)
                     Text(String(localized: .init(stringLiteral: remediation.actionKey), comment: "Network self-check primary remediation action"))
                         .font(.caption)
@@ -323,6 +339,54 @@ struct NetworkDiagnosticsView: View {
         .background(conclusionColor(conclusion).opacity(0.06))
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("network-diagnostics-conclusion")
+    }
+
+    private var sessionOutcomeStrip: some View {
+        let message = sessionOutcomeMessage
+        return HStack(alignment: .top, spacing: 12) {
+            Image(systemName: sessionOutcomeIcon)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.orange)
+                .frame(width: 26)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.orange.opacity(0.06))
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("network-diagnostics-session-outcome")
+    }
+
+    private var sessionOutcomeMessage: String {
+        switch viewModel.endReason {
+        case .timedOut:
+            String(
+                format: String(
+                    localized: "network_diagnostics.session.timed_out",
+                    comment: "Network self-check timeout summary"
+                ),
+                Int64(viewModel.results.count),
+                Int64(viewModel.checkIDs.count)
+            )
+        case .cancelled:
+            String(localized: "network_diagnostics.session.cancelled", comment: "Network self-check cancellation summary")
+        case .superseded:
+            String(localized: "network_diagnostics.session.network_changed", comment: "Network self-check unstable network summary")
+        case .completed, .none:
+            String(localized: "network_diagnostics.state.waiting", comment: "Network self-check waiting state")
+        }
+    }
+
+    private var sessionOutcomeIcon: String {
+        switch viewModel.endReason {
+        case .cancelled: "xmark.circle"
+        case .superseded: "arrow.triangle.2.circlepath"
+        case .timedOut, .completed, .none: "clock.badge.exclamationmark"
+        }
     }
 
     @ViewBuilder
@@ -341,7 +405,8 @@ struct NetworkDiagnosticsView: View {
         NetworkDiagnosticsPipelineView(
             presentation: NetworkDiagnosticsPipelinePresentation.from(
                 results: viewModel.results,
-                executionPhases: viewModel.executionPhases
+                executionPhases: viewModel.executionPhases,
+                assessment: viewModel.assessment
             )
         )
         .padding(.horizontal, 20)
@@ -462,6 +527,13 @@ struct NetworkDiagnosticsView: View {
                 .padding(.vertical, 4)
                 .background(statusColor(result.status).opacity(0.10), in: Capsule())
                 .accessibilityLabel(statusAccessibilityLabel(for: result))
+        } else if let pendingReason = row.pendingReason {
+            Label(pendingTitle(for: pendingReason), systemImage: "clock.badge.exclamationmark")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.secondary.opacity(0.10), in: Capsule())
         } else {
             HStack(spacing: 6) {
                 ProgressView().controlSize(.mini)
@@ -497,10 +569,20 @@ struct NetworkDiagnosticsView: View {
                         .foregroundStyle(.secondary)
                         .lineSpacing(1)
                 }
-                if result.status == .abnormal || result.status == .indeterminate {
+                if let target = gatewayTargetText(for: result) {
+                    Text(target)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if (result.status == .abnormal || result.status == .indeterminate),
+                   viewModel.assessment?.primaryIssue?.id == result.id {
                     remediationView(for: result)
                 }
             }
+        } else if let pendingReason = row.pendingReason {
+            Text(pendingDetail(for: pendingReason))
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -616,7 +698,8 @@ struct NetworkDiagnosticsView: View {
             pagePhase: viewModel.phase,
             executionPhases: viewModel.executionPhases,
             results: viewModel.results,
-            checkIDs: viewModel.checkIDs
+            checkIDs: viewModel.checkIDs,
+            endReason: viewModel.endReason
         )
     }
 
@@ -710,6 +793,46 @@ struct NetworkDiagnosticsView: View {
         }
     }
 
+    private func pendingTitle(for reason: DiagnosticRunEndReason) -> String {
+        switch reason {
+        case .cancelled:
+            String(localized: "network_diagnostics.check.not_run_cancelled", comment: "Pending network self-check cancelled row status")
+        case .timedOut, .superseded:
+            String(localized: "network_diagnostics.check.not_run_timeout", comment: "Pending network self-check timeout row status")
+        case .completed:
+            String(localized: "network_diagnostics.check.not_run_timeout", comment: "Pending network self-check incomplete row status")
+        }
+    }
+
+    private func pendingDetail(for reason: DiagnosticRunEndReason) -> String {
+        switch reason {
+        case .cancelled:
+            String(localized: "network_diagnostics.check.not_run_cancelled", comment: "Pending network self-check cancellation detail")
+        case .timedOut, .superseded, .completed:
+            String(localized: "network_diagnostics.check.not_run_timeout", comment: "Pending network self-check timeout detail")
+        }
+    }
+
+    private func gatewayTargetText(for result: NetworkDiagnosticResult) -> String? {
+        guard result.id == .gatewayReachability else { return nil }
+        let evidence = result.evidence.reduce(into: [String: String]()) { values, evidence in
+            if let value = evidence.value {
+                values[evidence.code] = value
+            }
+        }
+        guard let interface = evidence["gateway.interface"],
+              let address = evidence["gateway.address"] ?? evidence["gateway.no-response"]
+        else { return nil }
+        return String(
+            format: String(
+                localized: "network_diagnostics.gateway.target",
+                comment: "Selected gateway target details"
+            ),
+            interface,
+            address
+        )
+    }
+
     private func statusColor(_ status: NetworkDiagnosticStatus) -> Color {
         switch status.presentation.tone {
         case .success: .green
@@ -774,6 +897,7 @@ struct NetworkDiagnosticsPipelinePresentation: Equatable, Sendable {
     struct Station: Equatable, Identifiable, Sendable {
         let kind: StationKind
         let status: NetworkDiagnosticStatus?
+        let qualificationCode: String?
         let isUnreachable: Bool
 
         var id: StationKind { kind }
@@ -793,16 +917,27 @@ struct NetworkDiagnosticsPipelinePresentation: Equatable, Sendable {
     static func from(
         results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult],
         executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase],
+        assessment: NetworkDiagnosticAssessment? = nil,
         resolver: NetworkDiagnosticStageResolver = NetworkDiagnosticStageResolver()
     ) -> Self {
-        let thisMac = resolver.status(for: .thisMac, results: results)
-        let lan = resolver.status(for: .lan, results: results)
-        let internet = resolver.status(for: .internet, results: results)
+        let stageAssessments = assessment?.stages ?? NetworkDiagnosticStage.allCases.map { stage in
+            DiagnosticStageAssessment(
+                stage: stage,
+                status: resolver.status(for: stage, results: results),
+                qualificationCode: nil
+            )
+        }
+        let thisMac = stageAssessments.first { $0.stage == .thisMac }?.status
+        let lan = stageAssessments.first { $0.stage == .lan }?.status
+        let internet = stageAssessments.first { $0.stage == .internet }?.status
+        let thisMacQualification = stageAssessments.first { $0.stage == .thisMac }?.qualificationCode
+        let lanQualification = stageAssessments.first { $0.stage == .lan }?.qualificationCode
+        let internetQualification = stageAssessments.first { $0.stage == .internet }?.qualificationCode
 
         let stations = [
-            Station(kind: .thisMac, status: thisMac, isUnreachable: false),
-            Station(kind: .router, status: lan, isUnreachable: lan == .abnormal || lan == .blocked),
-            Station(kind: .internet, status: internet, isUnreachable: internet == .abnormal || internet == .blocked),
+            Station(kind: .thisMac, status: thisMac, qualificationCode: thisMacQualification, isUnreachable: false),
+            Station(kind: .router, status: lan, qualificationCode: lanQualification, isUnreachable: lan == .abnormal || lan == .blocked),
+            Station(kind: .internet, status: internet, qualificationCode: internetQualification, isUnreachable: internet == .abnormal || internet == .blocked),
         ]
         let edges = [
             Edge(kind: .lan, status: lan, isActive: isActive(stage: .lan, executionPhases: executionPhases)),
@@ -858,6 +993,13 @@ struct NetworkDiagnosticsPipelineView: View {
                 Label(statusTitle(status), systemImage: statusIcon(status))
                     .font(.caption2.weight(.medium))
                     .foregroundStyle(statusColor(status))
+            }
+            if let qualificationCode = station.qualificationCode {
+                Text(qualificationTitle(qualificationCode))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
             }
         }
         .frame(width: 110)
@@ -1011,6 +1153,17 @@ struct NetworkDiagnosticsPipelineView: View {
         case .caution: .orange
         case .informational: .blue
         case .muted: .secondary
+        }
+    }
+
+    private func qualificationTitle(_ code: String) -> String {
+        switch code {
+        case "gateway.unverified":
+            String(localized: "network_diagnostics.gateway.unverified", comment: "Gateway qualification after successful internet access")
+        case "proxy.direct-unverified":
+            String(localized: "network_diagnostics.proxy.direct_unverified", comment: "Direct proxy route qualification")
+        default:
+            String(localized: "network_diagnostics.state.indeterminate", comment: "Network self-check uncertainty qualification")
         }
     }
 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -126,9 +126,12 @@ final class NetworkDiagnosticsViewModel {
     private(set) var phase = NetworkDiagnosticsPagePhase.idle
     private(set) var executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase]
     private(set) var results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [:]
+    private(set) var logStore = NetworkDiagnosticsLogStore()
     private(set) var conclusion: NetworkDiagnosticConclusion?
     private(set) var automaticRestartCount = 0
     let checkIDs: [NetworkDiagnosticCheckID]
+
+    var logText: String { logStore.text }
 
     @ObservationIgnored private let checks: [any DiagnosticCheck]
     @ObservationIgnored private let minimumStepDuration: Duration
@@ -167,6 +170,8 @@ final class NetworkDiagnosticsViewModel {
         guard activeTask == nil else { return false }
 
         results = [:]
+        logStore.reset()
+        logStore.append("Checking…")
         conclusion = nil
         automaticRestartCount = 0
         phase = .running
@@ -187,9 +192,14 @@ final class NetworkDiagnosticsViewModel {
         activeTask?.cancel()
     }
 
+    func clearLogs() {
+        logStore.reset()
+    }
+
     private func accept(_ result: NetworkDiagnosticResult) {
         results[result.id] = result
         executionPhases[result.id] = .completed
+        logStore.append("\(result.id.logTitle): \(result.status.logTitle)")
 
         guard let index = checkIDs.firstIndex(of: result.id) else { return }
         let nextIndex = checkIDs.index(after: index)

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -36,6 +36,19 @@ struct NetworkDiagnosticsWorkbenchRow: Equatable, Identifiable, Sendable {
     let id: NetworkDiagnosticCheckID
     let executionPhase: NetworkDiagnosticExecutionPhase
     let result: NetworkDiagnosticResult?
+    let pendingReason: DiagnosticRunEndReason?
+
+    init(
+        id: NetworkDiagnosticCheckID,
+        executionPhase: NetworkDiagnosticExecutionPhase,
+        result: NetworkDiagnosticResult?,
+        pendingReason: DiagnosticRunEndReason? = nil
+    ) {
+        self.id = id
+        self.executionPhase = executionPhase
+        self.result = result
+        self.pendingReason = pendingReason
+    }
 }
 
 enum NetworkDiagnosticsWorkbenchItem: Equatable, Identifiable {
@@ -57,7 +70,8 @@ enum NetworkDiagnosticsPresentation {
         pagePhase: NetworkDiagnosticsPagePhase,
         executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase],
         results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult],
-        checkIDs: [NetworkDiagnosticCheckID] = NetworkDiagnosticCheckID.allCases
+        checkIDs: [NetworkDiagnosticCheckID] = NetworkDiagnosticCheckID.allCases,
+        endReason: DiagnosticRunEndReason? = nil
     ) -> [NetworkDiagnosticsWorkbenchRow] {
         guard pagePhase != .idle else { return [] }
 
@@ -66,13 +80,11 @@ enum NetworkDiagnosticsPresentation {
             if pagePhase == .running, executionPhase == .waiting {
                 return nil
             }
-            guard pagePhase != .completed || results[id] != nil else {
-                return nil
-            }
             return NetworkDiagnosticsWorkbenchRow(
                 id: id,
                 executionPhase: executionPhase,
-                result: results[id]
+                result: results[id],
+                pendingReason: pagePhase == .completed && results[id] == nil ? endReason : nil
             )
         }
     }
@@ -90,13 +102,15 @@ enum NetworkDiagnosticsPresentation {
         pagePhase: NetworkDiagnosticsPagePhase,
         executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase],
         results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult],
-        checkIDs: [NetworkDiagnosticCheckID] = NetworkDiagnosticCheckID.allCases
+        checkIDs: [NetworkDiagnosticCheckID] = NetworkDiagnosticCheckID.allCases,
+        endReason: DiagnosticRunEndReason? = nil
     ) -> [NetworkDiagnosticsWorkbenchItem] {
         let rows = workbenchRows(
             pagePhase: pagePhase,
             executionPhases: executionPhases,
             results: results,
-            checkIDs: checkIDs
+            checkIDs: checkIDs,
+            endReason: endReason
         )
         guard !rows.isEmpty else { return [] }
 
@@ -128,7 +142,12 @@ final class NetworkDiagnosticsViewModel {
     private(set) var results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [:]
     private(set) var logStore = NetworkDiagnosticsLogStore()
     private(set) var conclusion: NetworkDiagnosticConclusion?
+    private(set) var assessment: NetworkDiagnosticAssessment?
+    private(set) var endReason: DiagnosticRunEndReason?
+    private(set) var pendingCheckIDs: [NetworkDiagnosticCheckID] = []
     private(set) var automaticRestartCount = 0
+    private(set) var currentRunID: UUID?
+    private(set) var fingerprintMonitoringAvailable = true
     let checkIDs: [NetworkDiagnosticCheckID]
 
     var logText: String { logStore.text }
@@ -136,29 +155,52 @@ final class NetworkDiagnosticsViewModel {
     @ObservationIgnored private let checks: [any DiagnosticCheck]
     @ObservationIgnored private let minimumStepDuration: Duration
     @ObservationIgnored private let fingerprintMonitor: any NetworkFingerprintMonitoring
+    @ObservationIgnored private let contextSource: any DiagnosticNetworkContextSourcing
+    @ObservationIgnored private let diagnosticGatewayMeasuring: any DiagnosticGatewayMeasuring
+    @ObservationIgnored private let clock: any DiagnosticClock
+    @ObservationIgnored private let usesProductionChecks: Bool
     @ObservationIgnored private let guidance: GuidanceCoordinator
     @ObservationIgnored private var activeTask: Task<Void, Never>?
+    @ObservationIgnored private var runGeneration: UInt64 = 0
+    @ObservationIgnored private var logSessionID: UUID?
+    @ObservationIgnored private var logSessionStartedAt: ContinuousClock.Instant?
 
-    init(checks: [any DiagnosticCheck] = [
-        NetworkConnectivityCheck(),
-        GatewayReachabilityCheck(),
-        DNSResolutionCheck(),
-        HTTPSControlEndpointCheck(),
-        IPv6ControlEndpointCheck(),
-        SystemProxyCheck(),
-    ],
+    init(
+    checks: [any DiagnosticCheck]? = nil,
     minimumStepDuration: Duration = NetworkDiagnosticsViewModel.defaultMinimumStepDuration,
-    fingerprintMonitor: any NetworkFingerprintMonitoring = SystemNetworkFingerprintMonitor(),
+    fingerprintMonitor: any NetworkFingerprintMonitoring = SystemNetworkFingerprintMonitor(
+        routeStateSource: SystemNetworkFingerprintRouteStateSource()
+    ),
+    contextSource: any DiagnosticNetworkContextSourcing = SystemDiagnosticNetworkContextSource(),
+    diagnosticGatewayMeasuring: any DiagnosticGatewayMeasuring = GatewayLatencyProvider(),
+    clock: any DiagnosticClock = ContinuousDiagnosticClock(),
     guidance: GuidanceCoordinator = .shared
     ) {
-        self.checks = checks
+        let productionChecks = checks == nil
+        let configuredChecks = checks ?? Self.defaultChecks()
+        self.checks = configuredChecks
         self.minimumStepDuration = minimumStepDuration
         self.fingerprintMonitor = fingerprintMonitor
+        self.contextSource = contextSource
+        self.diagnosticGatewayMeasuring = diagnosticGatewayMeasuring
+        self.clock = clock
+        self.usesProductionChecks = productionChecks
         self.guidance = guidance
-        self.checkIDs = checks.map(\.id)
+        self.checkIDs = configuredChecks.map(\.id)
         self.executionPhases = Dictionary(
-            uniqueKeysWithValues: checks.map { ($0.id, .waiting) }
+            uniqueKeysWithValues: configuredChecks.map { ($0.id, .waiting) }
         )
+    }
+
+    private static func defaultChecks() -> [any DiagnosticCheck] {
+        [
+            NetworkConnectivityCheck(),
+            GatewayReachabilityCheck(),
+            DNSResolutionCheck(),
+            HTTPSControlEndpointCheck(),
+            SystemProxyCheck(),
+            IPv6ControlEndpointCheck(),
+        ]
     }
 
     deinit {
@@ -171,14 +213,23 @@ final class NetworkDiagnosticsViewModel {
 
         results = [:]
         logStore.reset()
-        logStore.append("Checking…")
+        logSessionID = UUID()
+        logSessionStartedAt = ContinuousClock().now
+        appendEvent(.sessionStarted)
         conclusion = nil
+        assessment = nil
+        endReason = nil
+        pendingCheckIDs = checkIDs
+        currentRunID = nil
+        fingerprintMonitoringAvailable = true
         automaticRestartCount = 0
         phase = .running
         prepareExecutionPhases(retaining: [])
+        runGeneration &+= 1
+        let generation = runGeneration
 
         activeTask = Task { [weak self] in
-            await self?.runSession()
+            await self?.runSession(generation: generation)
         }
         return true
     }
@@ -189,53 +240,110 @@ final class NetworkDiagnosticsViewModel {
     }
 
     func cancel() {
+        guard phase == .running else {
+            activeTask?.cancel()
+            activeTask = nil
+            return
+        }
+        runGeneration &+= 1
+        currentRunID = nil
         activeTask?.cancel()
+        activeTask = nil
+        endReason = .cancelled
+        pendingCheckIDs = checkIDs.filter { results[$0] == nil }
+        assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: results,
+            complete: false,
+            requiredIDs: Set(checkIDs)
+        )
+        conclusion = nil
+        phase = .completed
     }
 
     func clearLogs() {
         logStore.reset()
     }
 
-    private func accept(_ result: NetworkDiagnosticResult) {
+    private func accept(_ result: NetworkDiagnosticResult, runID: UUID) {
+        guard DiagnosticPublicationGate(activeRunID: currentRunID).accepts(runID) else { return }
         results[result.id] = result
         executionPhases[result.id] = .completed
-        logStore.append("\(result.id.logTitle): \(result.status.logTitle)")
-
-        guard let index = checkIDs.firstIndex(of: result.id) else { return }
-        let nextIndex = checkIDs.index(after: index)
-        if nextIndex < checkIDs.endIndex {
-            executionPhases[checkIDs[nextIndex]] = .checking
-        }
+        assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: results,
+            complete: false,
+            requiredIDs: Set(checkIDs)
+        )
+        appendEvent(.checkFinished, runID: runID, checkID: result.id)
     }
 
-    private func runSession() async {
+    private func runSession(generation: UInt64) async {
+        guard isCurrentGeneration(generation) else { return }
         let restartController = NetworkDiagnosticRestartController()
+        let sessionDeadline = (await clock.now()).advanced(by: Self.defaultSessionBudget)
 
         await withTaskCancellationHandler {
-            let fingerprintObservation = await fingerprintMonitor.observation()
+            let fingerprintObservation = await boundedFingerprintObservation(
+                until: min(
+                    sessionDeadline,
+                    (await clock.now()).advanced(by: .seconds(1))
+                )
+            )
+            if fingerprintObservation == nil {
+                fingerprintMonitoringAvailable = false
+            }
             guard !Task.isCancelled else {
-                phase = .idle
+                finish(
+                    DiagnosticRunOutcome(
+                        runID: UUID(),
+                        results: [],
+                        pendingIDs: checkIDs,
+                        endReason: .cancelled
+                    ),
+                    generation: generation
+                )
                 return
             }
             await executeSession(
                 fingerprintObservation: fingerprintObservation,
-                restartController: restartController
+                restartController: restartController,
+                sessionDeadline: sessionDeadline,
+                generation: generation
             )
         } onCancel: {
             Task { await restartController.cancelCurrentRun() }
         }
-        activeTask = nil
+        if generation == runGeneration {
+            activeTask = nil
+        }
     }
 
     private func executeSession(
         fingerprintObservation: NetworkFingerprintObservation?,
-        restartController: NetworkDiagnosticRestartController
+        restartController: NetworkDiagnosticRestartController,
+        sessionDeadline: ContinuousClock.Instant,
+        generation: UInt64
     ) async {
+        let fingerprintState: NetworkDiagnosticsFingerprintStreamState? = fingerprintObservation.map {
+            NetworkDiagnosticsFingerprintStreamState(baseline: $0.baseline)
+        }
         let monitorTask: Task<Void, Never>? = fingerprintObservation.map { observation in
             return Task {
                 for await fingerprint in observation.changes {
                     guard !Task.isCancelled else { break }
-                    await restartController.observe(fingerprint)
+                    guard let previous = await fingerprintState?.accept(fingerprint) else { continue }
+                    let runID = currentRunID ?? logSessionID
+                    currentRunID = nil
+                    if await restartController.observe(
+                        fingerprint,
+                        at: await clock.now()
+                    ) {
+                        invalidateNetworkResultsForChange()
+                        appendEvent(
+                            .restarted,
+                            runID: runID,
+                            reasonCode: fingerprint.restartReason(comparedWith: previous).rawValue
+                        )
+                    }
                 }
             }
         }
@@ -243,33 +351,160 @@ final class NetworkDiagnosticsViewModel {
 
         var retainedResults: [NetworkDiagnosticResult] = []
         while !Task.isCancelled {
+            guard isCurrentGeneration(generation), await clock.now() < sessionDeadline else {
+                finish(
+                    DiagnosticRunOutcome(
+                        runID: UUID(),
+                        results: retainedResults,
+                        pendingIDs: checkIDs.filter { id in
+                            !retainedResults.contains { $0.id == id }
+                        },
+                        endReason: .timedOut
+                    ),
+                    generation: generation
+                )
+                return
+            }
+            let runID = UUID()
+            currentRunID = runID
+            appendEvent(.runStarted, runID: runID)
+            let context: DiagnosticNetworkContext?
+            if usesProductionChecks {
+                let remaining = await clock.now().duration(to: sessionDeadline)
+                if remaining > .zero {
+                    context = await contextSource.capture(
+                        runID: runID,
+                        timeout: min(remaining, .seconds(1))
+                    )
+                } else {
+                    context = nil
+                }
+            } else {
+                context = nil
+            }
+            guard isCurrentGeneration(generation) else {
+                finish(
+                    DiagnosticRunOutcome(
+                        runID: runID,
+                        results: retainedResults,
+                        pendingIDs: checkIDs.filter { id in
+                            !retainedResults.contains { $0.id == id }
+                        },
+                        endReason: .cancelled
+                    ),
+                    generation: generation
+                )
+                return
+            }
+            let checks = checksForRun(context: context)
             let runner = DiagnosticRunner(
                 checks: checks,
                 minimumStepDuration: minimumStepDuration,
-                sessionBudget: Self.defaultSessionBudget
+                sessionBudget: Self.defaultSessionBudget,
+                clock: clock
             )
             let retainedSnapshot = retainedResults
             let runTask = Task { [weak self] in
-                await runner.run(retaining: retainedSnapshot) { [weak self] result in
-                    await self?.accept(result)
-                }
+                await runner.run(
+                    runID: runID,
+                    retaining: retainedSnapshot,
+                    deadline: sessionDeadline,
+                    onCheckStarted: { [weak self] id in
+                        await self?.beginCheck(id, runID: runID)
+                    },
+                    onResult: { [weak self] result in
+                        await self?.accept(result, runID: runID)
+                    }
+                )
             }
             await restartController.install(runTask)
-            let orderedResults = await runTask.value
+            let outcome = await runTask.value
 
             if await restartController.completeRun() {
+                guard await restartController.waitForStability(
+                    using: clock,
+                    until: sessionDeadline
+                ) else {
+                    finish(
+                        DiagnosticRunOutcome(
+                            runID: outcome.runID,
+                            results: outcome.results,
+                            pendingIDs: outcome.pendingIDs,
+                            endReason: .superseded
+                        ),
+                        generation: generation
+                    )
+                    return
+                }
                 automaticRestartCount += 1
-                retainedResults = configurationOnlyResults(from: orderedResults)
+                retainedResults = configurationOnlyResults(from: outcome.results)
+                currentRunID = nil
                 results = Dictionary(uniqueKeysWithValues: retainedResults.map { ($0.id, $0) })
                 conclusion = nil
+                assessment = NetworkDiagnosticAssessmentResolver().resolve(
+                    results: results,
+                    complete: false,
+                    requiredIDs: Set(checkIDs)
+                )
                 prepareExecutionPhases(retaining: retainedResults)
                 continue
             }
 
-            finish(orderedResults)
+            finish(outcome, generation: generation)
             return
         }
-        phase = .idle
+        guard generation == runGeneration else { return }
+        finish(
+            DiagnosticRunOutcome(
+                runID: UUID(),
+                results: retainedResults,
+                pendingIDs: checkIDs.filter { id in
+                    !retainedResults.contains { $0.id == id }
+                },
+                endReason: .cancelled
+            ),
+            generation: generation
+        )
+    }
+
+    private func boundedFingerprintObservation(
+        until deadline: ContinuousClock.Instant
+    ) async -> NetworkFingerprintObservation? {
+        let observationTask = Task {
+            await fingerprintMonitor.observation()
+        }
+        return await withTaskGroup(of: NetworkFingerprintObservation?.self) { group in
+            group.addTask { await observationTask.value }
+            group.addTask {
+                try? await self.clock.sleep(until: deadline)
+                observationTask.cancel()
+                return nil
+            }
+            let observation = await group.next() ?? nil
+            group.cancelAll()
+            return observation
+        }
+    }
+
+    private func beginCheck(_ id: NetworkDiagnosticCheckID, runID: UUID) {
+        guard DiagnosticPublicationGate(activeRunID: currentRunID).accepts(runID) else { return }
+        executionPhases[id] = .checking
+        appendEvent(.checkStarted, runID: runID, checkID: id)
+    }
+
+    private func checksForRun(context: DiagnosticNetworkContext?) -> [any DiagnosticCheck] {
+        guard usesProductionChecks, let context else { return checks }
+        return [
+            NetworkConnectivityCheck(context: context),
+            GatewayReachabilityCheck(
+                context: context,
+                gatewayMeasuring: diagnosticGatewayMeasuring
+            ),
+            DNSResolutionCheck(),
+            HTTPSControlEndpointCheck(),
+            SystemProxyCheck(),
+            IPv6ControlEndpointCheck(),
+        ]
     }
 
     private func configurationOnlyResults(
@@ -286,34 +521,106 @@ final class NetworkDiagnosticsViewModel {
         executionPhases = Dictionary(uniqueKeysWithValues: checkIDs.map { id in
             (id, retainedIDs.contains(id) ? .completed : .waiting)
         })
-        if let firstPendingID = checkIDs.first(where: { !retainedIDs.contains($0) }) {
-            executionPhases[firstPendingID] = .checking
-        }
     }
 
-    private func finish(_ orderedResults: [NetworkDiagnosticResult]) {
-        guard !Task.isCancelled, let conclusion = NetworkDiagnosticConclusion.evaluate(
-            orderedResults,
+    private func invalidateNetworkResultsForChange() {
+        let retainedResults = configurationOnlyResults(from: Array(results.values))
+        results = Dictionary(uniqueKeysWithValues: retainedResults.map { ($0.id, $0) })
+        conclusion = nil
+        assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: results,
+            complete: false,
             requiredIDs: Set(checkIDs)
-        ) else {
-            phase = .idle
-            return
+        )
+        pendingCheckIDs = checkIDs.filter { results[$0] == nil }
+        prepareExecutionPhases(retaining: retainedResults)
+    }
+
+    private func isCurrentGeneration(_ generation: UInt64) -> Bool {
+        generation == runGeneration && !Task.isCancelled
+    }
+
+    private func appendEvent(
+        _ kind: DiagnosticEventKind,
+        runID: UUID? = nil,
+        checkID: NetworkDiagnosticCheckID? = nil,
+        reasonCode: String? = nil
+    ) {
+        let eventRunID = runID ?? currentRunID ?? logSessionID ?? UUID()
+        let elapsedMilliseconds: Int64
+        if let startedAt = logSessionStartedAt {
+            let duration = startedAt.duration(to: ContinuousClock().now)
+            let components = duration.components
+            let milliseconds = Double(components.seconds) * 1_000
+                + Double(components.attoseconds) / 1_000_000_000_000_000
+            elapsedMilliseconds = Int64(max(0, milliseconds.rounded()))
+        } else {
+            elapsedMilliseconds = 0
         }
-        self.conclusion = conclusion
+        logStore.append(NetworkDiagnosticEvent(
+            runID: eventRunID,
+            elapsedMilliseconds: elapsedMilliseconds,
+            kind: kind,
+            checkID: checkID,
+            reasonCode: reasonCode
+        ))
+    }
+
+    private func finish(_ outcome: DiagnosticRunOutcome, generation: UInt64) {
+        guard generation == runGeneration else { return }
+        currentRunID = nil
+        endReason = outcome.endReason
+        pendingCheckIDs = outcome.pendingIDs
+        results = Dictionary(uniqueKeysWithValues: outcome.results.map { ($0.id, $0) })
+        assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: results,
+            complete: outcome.endReason == .completed,
+            requiredIDs: Set(checkIDs)
+        )
+        conclusion = assessment?.conclusion
         phase = .completed
-        guidance.record(.diagnosticsCompleted)
+        let endEvent: DiagnosticEventKind = switch outcome.endReason {
+        case .completed: .completed
+        case .timedOut, .superseded: .timedOut
+        case .cancelled: .cancelled
+        }
+        appendEvent(
+            endEvent,
+            runID: outcome.runID,
+            reasonCode: outcome.endReason == .superseded ? "network-change" : nil
+        )
+        if outcome.endReason == .completed, conclusion != nil {
+            guidance.record(.diagnosticsCompleted)
+        }
+    }
+}
+
+private actor NetworkDiagnosticsFingerprintStreamState {
+    private var latest: NetworkFingerprint
+
+    init(baseline: NetworkFingerprint) {
+        latest = baseline
+    }
+
+    func accept(_ fingerprint: NetworkFingerprint) -> NetworkFingerprint? {
+        guard fingerprint != latest else { return nil }
+        let previous = latest
+        latest = fingerprint
+        return previous
     }
 }
 
 actor NetworkDiagnosticRestartController {
-    private var currentRun: Task<[NetworkDiagnosticResult], Never>?
+    private var currentRunCancellation: (@Sendable () -> Void)?
     private var restartRequested = false
     private var restartInstallPending = false
     private var cancellationRequested = false
     private var finalized = false
+    private var lastFingerprint: NetworkFingerprint?
+    private var lastChangeAt: ContinuousClock.Instant?
 
-    func install(_ task: Task<[NetworkDiagnosticResult], Never>) {
-        currentRun = task
+    func install<Success: Sendable>(_ task: Task<Success, Never>) {
+        currentRunCancellation = { task.cancel() }
         restartInstallPending = false
         if restartRequested || cancellationRequested {
             task.cancel()
@@ -321,16 +628,42 @@ actor NetworkDiagnosticRestartController {
     }
 
     @discardableResult
-    func observe(_: NetworkFingerprint) -> Bool {
+    func observe(
+        _ fingerprint: NetworkFingerprint,
+        at now: ContinuousClock.Instant = ContinuousClock().now
+    ) -> Bool {
         guard !finalized, !cancellationRequested else { return false }
-        guard !restartInstallPending else { return true }
+        guard fingerprint != lastFingerprint else { return true }
+        lastFingerprint = fingerprint
+        lastChangeAt = now
+        if restartInstallPending { return true }
         restartRequested = true
-        currentRun?.cancel()
+        currentRunCancellation?()
         return true
     }
 
+    func waitForStability(
+        using clock: any DiagnosticClock,
+        until deadline: ContinuousClock.Instant
+    ) async -> Bool {
+        while !cancellationRequested, !finalized {
+            guard let lastChangeAt else { return false }
+            let stableAt = lastChangeAt.advanced(by: .milliseconds(500))
+            let waitUntil = min(stableAt, deadline)
+            try? await clock.sleep(until: waitUntil)
+            if cancellationRequested || finalized { return false }
+            let now = await clock.now()
+            if now >= stableAt {
+                restartInstallPending = false
+                return true
+            }
+            if now >= deadline { return false }
+        }
+        return false
+    }
+
     func completeRun() -> Bool {
-        currentRun = nil
+        currentRunCancellation = nil
         if cancellationRequested {
             finalized = true
             return false
@@ -348,8 +681,8 @@ actor NetworkDiagnosticRestartController {
         cancellationRequested = true
         restartRequested = false
         restartInstallPending = false
-        currentRun?.cancel()
-        currentRun = nil
+        currentRunCancellation?()
+        currentRunCancellation = nil
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -288,6 +288,7 @@ final class NetworkDiagnosticsViewModel {
                     (await clock.now()).advanced(by: .seconds(1))
                 )
             )
+            guard isCurrentGeneration(generation) else { return }
             if fingerprintObservation == nil {
                 fingerprintMonitoringAvailable = false
             }
@@ -329,14 +330,20 @@ final class NetworkDiagnosticsViewModel {
         let monitorTask: Task<Void, Never>? = fingerprintObservation.map { observation in
             return Task {
                 for await fingerprint in observation.changes {
-                    guard !Task.isCancelled else { break }
+                    guard isCurrentGeneration(generation) else { break }
                     guard let previous = await fingerprintState?.accept(fingerprint) else { continue }
+                    guard isCurrentGeneration(generation) else { break }
+                    let now = await clock.now()
+                    guard isCurrentGeneration(generation) else { break }
+                    let shouldRestart = await restartController.observe(
+                        fingerprint,
+                        at: now
+                    )
+                    guard isCurrentGeneration(generation) else { break }
                     let runID = currentRunID ?? logSessionID
                     currentRunID = nil
-                    if await restartController.observe(
-                        fingerprint,
-                        at: await clock.now()
-                    ) {
+                    if shouldRestart {
+                        guard isCurrentGeneration(generation) else { break }
                         invalidateNetworkResultsForChange()
                         appendEvent(
                             .restarted,
@@ -419,23 +426,31 @@ final class NetworkDiagnosticsViewModel {
             }
             await restartController.install(runTask)
             let outcome = await runTask.value
+            guard isCurrentGeneration(generation) else { return }
 
-            if await restartController.completeRun() {
+            let shouldRestart = await restartController.completeRun()
+            guard isCurrentGeneration(generation) else { return }
+            if shouldRestart {
                 guard await restartController.waitForStability(
                     using: clock,
                     until: sessionDeadline
                 ) else {
+                    guard isCurrentGeneration(generation) else { return }
+                    let retainedResults = configurationOnlyResults(from: outcome.results)
                     finish(
                         DiagnosticRunOutcome(
                             runID: outcome.runID,
-                            results: outcome.results,
-                            pendingIDs: outcome.pendingIDs,
+                            results: retainedResults,
+                            pendingIDs: checkIDs.filter { id in
+                                !retainedResults.contains { $0.id == id }
+                            },
                             endReason: .superseded
                         ),
                         generation: generation
                     )
                     return
                 }
+                guard isCurrentGeneration(generation) else { return }
                 automaticRestartCount += 1
                 retainedResults = configurationOnlyResults(from: outcome.results)
                 currentRunID = nil
@@ -647,13 +662,15 @@ actor NetworkDiagnosticRestartController {
         until deadline: ContinuousClock.Instant
     ) async -> Bool {
         while !cancellationRequested, !finalized {
-            guard let lastChangeAt else { return false }
-            let stableAt = lastChangeAt.advanced(by: .milliseconds(500))
+            guard let latestChangeAt = lastChangeAt else { return false }
+            let stableAt = latestChangeAt.advanced(by: .milliseconds(500))
             let waitUntil = min(stableAt, deadline)
             try? await clock.sleep(until: waitUntil)
             if cancellationRequested || finalized { return false }
             let now = await clock.now()
-            if now >= stableAt {
+            guard let latestChangeAt = lastChangeAt else { return false }
+            let latestStableAt = latestChangeAt.advanced(by: .milliseconds(500))
+            if now >= latestStableAt {
                 restartInstallPending = false
                 return true
             }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkDiagnosticsViewModel.swift
@@ -134,7 +134,6 @@ enum NetworkDiagnosticsPresentation {
 @MainActor
 @Observable
 final class NetworkDiagnosticsViewModel {
-    static let defaultMinimumStepDuration = Duration.milliseconds(800)
     static let defaultSessionBudget = Duration.seconds(30)
 
     private(set) var phase = NetworkDiagnosticsPagePhase.idle
@@ -153,7 +152,6 @@ final class NetworkDiagnosticsViewModel {
     var logText: String { logStore.text }
 
     @ObservationIgnored private let checks: [any DiagnosticCheck]
-    @ObservationIgnored private let minimumStepDuration: Duration
     @ObservationIgnored private let fingerprintMonitor: any NetworkFingerprintMonitoring
     @ObservationIgnored private let contextSource: any DiagnosticNetworkContextSourcing
     @ObservationIgnored private let diagnosticGatewayMeasuring: any DiagnosticGatewayMeasuring
@@ -167,7 +165,6 @@ final class NetworkDiagnosticsViewModel {
 
     init(
     checks: [any DiagnosticCheck]? = nil,
-    minimumStepDuration: Duration = NetworkDiagnosticsViewModel.defaultMinimumStepDuration,
     fingerprintMonitor: any NetworkFingerprintMonitoring = SystemNetworkFingerprintMonitor(
         routeStateSource: SystemNetworkFingerprintRouteStateSource()
     ),
@@ -179,7 +176,6 @@ final class NetworkDiagnosticsViewModel {
         let productionChecks = checks == nil
         let configuredChecks = checks ?? Self.defaultChecks()
         self.checks = configuredChecks
-        self.minimumStepDuration = minimumStepDuration
         self.fingerprintMonitor = fingerprintMonitor
         self.contextSource = contextSource
         self.diagnosticGatewayMeasuring = diagnosticGatewayMeasuring
@@ -406,7 +402,6 @@ final class NetworkDiagnosticsViewModel {
             let checks = checksForRun(context: context)
             let runner = DiagnosticRunner(
                 checks: checks,
-                minimumStepDuration: minimumStepDuration,
                 sessionBudget: Self.defaultSessionBudget,
                 clock: clock
             )
@@ -485,19 +480,30 @@ final class NetworkDiagnosticsViewModel {
     private func boundedFingerprintObservation(
         until deadline: ContinuousClock.Instant
     ) async -> NetworkFingerprintObservation? {
-        let observationTask = Task {
-            await fingerprintMonitor.observation()
-        }
-        return await withTaskGroup(of: NetworkFingerprintObservation?.self) { group in
-            group.addTask { await observationTask.value }
-            group.addTask {
-                try? await self.clock.sleep(until: deadline)
-                observationTask.cancel()
-                return nil
+        let gate = NetworkFingerprintObservationCompletionGate()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard gate.install(continuation: continuation) else { return }
+
+                let observationTask = Task { [fingerprintMonitor, gate] in
+                    gate.finish(await fingerprintMonitor.observation())
+                }
+                let timeoutTask = Task { [clock, gate] in
+                    do {
+                        try await clock.sleep(until: deadline)
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
+                    gate.finish(nil)
+                }
+                gate.install(
+                    observationTask: observationTask,
+                    timeoutTask: timeoutTask
+                )
             }
-            let observation = await group.next() ?? nil
-            group.cancelAll()
-            return observation
+        } onCancel: {
+            gate.cancel()
         }
     }
 
@@ -607,6 +613,71 @@ final class NetworkDiagnosticsViewModel {
         if outcome.endReason == .completed, conclusion != nil {
             guidance.record(.diagnosticsCompleted)
         }
+    }
+}
+
+private final class NetworkFingerprintObservationCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<NetworkFingerprintObservation?, Never>?
+    private var observationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var storedResult: NetworkFingerprintObservation?
+    private var didFinish = false
+
+    func install(
+        continuation: CheckedContinuation<NetworkFingerprintObservation?, Never>
+    ) -> Bool {
+        lock.lock()
+        guard !didFinish else {
+            let result = storedResult
+            lock.unlock()
+            continuation.resume(returning: result)
+            return false
+        }
+        self.continuation = continuation
+        lock.unlock()
+        return true
+    }
+
+    func install(
+        observationTask: Task<Void, Never>,
+        timeoutTask: Task<Void, Never>
+    ) {
+        lock.lock()
+        self.observationTask = observationTask
+        self.timeoutTask = timeoutTask
+        let shouldCancel = didFinish
+        lock.unlock()
+
+        if shouldCancel {
+            observationTask.cancel()
+            timeoutTask.cancel()
+        }
+    }
+
+    func finish(_ result: NetworkFingerprintObservation?) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        didFinish = true
+        storedResult = result
+        let continuation = self.continuation
+        self.continuation = nil
+        let observationTask = self.observationTask
+        let timeoutTask = self.timeoutTask
+        self.observationTask = nil
+        self.timeoutTask = nil
+        lock.unlock()
+
+        observationTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(returning: result)
+    }
+
+    func cancel() {
+        finish(nil)
     }
 }
 

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
@@ -481,12 +481,6 @@ private actor NetworkFingerprintEmissionState {
         staticProxySettingsHash: UInt64,
         routeState: NetworkFingerprintRouteState? = nil
     ) -> NetworkFingerprint? {
-        guard
-            dnsSettingsHash != latest.dnsSettingsHash
-                || staticProxySettingsHash != latest.staticProxySettingsHash
-        else {
-            return nil
-        }
         let fingerprint = NetworkFingerprint(
             interfaceType: latest.interfaceType,
             interfaceName: latest.interfaceName,
@@ -495,13 +489,24 @@ private actor NetworkFingerprintEmissionState {
             staticProxySettingsHash: staticProxySettingsHash,
             tunnelInterfaces: latest.tunnelInterfaces,
             routedTunnelInterface: latest.routedTunnelInterface,
-            selectedInterfaceIndex: routeState?.interfaceIndex ?? latest.selectedInterfaceIndex,
-            selectedInterfaceAddresses: routeState?.addresses ?? latest.selectedInterfaceAddresses,
-            selectedInterfaceSubnets: routeState?.subnets ?? latest.selectedInterfaceSubnets,
-            selectedGateway: routeState?.gateway ?? latest.selectedGateway,
-            ipv4PrimaryServiceIdentity: routeState?.ipv4PrimaryServiceIdentity ?? latest.ipv4PrimaryServiceIdentity,
-            ipv6PrimaryServiceIdentity: routeState?.ipv6PrimaryServiceIdentity ?? latest.ipv6PrimaryServiceIdentity
+            selectedInterfaceIndex: routeState == nil
+                ? latest.selectedInterfaceIndex
+                : routeState?.interfaceIndex,
+            selectedInterfaceAddresses: routeState == nil
+                ? latest.selectedInterfaceAddresses
+                : routeState?.addresses ?? [],
+            selectedInterfaceSubnets: routeState == nil
+                ? latest.selectedInterfaceSubnets
+                : routeState?.subnets ?? [],
+            selectedGateway: routeState == nil ? latest.selectedGateway : routeState?.gateway,
+            ipv4PrimaryServiceIdentity: routeState == nil
+                ? latest.ipv4PrimaryServiceIdentity
+                : routeState?.ipv4PrimaryServiceIdentity,
+            ipv6PrimaryServiceIdentity: routeState == nil
+                ? latest.ipv6PrimaryServiceIdentity
+                : routeState?.ipv6PrimaryServiceIdentity
         )
+        guard fingerprint != latest else { return nil }
         latest = fingerprint
         return fingerprint
     }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
@@ -3,6 +3,90 @@ import Foundation
 import Network
 import SystemConfiguration
 
+struct NetworkFingerprintRouteState: Equatable, Sendable {
+    let interfaceName: String?
+    let interfaceIndex: UInt32?
+    let gateway: String?
+    let addresses: [String]
+    let subnets: [String]
+    let ipv4PrimaryServiceIdentity: String?
+    let ipv6PrimaryServiceIdentity: String?
+
+    init(
+        interfaceName: String?,
+        interfaceIndex: UInt32?,
+        gateway: String?,
+        addresses: [String] = [],
+        subnets: [String] = [],
+        ipv4PrimaryServiceIdentity: String? = nil,
+        ipv6PrimaryServiceIdentity: String? = nil
+    ) {
+        self.interfaceName = interfaceName
+        self.interfaceIndex = interfaceIndex
+        self.gateway = gateway
+        self.addresses = Array(Set(addresses)).sorted()
+        self.subnets = Array(Set(subnets)).sorted()
+        self.ipv4PrimaryServiceIdentity = ipv4PrimaryServiceIdentity
+        self.ipv6PrimaryServiceIdentity = ipv6PrimaryServiceIdentity
+    }
+}
+
+protocol NetworkFingerprintRouteStateSourcing: Sendable {
+    func currentState() async -> NetworkFingerprintRouteState?
+}
+
+struct SystemNetworkFingerprintRouteStateSource: NetworkFingerprintRouteStateSourcing {
+    private let routeSource: any DiagnosticRouteSourcing
+    private let interfaceSource: any NetworkInterfaceSnapshotSourcing
+
+    init(
+        routeSource: any DiagnosticRouteSourcing = SystemDiagnosticRouteSource(),
+        interfaceSource: any NetworkInterfaceSnapshotSourcing = SystemNetworkInterfaceSnapshotSource()
+    ) {
+        self.routeSource = routeSource
+        self.interfaceSource = interfaceSource
+    }
+
+    func currentState() async -> NetworkFingerprintRouteState? {
+        let route = await routeSource.currentRoute(timeout: .milliseconds(250))
+        let snapshot = await interfaceSource.capture(cycleID: UUID())
+        let primaryServices = Self.primaryServiceIdentities()
+        guard case .selected(let target) = route else {
+            return NetworkFingerprintRouteState(
+                interfaceName: nil,
+                interfaceIndex: nil,
+                gateway: nil,
+                ipv4PrimaryServiceIdentity: primaryServices.ipv4,
+                ipv6PrimaryServiceIdentity: primaryServices.ipv6
+            )
+        }
+        let selectedInterface = snapshot.interfaces.first { $0.interfaceName == target.interfaceName }
+        return NetworkFingerprintRouteState(
+            interfaceName: target.interfaceName,
+            interfaceIndex: target.interfaceIndex,
+            gateway: target.address,
+            addresses: selectedInterface?.ipv4Addresses ?? [],
+            subnets: selectedInterface?.subnetMasks ?? [],
+            ipv4PrimaryServiceIdentity: primaryServices.ipv4,
+            ipv6PrimaryServiceIdentity: primaryServices.ipv6
+        )
+    }
+
+    private static func primaryServiceIdentities() -> (
+        ipv4: String?,
+        ipv6: String?
+    ) {
+        let store = SCDynamicStoreCreate(nil, "WiFiLens" as CFString, nil, nil)
+        func value(for key: String) -> String? {
+            (SCDynamicStoreCopyValue(store, key as CFString) as? [String: Any])?["PrimaryService"] as? String
+        }
+        return (
+            value(for: "State:/Network/Global/IPv4"),
+            value(for: "State:/Network/Global/IPv6")
+        )
+    }
+}
+
 struct NetworkFingerprint: Equatable, Sendable {
     let interfaceType: String?
     let interfaceName: String?
@@ -11,6 +95,12 @@ struct NetworkFingerprint: Equatable, Sendable {
     let staticProxySettingsHash: UInt64
     let tunnelInterfaces: [String]
     let routedTunnelInterface: String?
+    let selectedInterfaceIndex: UInt32?
+    let selectedInterfaceAddresses: [String]
+    let selectedInterfaceSubnets: [String]
+    let selectedGateway: String?
+    let ipv4PrimaryServiceIdentity: String?
+    let ipv6PrimaryServiceIdentity: String?
 
     init(
         interfaceType: String?,
@@ -19,15 +109,52 @@ struct NetworkFingerprint: Equatable, Sendable {
         dnsSettingsHash: UInt64,
         staticProxySettingsHash: UInt64,
         tunnelInterfaces: [String] = [],
-        routedTunnelInterface: String? = nil
+        routedTunnelInterface: String? = nil,
+        selectedInterfaceIndex: UInt32? = nil,
+        selectedInterfaceAddresses: [String] = [],
+        selectedInterfaceSubnets: [String] = [],
+        selectedGateway: String? = nil,
+        ipv4PrimaryServiceIdentity: String? = nil,
+        ipv6PrimaryServiceIdentity: String? = nil
     ) {
         self.interfaceType = interfaceType
         self.interfaceName = interfaceName
         self.pathStatus = pathStatus
         self.dnsSettingsHash = dnsSettingsHash
         self.staticProxySettingsHash = staticProxySettingsHash
-        self.tunnelInterfaces = tunnelInterfaces
+        self.tunnelInterfaces = Self.normalized(tunnelInterfaces)
         self.routedTunnelInterface = routedTunnelInterface
+        self.selectedInterfaceIndex = selectedInterfaceIndex
+        self.selectedInterfaceAddresses = Self.normalized(selectedInterfaceAddresses)
+        self.selectedInterfaceSubnets = Self.normalized(selectedInterfaceSubnets)
+        self.selectedGateway = selectedGateway
+        self.ipv4PrimaryServiceIdentity = ipv4PrimaryServiceIdentity
+        self.ipv6PrimaryServiceIdentity = ipv6PrimaryServiceIdentity
+    }
+
+    private static func normalized(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    func restartReason(comparedWith previous: Self) -> DiagnosticRestartReason {
+        if interfaceName != previous.interfaceName
+            || selectedInterfaceIndex != previous.selectedInterfaceIndex
+            || selectedGateway != previous.selectedGateway
+            || ipv4PrimaryServiceIdentity != previous.ipv4PrimaryServiceIdentity
+            || ipv6PrimaryServiceIdentity != previous.ipv6PrimaryServiceIdentity {
+            return .route
+        }
+        if selectedInterfaceAddresses != previous.selectedInterfaceAddresses
+            || selectedInterfaceSubnets != previous.selectedInterfaceSubnets {
+            return .address
+        }
+        if dnsSettingsHash != previous.dnsSettingsHash {
+            return .dns
+        }
+        if staticProxySettingsHash != previous.staticProxySettingsHash {
+            return .proxy
+        }
+        return .path
     }
 }
 
@@ -57,19 +184,37 @@ struct NetworkPathFingerprint: Equatable, Sendable {
     let pathStatus: NetworkPathState
     let tunnelInterfaces: [String]
     let routedTunnelInterface: String?
+    let selectedInterfaceIndex: UInt32?
+    let selectedInterfaceAddresses: [String]
+    let selectedInterfaceSubnets: [String]
+    let selectedGateway: String?
+    let ipv4PrimaryServiceIdentity: String?
+    let ipv6PrimaryServiceIdentity: String?
 
     init(
         interfaceType: String?,
         interfaceName: String?,
         pathStatus: NetworkPathState,
         tunnelInterfaces: [String] = [],
-        routedTunnelInterface: String? = nil
+        routedTunnelInterface: String? = nil,
+        selectedInterfaceIndex: UInt32? = nil,
+        selectedInterfaceAddresses: [String] = [],
+        selectedInterfaceSubnets: [String] = [],
+        selectedGateway: String? = nil,
+        ipv4PrimaryServiceIdentity: String? = nil,
+        ipv6PrimaryServiceIdentity: String? = nil
     ) {
         self.interfaceType = interfaceType
         self.interfaceName = interfaceName
         self.pathStatus = pathStatus
-        self.tunnelInterfaces = tunnelInterfaces
+        self.tunnelInterfaces = Array(Set(tunnelInterfaces)).sorted()
         self.routedTunnelInterface = routedTunnelInterface
+        self.selectedInterfaceIndex = selectedInterfaceIndex
+        self.selectedInterfaceAddresses = Array(Set(selectedInterfaceAddresses)).sorted()
+        self.selectedInterfaceSubnets = Array(Set(selectedInterfaceSubnets)).sorted()
+        self.selectedGateway = selectedGateway
+        self.ipv4PrimaryServiceIdentity = ipv4PrimaryServiceIdentity
+        self.ipv6PrimaryServiceIdentity = ipv6PrimaryServiceIdentity
     }
 }
 
@@ -227,17 +372,20 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
     private let pathSource: any NetworkPathFingerprintSourcing
     private let settingsPoller: any NetworkFingerprintSettingsPolling
     private let settingsPollInterval: Duration
+    private let routeStateSource: (any NetworkFingerprintRouteStateSourcing)?
 
     init(
         settingsReader: any NetworkFingerprintSettingsReading = SystemNetworkFingerprintSettingsReader(),
         pathSource: any NetworkPathFingerprintSourcing = SystemNetworkPathFingerprintSource(),
         settingsPoller: any NetworkFingerprintSettingsPolling = SystemNetworkFingerprintSettingsPoller(),
-        settingsPollInterval: Duration = .milliseconds(250)
+        settingsPollInterval: Duration = .milliseconds(250),
+        routeStateSource: (any NetworkFingerprintRouteStateSourcing)? = nil
     ) {
         self.settingsReader = settingsReader
         self.pathSource = pathSource
         self.settingsPoller = settingsPoller
         self.settingsPollInterval = settingsPollInterval
+        self.routeStateSource = routeStateSource
     }
 
     func observation() async -> NetworkFingerprintObservation? {
@@ -245,7 +393,7 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
         var pathIterator = pathStream.makeAsyncIterator()
         guard let baselinePath = await pathIterator.next() else { return nil }
 
-        let baseline = fingerprint(path: baselinePath)
+        let baseline = await fingerprint(path: baselinePath)
         let remainingPathIterator = NetworkPathFingerprintIterator(pathIterator)
         let emissionState = NetworkFingerprintEmissionState(baseline: baseline)
         let streamPair = AsyncStream<NetworkFingerprint>.makeStream()
@@ -254,7 +402,7 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
                 group.addTask {
                     while let path = await remainingPathIterator.next() {
                         guard !Task.isCancelled else { return }
-                        let fingerprint = fingerprint(path: path)
+                        let fingerprint = await fingerprint(path: path)
                         if let emitted = await emissionState.receivePath(fingerprint) {
                             streamPair.continuation.yield(emitted)
                         }
@@ -265,7 +413,8 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
                         guard !Task.isCancelled else { return }
                         if let fingerprint = await emissionState.receiveSettings(
                             dnsSettingsHash: settingsReader.dnsSettingsHash(),
-                            staticProxySettingsHash: settingsReader.staticProxySettingsHash()
+                            staticProxySettingsHash: settingsReader.staticProxySettingsHash(),
+                            routeState: await routeStateSource?.currentState()
                         ) {
                             streamPair.continuation.yield(fingerprint)
                         }
@@ -282,15 +431,22 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
         )
     }
 
-    private func fingerprint(path: NetworkPathFingerprint) -> NetworkFingerprint {
-        NetworkFingerprint(
+    private func fingerprint(path: NetworkPathFingerprint) async -> NetworkFingerprint {
+        let routeState = await routeStateSource?.currentState()
+        return NetworkFingerprint(
             interfaceType: path.interfaceType,
             interfaceName: path.interfaceName,
             pathStatus: path.pathStatus,
             dnsSettingsHash: settingsReader.dnsSettingsHash(),
             staticProxySettingsHash: settingsReader.staticProxySettingsHash(),
             tunnelInterfaces: path.tunnelInterfaces,
-            routedTunnelInterface: path.routedTunnelInterface
+            routedTunnelInterface: path.routedTunnelInterface,
+            selectedInterfaceIndex: routeState?.interfaceIndex ?? path.selectedInterfaceIndex,
+            selectedInterfaceAddresses: routeState?.addresses ?? path.selectedInterfaceAddresses,
+            selectedInterfaceSubnets: routeState?.subnets ?? path.selectedInterfaceSubnets,
+            selectedGateway: routeState?.gateway ?? path.selectedGateway,
+            ipv4PrimaryServiceIdentity: routeState?.ipv4PrimaryServiceIdentity ?? path.ipv4PrimaryServiceIdentity,
+            ipv6PrimaryServiceIdentity: routeState?.ipv6PrimaryServiceIdentity ?? path.ipv6PrimaryServiceIdentity
         )
     }
 }
@@ -322,7 +478,8 @@ private actor NetworkFingerprintEmissionState {
 
     func receiveSettings(
         dnsSettingsHash: UInt64,
-        staticProxySettingsHash: UInt64
+        staticProxySettingsHash: UInt64,
+        routeState: NetworkFingerprintRouteState? = nil
     ) -> NetworkFingerprint? {
         guard
             dnsSettingsHash != latest.dnsSettingsHash
@@ -337,7 +494,13 @@ private actor NetworkFingerprintEmissionState {
             dnsSettingsHash: dnsSettingsHash,
             staticProxySettingsHash: staticProxySettingsHash,
             tunnelInterfaces: latest.tunnelInterfaces,
-            routedTunnelInterface: latest.routedTunnelInterface
+            routedTunnelInterface: latest.routedTunnelInterface,
+            selectedInterfaceIndex: routeState?.interfaceIndex ?? latest.selectedInterfaceIndex,
+            selectedInterfaceAddresses: routeState?.addresses ?? latest.selectedInterfaceAddresses,
+            selectedInterfaceSubnets: routeState?.subnets ?? latest.selectedInterfaceSubnets,
+            selectedGateway: routeState?.gateway ?? latest.selectedGateway,
+            ipv4PrimaryServiceIdentity: routeState?.ipv4PrimaryServiceIdentity ?? latest.ipv4PrimaryServiceIdentity,
+            ipv6PrimaryServiceIdentity: routeState?.ipv6PrimaryServiceIdentity ?? latest.ipv6PrimaryServiceIdentity
         )
         latest = fingerprint
         return fingerprint

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/NetworkFingerprint.swift
@@ -255,8 +255,9 @@ struct SystemNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
                     while let path = await remainingPathIterator.next() {
                         guard !Task.isCancelled else { return }
                         let fingerprint = fingerprint(path: path)
-                        let emitted = await emissionState.receivePath(fingerprint)
-                        streamPair.continuation.yield(emitted)
+                        if let emitted = await emissionState.receivePath(fingerprint) {
+                            streamPair.continuation.yield(emitted)
+                        }
                     }
                 }
                 group.addTask {
@@ -313,7 +314,8 @@ private actor NetworkFingerprintEmissionState {
         latest = baseline
     }
 
-    func receivePath(_ fingerprint: NetworkFingerprint) -> NetworkFingerprint {
+    func receivePath(_ fingerprint: NetworkFingerprint) -> NetworkFingerprint? {
+        guard fingerprint != latest else { return nil }
         latest = fingerprint
         return fingerprint
     }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/ProxyResolution.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/ProxyResolution.swift
@@ -29,6 +29,19 @@ struct ProxyTargetRouteResult: Equatable, Sendable {
     let selectedCandidateIndex: Int?
     let selectedProxy: EffectiveProxy?
     let evidence: [NetworkDiagnosticEvidence]
+
+    var diagnosticAvailability: DiagnosticRouteAvailability {
+        switch status {
+        case .proxied:
+            .available
+        case .authenticationRequired:
+            .authenticationRequired
+        case .unavailable:
+            .unavailable
+        case .direct, .tunnel, .indeterminate:
+            .unverified
+        }
+    }
 }
 
 protocol ProxyResolving: Sendable {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
@@ -121,7 +121,7 @@ struct SystemDiagnosticRouteSource: DiagnosticRouteSourcing {
     }
 }
 
-private struct DiagnosticRouteProcessResult: Sendable {
+struct DiagnosticRouteProcessResult: Sendable {
     let exitCode: Int32?
     let stdout: String
     let stderr: String
@@ -129,7 +129,7 @@ private struct DiagnosticRouteProcessResult: Sendable {
     let cancelled: Bool
 }
 
-private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
+final class DiagnosticRouteProcessExecution: @unchecked Sendable {
     private let lock = NSLock()
     private let process: Process
     private let stdoutPipe = Pipe()
@@ -194,11 +194,14 @@ private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
             lock.unlock()
             return
         }
-        process.terminate()
         let continuation = self.continuation
         self.continuation = nil
         didFinish = true
         lock.unlock()
+
+        if process.isRunning {
+            process.terminate()
+        }
 
         continuation?.resume(returning: .init(
             exitCode: nil,
@@ -210,11 +213,16 @@ private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
     }
 
     private func execute() {
+        guard !isFinished() else { return }
         do {
             try process.run()
         } catch {
             finish(timedOut: false, cancelled: false)
             return
+        }
+
+        if isFinished(), process.isRunning {
+            process.terminate()
         }
 
         process.waitUntilExit()
@@ -230,10 +238,16 @@ private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
         didFinish = true
         let continuation = self.continuation
         self.continuation = nil
-        let exitCode = process.isRunning ? nil : process.terminationStatus
-        let stdout = read(pipe: stdoutPipe.fileHandleForReading)
-        let stderr = read(pipe: stderrPipe.fileHandleForReading)
         lock.unlock()
+
+        let shouldStop = timedOut || cancelled
+        if shouldStop, process.isRunning {
+            process.terminate()
+        }
+
+        let exitCode = shouldStop || process.isRunning ? nil : process.terminationStatus
+        let stdout = shouldStop ? "" : read(pipe: stdoutPipe.fileHandleForReading)
+        let stderr = shouldStop ? "" : read(pipe: stderrPipe.fileHandleForReading)
 
         continuation?.resume(returning: .init(
             exitCode: exitCode,
@@ -242,6 +256,12 @@ private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
             timedOut: timedOut,
             cancelled: cancelled
         ))
+    }
+
+    private func isFinished() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didFinish
     }
 
     private func read(pipe: FileHandle) -> String {

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
@@ -135,7 +135,12 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
     private let stdoutPipe = Pipe()
     private let stderrPipe = Pipe()
     private let outputLimit: Int
+    private let timeoutQueue = DispatchQueue(
+        label: "com.shiinalabs.wifi-lens.diagnostic-route-timeout",
+        qos: .utility
+    )
     private var continuation: CheckedContinuation<DiagnosticRouteProcessResult, Never>?
+    private var timeoutSource: DispatchSourceTimer?
     private var didFinish = false
 
     init(
@@ -156,15 +161,6 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
     }
 
     func run(timeout: Duration) async -> DiagnosticRouteProcessResult {
-        let timeoutTask = Task { [weak self] in
-            do {
-                try await Task.sleep(for: timeout)
-            } catch {
-                return
-            }
-            self?.finish(timedOut: true, cancelled: false)
-        }
-
         let result = await withCheckedContinuation { continuation in
             lock.lock()
             if didFinish {
@@ -178,13 +174,22 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
                 ))
             } else {
                 self.continuation = continuation
+                let timeoutSource = DispatchSource.makeTimerSource(queue: timeoutQueue)
+                timeoutSource.schedule(
+                    deadline: .now() + Self.dispatchInterval(for: timeout),
+                    leeway: .milliseconds(1)
+                )
+                timeoutSource.setEventHandler { [weak self] in
+                    self?.finish(timedOut: true, cancelled: false)
+                }
+                timeoutSource.resume()
+                self.timeoutSource = timeoutSource
                 lock.unlock()
                 DispatchQueue.global(qos: .utility).async { [self] in
                     execute()
                 }
             }
         }
-        timeoutTask.cancel()
         return result
     }
 
@@ -196,8 +201,13 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
         }
         let continuation = self.continuation
         self.continuation = nil
+        let timeoutSource = self.timeoutSource
+        self.timeoutSource = nil
         didFinish = true
         lock.unlock()
+
+        timeoutSource?.setEventHandler {}
+        timeoutSource?.cancel()
 
         if process.isRunning {
             process.terminate()
@@ -238,7 +248,12 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
         didFinish = true
         let continuation = self.continuation
         self.continuation = nil
+        let timeoutSource = self.timeoutSource
+        self.timeoutSource = nil
         lock.unlock()
+
+        timeoutSource?.setEventHandler {}
+        timeoutSource?.cancel()
 
         let shouldStop = timedOut || cancelled
         if shouldStop, process.isRunning {
@@ -268,5 +283,13 @@ final class DiagnosticRouteProcessExecution: @unchecked Sendable {
         let data = pipe.readDataToEndOfFile()
         let limited = data.prefix(outputLimit)
         return String(data: limited, encoding: .utf8) ?? ""
+    }
+
+    private static func dispatchInterval(for duration: Duration) -> DispatchTimeInterval {
+        let components = duration.components
+        let nanoseconds = Double(components.seconds) * 1_000_000_000
+            + Double(components.attoseconds) / 1_000_000_000
+        let clamped = min(max(nanoseconds, 0), Double(Int.max))
+        return .nanoseconds(Int(clamped))
     }
 }

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemDiagnosticRouteSource.swift
@@ -1,0 +1,252 @@
+import Darwin
+import Foundation
+
+enum DiagnosticRouteParser {
+    private static let requiredFields = ["destination", "gateway", "interface", "flags"]
+    private static let unsupportedInterfacePrefixes = [
+        "lo", "utun", "ipsec", "ppp", "tun", "tap", "bridge", "gif", "stf"
+    ]
+
+    static func parse(
+        output: String,
+        interfaceIndices: [String: UInt32]
+    ) -> DiagnosticRouteSelection {
+        var fields: [String: String] = [:]
+
+        for line in output.split(whereSeparator: \.isNewline) {
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let key = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard requiredFields.contains(key) else { continue }
+            let value = line[line.index(after: separator)...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard fields[key] == nil else { return .ambiguous }
+            fields[key] = value
+        }
+
+        guard let destination = fields["destination"], destination == "default",
+              let gateway = fields["gateway"], !gateway.isEmpty,
+              let interfaceName = fields["interface"], !interfaceName.isEmpty,
+              let flags = fields["flags"], !flags.isEmpty else {
+            return .unavailable
+        }
+
+        guard hasRequiredFlags(flags) else { return .unavailable }
+        if isLinkLayerAddress(gateway) {
+            return .unsupported
+        }
+        guard isUnicastIPv4(gateway) else { return .unavailable }
+        guard let interfaceIndex = interfaceIndices[interfaceName], interfaceIndex != 0 else {
+            return .unavailable
+        }
+        if unsupportedInterfacePrefixes.contains(where: { interfaceName.hasPrefix($0) }) {
+            return .unsupported
+        }
+
+        return .selected(.init(
+            interfaceName: interfaceName,
+            interfaceIndex: interfaceIndex,
+            address: gateway
+        ))
+    }
+
+    private static func hasRequiredFlags(_ flags: String) -> Bool {
+        let normalized = flags
+            .trimmingCharacters(in: CharacterSet(charactersIn: "<>"))
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let flagSet = Set(normalized)
+        return flagSet.contains("UP") && flagSet.contains("GATEWAY")
+    }
+
+    private static func isLinkLayerAddress(_ address: String) -> Bool {
+        address.lowercased().hasPrefix("link#") || address.contains("#")
+    }
+
+    private static func isUnicastIPv4(_ address: String) -> Bool {
+        var value = in_addr()
+        let result = address.withCString { pointer in
+            inet_pton(AF_INET, pointer, &value)
+        }
+        guard result == 1 else { return false }
+
+        let bytes = withUnsafeBytes(of: value.s_addr) { Array($0) }
+        guard bytes.count == 4 else { return false }
+        let first = bytes[0]
+        let isUnspecified = bytes.allSatisfy { $0 == 0 }
+        let isLoopback = first == 127
+        let isMulticast = (224...239).contains(first)
+        let isBroadcast = bytes.allSatisfy { $0 == 255 }
+        return !isUnspecified && !isLoopback && !isMulticast && !isBroadcast
+    }
+}
+
+struct SystemDiagnosticRouteSource: DiagnosticRouteSourcing {
+    private static let executablePath = "/sbin/route"
+    private static let arguments = ["-n", "get", "-inet", "default"]
+    private static let outputLimit = 16 * 1024
+
+    func currentRoute(timeout: Duration) async -> DiagnosticRouteSelection {
+        let interfaceIndices = await interfaceIndices()
+        let execution = DiagnosticRouteProcessExecution(
+            executablePath: Self.executablePath,
+            arguments: Self.arguments,
+            environment: ["LC_ALL": "C"],
+            outputLimit: Self.outputLimit
+        )
+        let result = await withTaskCancellationHandler {
+            await execution.run(timeout: timeout)
+        } onCancel: {
+            execution.cancel()
+        }
+
+        guard result.exitCode == 0, !result.timedOut, !result.cancelled else {
+            return .unavailable
+        }
+        return DiagnosticRouteParser.parse(
+            output: result.stdout,
+            interfaceIndices: interfaceIndices
+        )
+    }
+
+    private func interfaceIndices() async -> [String: UInt32] {
+        await Task.detached(priority: .utility) {
+            Dictionary(
+                uniqueKeysWithValues: NetworkInfoService.fetchAll().compactMap { interface in
+                    let index = if_nametoindex(interface.interfaceName)
+                    guard index != 0 else { return nil }
+                    return (interface.interfaceName, index)
+                }
+            )
+        }.value
+    }
+}
+
+private struct DiagnosticRouteProcessResult: Sendable {
+    let exitCode: Int32?
+    let stdout: String
+    let stderr: String
+    let timedOut: Bool
+    let cancelled: Bool
+}
+
+private final class DiagnosticRouteProcessExecution: @unchecked Sendable {
+    private let lock = NSLock()
+    private let process: Process
+    private let stdoutPipe = Pipe()
+    private let stderrPipe = Pipe()
+    private let outputLimit: Int
+    private var continuation: CheckedContinuation<DiagnosticRouteProcessResult, Never>?
+    private var didFinish = false
+
+    init(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        outputLimit: Int
+    ) {
+        process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        var inheritedEnvironment = ProcessInfo.processInfo.environment
+        environment.forEach { inheritedEnvironment[$0.key] = $0.value }
+        process.environment = inheritedEnvironment
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        self.outputLimit = outputLimit
+    }
+
+    func run(timeout: Duration) async -> DiagnosticRouteProcessResult {
+        let timeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            self?.finish(timedOut: true, cancelled: false)
+        }
+
+        let result = await withCheckedContinuation { continuation in
+            lock.lock()
+            if didFinish {
+                lock.unlock()
+                continuation.resume(returning: DiagnosticRouteProcessResult(
+                    exitCode: nil,
+                    stdout: "",
+                    stderr: "",
+                    timedOut: false,
+                    cancelled: true
+                ))
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+                DispatchQueue.global(qos: .utility).async { [self] in
+                    execute()
+                }
+            }
+        }
+        timeoutTask.cancel()
+        return result
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        process.terminate()
+        let continuation = self.continuation
+        self.continuation = nil
+        didFinish = true
+        lock.unlock()
+
+        continuation?.resume(returning: .init(
+            exitCode: nil,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            cancelled: true
+        ))
+    }
+
+    private func execute() {
+        do {
+            try process.run()
+        } catch {
+            finish(timedOut: false, cancelled: false)
+            return
+        }
+
+        process.waitUntilExit()
+        finish(timedOut: false, cancelled: false)
+    }
+
+    private func finish(timedOut: Bool, cancelled: Bool) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        didFinish = true
+        let continuation = self.continuation
+        self.continuation = nil
+        let exitCode = process.isRunning ? nil : process.terminationStatus
+        let stdout = read(pipe: stdoutPipe.fileHandleForReading)
+        let stderr = read(pipe: stderrPipe.fileHandleForReading)
+        lock.unlock()
+
+        continuation?.resume(returning: .init(
+            exitCode: exitCode,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut,
+            cancelled: cancelled
+        ))
+    }
+
+    private func read(pipe: FileHandle) -> String {
+        let data = pipe.readDataToEndOfFile()
+        let limited = data.prefix(outputLimit)
+        return String(data: limited, encoding: .utf8) ?? ""
+    }
+}

--- a/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
+++ b/WiFiLens/Sources/WiFiLens/NetworkDiagnostics/SystemProxyCheck.swift
@@ -231,10 +231,15 @@ struct NetworkProxyEndpointConnector: ProxyEndpointConnecting {
                     }
                 }
                 connection.start(queue: DispatchQueue(label: "io.github.kaoru.wifi-lens.network-diagnostics.proxy"))
-                Task {
-                    try? await Task.sleep(for: timeout)
-                    context.finish(false)
+                let timeoutTask = Task { [context] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                        context.finish(false)
+                    } catch {
+                        // The connection completed or the caller cancelled.
+                    }
                 }
+                context.install(timeoutTask: timeoutTask)
             }
         } onCancel: {
             context.cancel()
@@ -247,6 +252,8 @@ private final class ProxyConnectionContext: @unchecked Sendable {
     private let connection: NWConnection
     private var continuation: CheckedContinuation<Bool, Never>?
     private var cancellationRequested = false
+    private var didFinish = false
+    private var timeoutTask: Task<Void, Never>?
 
     init(connection: NWConnection) {
         self.connection = connection
@@ -254,7 +261,7 @@ private final class ProxyConnectionContext: @unchecked Sendable {
 
     func install(continuation: CheckedContinuation<Bool, Never>) -> Bool {
         lock.lock()
-        guard !cancellationRequested else {
+        guard !cancellationRequested, !didFinish else {
             lock.unlock()
             continuation.resume(returning: false)
             return false
@@ -264,16 +271,33 @@ private final class ProxyConnectionContext: @unchecked Sendable {
         return true
     }
 
+    func install(timeoutTask: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        self.timeoutTask = timeoutTask
+        lock.unlock()
+    }
+
     func finish(_ reachable: Bool) {
         lock.lock()
-        guard let continuation else {
+        guard !didFinish else {
             lock.unlock()
             return
         }
+        didFinish = true
+        let continuation = self.continuation
         self.continuation = nil
+        let timeoutTask = self.timeoutTask
+        self.timeoutTask = nil
         lock.unlock()
+        timeoutTask?.cancel()
+        connection.stateUpdateHandler = nil
         connection.cancel()
-        continuation.resume(returning: reachable)
+        continuation?.resume(returning: reachable)
     }
 
     func cancel() {
@@ -707,26 +731,33 @@ struct SystemProxyCheck: DiagnosticCheck {
     private func aggregate(_ routes: [ProxyTargetRouteResult]) -> NetworkDiagnosticResult {
         let statuses = routes.map(\.status)
         let evidence = routes.flatMap(\.evidence)
+        let proxyFacts = DiagnosticProxyFacts(
+            http: routes.first(where: { $0.target.scheme?.lowercased() == "http" })?.diagnosticAvailability ?? .unverified,
+            https: routes.first(where: { $0.target.scheme?.lowercased() == "https" })?.diagnosticAvailability ?? .unverified
+        )
 
         if statuses.contains(.authenticationRequired) {
             return result(
                 .abnormal,
                 key: "network_diagnostics.proxy.authentication_required.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         if statuses.contains(.unavailable) {
             return result(
                 .abnormal,
                 key: "network_diagnostics.proxy.route_unavailable.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         if statuses.contains(.indeterminate) {
             return result(
                 .indeterminate,
                 key: "network_diagnostics.proxy.unable_to_determine.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         if statuses.allSatisfy({ $0 == .tunnel || $0 == .direct }),
@@ -740,40 +771,46 @@ struct SystemProxyCheck: DiagnosticCheck {
                 key: nwPathConfirmed
                     ? "network_diagnostics.proxy.tunnel_routes.summary"
                     : "network_diagnostics.proxy.tunnel_routes_active.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         if statuses.allSatisfy({ $0 == .direct }) {
             return result(
                 .indeterminate,
                 key: "network_diagnostics.proxy.direct_routes.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         if statuses.allSatisfy({ $0 == .proxied }) {
             return result(
                 .normal,
                 key: "network_diagnostics.proxy.routes_available.summary",
-                evidence: evidence
+                evidence: evidence,
+                proxyFacts: proxyFacts
             )
         }
         return result(
             .indeterminate,
             key: "network_diagnostics.proxy.mixed_routing.summary",
-            evidence: evidence
+            evidence: evidence,
+            proxyFacts: proxyFacts
         )
     }
 
     private func result(
         _ status: NetworkDiagnosticStatus,
         key: String.LocalizationValue,
-        evidence: [NetworkDiagnosticEvidence] = []
+        evidence: [NetworkDiagnosticEvidence] = [],
+        proxyFacts: DiagnosticProxyFacts? = nil
     ) -> NetworkDiagnosticResult {
         NetworkDiagnosticResult(
             id: id,
             status: status,
             summary: String(localized: key, comment: "Network self-check system proxy result summary"),
-            evidence: evidence
+            evidence: evidence,
+            proxyFacts: proxyFacts
         )
     }
 }

--- a/WiFiLens/Sources/WiFiLens/Observation/Providers/GatewayLatencyProvider.swift
+++ b/WiFiLens/Sources/WiFiLens/Observation/Providers/GatewayLatencyProvider.swift
@@ -6,9 +6,20 @@ protocol GatewayLatencyProviding: Sendable {
 
 protocol GatewayPinging: Sendable {
     func ping(host: String) async -> Double?
+    func ping(target: DiagnosticGatewayTarget) async -> Double?
+}
+
+extension GatewayPinging {
+    /// Address-only callers cannot safely provide interface binding. Diagnostics
+    /// must inject a target-aware implementation instead of falling back here.
+    func ping(target: DiagnosticGatewayTarget) async -> Double? { nil }
 }
 
 extension GatewayPinger: GatewayPinging {}
+
+protocol DiagnosticGatewayMeasuring: Sendable {
+    func measure(target: DiagnosticGatewayTarget) async -> GatewayLatencyResult
+}
 
 struct GatewayLatencyProvider: GatewayLatencyProviding {
     private let pinger: GatewayPinging
@@ -38,4 +49,22 @@ struct GatewayLatencyProvider: GatewayLatencyProviding {
             latencyMs: latency
         )
     }
+
+    func measure(target: DiagnosticGatewayTarget) async -> GatewayLatencyResult {
+        let latency = await pinger.ping(target: target)
+        guard let latency else {
+            return GatewayLatencyResult(
+                timestamp: Date(),
+                routerIP: target.address,
+                error: .gatewayPingFailed(target.address)
+            )
+        }
+        return GatewayLatencyResult(
+            timestamp: Date(),
+            routerIP: target.address,
+            latencyMs: latency
+        )
+    }
 }
+
+extension GatewayLatencyProvider: DiagnosticGatewayMeasuring {}

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -45568,6 +45568,129 @@
           }
         }
       }
+    },
+    "network_diagnostics.log.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
+        }
+      }
+    },
+    "network_diagnostics.log.expand": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweitern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开"
+          }
+        }
+      }
+    },
+    "network_diagnostics.log.collapse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einklappen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réduire"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折りたたむ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收起"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
+++ b/WiFiLens/Sources/WiFiLens/Resources/Localizable.xcstrings
@@ -45691,6 +45691,580 @@
           }
         }
       }
+    },
+    "network_diagnostics.session.timed_out": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check timed out. %lld of %lld checks completed."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung. %lld von %lld Prüfungen abgeschlossen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La comprobación agotó el tiempo. %lld de %lld comprobaciones completadas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェックがタイムアウトしました。%lld / %lld 件のチェックが完了しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测超时。已完成 %lld/%lld 项检测。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le contrôle a expiré. %lld contrôles sur %lld ont été terminés."
+          }
+        }
+      }
+    },
+    "network_diagnostics.session.cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check cancelled. Completed results are shown below."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfung abgebrochen. Abgeschlossene Ergebnisse werden unten angezeigt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobación cancelada. Los resultados completados se muestran a continuación."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェックがキャンセルされました。完了した結果を以下に表示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测已取消。下面显示已完成的结果。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le contrôle a été annulé. Les résultats partiels sont conservés."
+          }
+        }
+      }
+    },
+    "network_diagnostics.session.network_changed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The network kept changing. Run the check again when the connection is stable."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Netzwerk hat sich wiederholt geändert. Führe die Prüfung erneut aus, sobald die Verbindung stabil ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La red siguió cambiando. Vuelve a ejecutar la comprobación cuando la conexión sea estable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークが変化し続けました。接続が安定してからもう一度チェックしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络持续发生变化。连接稳定后请重新检测。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le réseau a continué de changer. Aucun résultat complet n’a été publié."
+          }
+        }
+      }
+    },
+    "network_diagnostics.session.restarting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network changed. Checking the new connection…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerk geändert. Die neue Verbindung wird geprüft…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La red ha cambiado. Comprobando la nueva conexión…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークが変化しました。新しい接続をチェックしています…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络已变化。正在检测新连接…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le réseau a changé. Redémarrage du contrôle…"
+          }
+        }
+      }
+    },
+    "network_diagnostics.session.monitor_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network change monitoring is unavailable for this check."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Überwachung von Netzwerkänderungen ist für diese Prüfung nicht verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La supervisión de cambios de red no está disponible para esta comprobación."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このチェックではネットワーク変更の監視を利用できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次检测无法监控网络变化。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les changements de réseau ne peuvent pas être surveillés pendant ce contrôle."
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.not_run_timeout": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not run: the check time limit was reached."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht ausgeführt: Das Zeitlimit der Prüfung wurde erreicht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No ejecutada: se alcanzó el límite de tiempo de la comprobación."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未実行：チェックの制限時間に達しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未运行：已达到检测时间限制。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non exécuté : le délai du contrôle a expiré."
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.not_run_cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not run: the check was cancelled."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht ausgeführt: Die Prüfung wurde abgebrochen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No ejecutada: se canceló la comprobación."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未実行：チェックがキャンセルされました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未运行：检测已取消。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non exécuté : le contrôle a été annulé."
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.target": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface: %@ · Gateway: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnittstelle: %@ · Gateway: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaz: %@ · Puerta de enlace: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インターフェイス：%@ · ゲートウェイ：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接口：%@ · 网关：%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface : %@ · Passerelle : %@"
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.no_response": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The gateway did not respond to the ICMP probe."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Gateway hat auf die ICMP-Prüfung nicht geantwortet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La puerta de enlace no respondió a la prueba ICMP."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイは ICMP プローブに応答しませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网关没有响应 ICMP 探测。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La passerelle n’a pas répondu à la sonde ICMP."
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.route_changed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The network route changed during this probe."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Netzwerkroute hat sich während dieser Prüfung geändert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta de red cambió durante esta prueba."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このプローブ中にネットワークルートが変化しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测过程中网络路由发生了变化。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La route réseau a changé pendant cette sonde."
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.unsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This route has no supported IPv4 gateway to test."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Route hat kein unterstütztes IPv4-Gateway zum Testen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta ruta no tiene una puerta de enlace IPv4 compatible para probar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このルートにはテスト可能な IPv4 ゲートウェイがありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此路由没有可供检测的受支持 IPv4 网关。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette route ne possède pas de passerelle IPv4 prise en charge à tester."
+          }
+        }
+      }
+    },
+    "network_diagnostics.gateway.unverified": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway reachability could not be verified; internet access succeeded."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Erreichbarkeit des Gateways konnte nicht bestätigt werden; der Internetzugriff war erfolgreich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo verificar la accesibilidad de la puerta de enlace; el acceso a Internet funcionó."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゲートウェイの到達性は確認できませんでしたが、インターネットアクセスは成功しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法验证网关可达性，但互联网访问成功。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La disponibilité de la passerelle n’a pas pu être vérifiée ; l’accès Internet a réussi."
+          }
+        }
+      }
+    },
+    "network_diagnostics.proxy.direct_unverified": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct routing is unverified; base internet access succeeded."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die direkte Route ist nicht verifiziert; der Internetzugriff über die Basisverbindung war erfolgreich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El enrutamiento directo no está verificado; el acceso base a Internet funcionó."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接ルートは未確認ですが、基本インターネットアクセスは成功しました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直连路由未经验证，但基础互联网访问成功。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route DIRECT non vérifiée ; l’accès Internet a réussi."
+          }
+        }
+      }
+    },
+    "network_diagnostics.check.timed_out": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This check timed out before it produced a result."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Prüfung wurde beendet, bevor sie ein Ergebnis liefern konnte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta comprobación agotó el tiempo antes de producir un resultado."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このチェックは結果を返す前にタイムアウトしました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此项检测在产生结果前已超时。"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le contrôle a expiré avant de produire un résultat."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/WiFiLens/Sources/WiFiLens/Utilities/GatewayPinger.swift
+++ b/WiFiLens/Sources/WiFiLens/Utilities/GatewayPinger.swift
@@ -61,7 +61,9 @@ actor SystemGatewayPingProcessRunner: GatewayPingProcessRunning {
         } onCancel: {
             state.terminate()
         }
-        currentState = nil
+        if currentState === state {
+            currentState = nil
+        }
 
         guard status == 0, !Task.isCancelled else { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()

--- a/WiFiLens/Sources/WiFiLens/Utilities/GatewayPinger.swift
+++ b/WiFiLens/Sources/WiFiLens/Utilities/GatewayPinger.swift
@@ -1,59 +1,84 @@
 import Foundation
 
+protocol GatewayPingProcessRunning: Sendable {
+    func run(executablePath: String, arguments: [String]) async -> Double?
+    func cancel() async
+}
+
 actor GatewayPinger {
+    private let processRunner: any GatewayPingProcessRunning
+
+    init(processRunner: any GatewayPingProcessRunning = SystemGatewayPingProcessRunner()) {
+        self.processRunner = processRunner
+    }
+
+    func ping(host: String) async -> Double? {
+        await ping(arguments: ["-c", "1", "-W", "1000", host])
+    }
+
+    func ping(target: DiagnosticGatewayTarget) async -> Double? {
+        await ping(arguments: DiagnosticPingArguments.make(target: target))
+    }
+
+    private func ping(arguments: [String]) async -> Double? {
+        await processRunner.cancel()
+        return await withTaskCancellationHandler {
+            await processRunner.run(executablePath: "/sbin/ping", arguments: arguments)
+        } onCancel: {
+            Task { await processRunner.cancel() }
+        }
+    }
+}
+
+actor SystemGatewayPingProcessRunner: GatewayPingProcessRunning {
     /// Overall budget for a single ping, including process startup. Kept just
     /// above the `-W 1000` ping timeout so an unreachable gateway is normally
     /// reported by the process itself, while still bounding the wait if the
     /// process ever hangs.
     private static let pingTimeout: Duration = .milliseconds(1500)
 
-    private var lastTask: Task<Double?, Never>?
-    private var currentProcess: Process?
+    private var currentState: PingWaitState?
 
-    func ping(host: String) async -> Double? {
-        lastTask?.cancel()
-        currentProcess?.terminate()
-
-        let task = Task<Double?, Never> { [host] in
-            await self.runPing(host: host)
-        }
-        lastTask = task
-        return await task.value
-    }
-
-    private func runPing(host: String) async -> Double? {
+    func run(executablePath: String, arguments: [String]) async -> Double? {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/sbin/ping")
-        process.arguments = ["-c", "1", "-W", "1000", host]
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
 
         let pipe = Pipe()
         process.standardOutput = pipe
-
-        currentProcess = process
+        let state = PingWaitState(process: process)
+        currentState = state
 
         do {
             try process.run()
         } catch {
+            currentState = nil
             return nil
         }
 
-        guard await Self.waitForExit(process) == 0,
-              !Task.isCancelled
-        else {
-            return nil
+        let status = await withTaskCancellationHandler {
+            await Self.waitForExit(state)
+        } onCancel: {
+            state.terminate()
         }
+        currentState = nil
 
+        guard status == 0, !Task.isCancelled else { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8) else { return nil }
+        return Self.parseLatency(from: output)
+    }
 
+    func cancel() {
+        currentState?.terminate()
+    }
+
+    private static func parseLatency(from output: String) -> Double? {
         for line in output.components(separatedBy: "\n") {
-            if line.contains("time=") {
-                if let range = line.range(of: "time=") {
-                    let rest = line[range.upperBound...]
-                    let msStr = rest.components(separatedBy: " ").first ?? ""
-                    return Double(msStr)
-                }
-            }
+            guard let range = line.range(of: "time=") else { continue }
+            let rest = line[range.upperBound...]
+            let milliseconds = rest.components(separatedBy: " ").first ?? ""
+            return Double(milliseconds)
         }
         return nil
     }
@@ -63,9 +88,7 @@ actor GatewayPinger {
     /// process immediately so the caller gets `nil` quickly instead of waiting
     /// out the ping timeout; a timeout task is the backstop if the process
     /// hangs.
-    private static func waitForExit(_ process: Process) async -> Int32 {
-        let state = PingWaitState(process: process)
-
+    private static func waitForExit(_ state: PingWaitState) async -> Int32 {
         let timeoutTask = Task { [state] in
             do {
                 try await Task.sleep(for: Self.pingTimeout)
@@ -75,19 +98,15 @@ actor GatewayPinger {
             state.terminate()
         }
 
-        let status = await withTaskCancellationHandler {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
-                state.process.terminationHandler = { [state] terminatedProcess in
-                    _ = state.resumeIfNeeded(continuation, status: terminatedProcess.terminationStatus)
-                }
-                // Cover the race where the process exited before the handler
-                // was installed.
-                if !state.process.isRunning {
-                    _ = state.resumeIfNeeded(continuation, status: state.process.terminationStatus)
-                }
+        let status = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            state.process.terminationHandler = { [state] terminatedProcess in
+                _ = state.resumeIfNeeded(continuation, status: terminatedProcess.terminationStatus)
             }
-        } onCancel: {
-            state.terminate()
+            // Cover the race where the process exited before the handler
+            // was installed.
+            if !state.process.isRunning {
+                _ = state.resumeIfNeeded(continuation, status: state.process.terminationStatus)
+            }
         }
 
         timeoutTask.cancel()

--- a/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
@@ -284,8 +284,8 @@ struct EditionCompositionTests {
         let replyProbe = TerminationBoolProbe()
         var steps: [String] = []
         let coordinator = ApplicationTerminationCoordinator(
-            waitForDeadline: { _ in
-                await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in }
+            waitForDeadline: { duration in
+                try await Task.sleep(for: duration)
             },
             reply: { replyProbe.record($0) }
         )

--- a/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/EditionCompositionTests.swift
@@ -284,6 +284,7 @@ struct EditionCompositionTests {
         let replyProbe = TerminationBoolProbe()
         var steps: [String] = []
         let coordinator = ApplicationTerminationCoordinator(
+            terminationDeadline: .seconds(60),
             waitForDeadline: { duration in
                 try await Task.sleep(for: duration)
             },

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsAssessmentTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsAssessmentTests.swift
@@ -1,0 +1,222 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("conclusion and assessment rules cover the decision table")
+    func conclusionDecisionTable() {
+        func assessment(for results: [NetworkDiagnosticResult]) -> NetworkDiagnosticAssessment {
+            NetworkDiagnosticAssessmentResolver().resolve(
+                results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+                complete: true
+            )
+        }
+
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .abnormal, dns: .normal, internet: .normal, proxy: .normal)
+        ) == .networkUnavailable)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .normal, dns: .abnormal, internet: .normal, proxy: .normal)
+        ) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .normal, dns: .normal, internet: .normal, proxy: .abnormal)
+        ) == .needsAttention)
+
+        let gatewayFailure = makeResults(
+            path: .normal,
+            gateway: .abnormal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .normal
+        )
+        #expect(NetworkDiagnosticConclusion.evaluate(gatewayFailure) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.primaryIssue(in: gatewayFailure)?.id == .gatewayReachability)
+
+        var usableProxy = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .normal
+        )
+        usableProxy[5] = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .normal,
+            summary: "proxy",
+            evidence: [.init(code: "proxy.https.egress-status", value: "200")]
+        )
+        #expect(NetworkDiagnosticConclusion.evaluate(usableProxy) == .needsAttention)
+
+        var directWithoutEgress = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .normal
+        )
+        directWithoutEgress[3] = NetworkDiagnosticResult(
+            id: .internet,
+            status: .abnormal,
+            summary: "internet",
+            evidence: [.init(
+                code: "https.connectivity-error",
+                value: String(URLError.notConnectedToInternet.rawValue)
+            )]
+        )
+        directWithoutEgress[5] = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .normal,
+            summary: "proxy",
+            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")]
+        )
+        #expect(NetworkDiagnosticConclusion.evaluate(directWithoutEgress) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .normal, dns: .normal, internet: .normal, proxy: .abnormal)
+        ) == .needsAttention)
+
+        let captivePortal = [
+            NetworkDiagnosticResult(id: .path, status: .normal, summary: "path"),
+            NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "gateway"),
+            NetworkDiagnosticResult(id: .dns, status: .normal, summary: "dns"),
+            NetworkDiagnosticResult(
+                id: .internet,
+                status: .abnormal,
+                summary: "internet",
+                evidence: [
+                    .init(code: "https.available", value: "200"),
+                    .init(code: "captive-portal.suspected", value: nil),
+                ]
+            ),
+            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: "ipv6"),
+            NetworkDiagnosticResult(id: .proxy, status: .normal, summary: "proxy"),
+        ]
+        #expect(NetworkDiagnosticConclusion.evaluate(captivePortal) == .needsAttention)
+        #expect(assessment(for: captivePortal).primaryIssue?.id == .internet)
+
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .normal, dns: .indeterminate, internet: .normal, proxy: .normal)
+        ) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(path: .normal, dns: .normal, internet: .normal, proxy: .normal)
+        ) == .networkNormal)
+        #expect(NetworkDiagnosticConclusion.evaluate([
+            NetworkDiagnosticResult(id: .path, status: .normal, summary: "ok"),
+        ]) == nil)
+
+        var directRoute = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .indeterminate
+        )
+        directRoute[5] = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .indeterminate,
+            summary: "direct routing selected",
+            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")],
+            proxyFacts: .init(http: .unverified, https: .unverified)
+        )
+        #expect(NetworkDiagnosticConclusion.evaluate(directRoute) == .networkNormal)
+
+        let pacFailure = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .indeterminate
+        ).map { result in
+            guard result.id == .proxy else { return result }
+            return NetworkDiagnosticResult(
+                id: .proxy,
+                status: .indeterminate,
+                summary: "proxy resolution failed",
+                evidence: [
+                    .init(code: "proxy.http.resolution", value: "pac-timeout"),
+                    .init(code: "proxy.https.resolution", value: "pac-timeout"),
+                ],
+                proxyFacts: .init(http: .unverified, https: .unverified)
+            )
+        }
+        #expect(assessment(for: pacFailure).conclusion == .needsAttention)
+
+        var singleHTTPSFailure = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .indeterminate
+        )
+        singleHTTPSFailure[3] = NetworkDiagnosticResult(
+            id: .internet,
+            status: .abnormal,
+            summary: "one HTTPS target failed",
+            evidence: [.init(code: "https.connectivity-error", value: nil)]
+        )
+        #expect(NetworkDiagnosticConclusion.evaluate(singleHTTPSFailure) == .needsAttention)
+
+        var uncertainDNS = makeResults(
+            path: .normal,
+            dns: .indeterminate,
+            internet: .normal,
+            proxy: .indeterminate
+        )
+        uncertainDNS[5] = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .indeterminate,
+            summary: "direct routing selected",
+            proxyFacts: .init(http: .unverified, https: .unverified)
+        )
+        let uncertainDNSAssessment = assessment(for: uncertainDNS)
+        #expect(uncertainDNSAssessment.conclusion == .needsAttention)
+        #expect(uncertainDNSAssessment.stages.first { $0.stage == .thisMac }?.status == .indeterminate)
+
+        let facts = DiagnosticProxyFacts(http: .unavailable, https: .available)
+        #expect(facts.https == .available)
+        let independentHTTPS = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .abnormal
+        ).map { result in
+            if result.id == .internet {
+                return NetworkDiagnosticResult(
+                    id: result.id,
+                    status: result.status,
+                    summary: result.summary,
+                    evidence: [.init(code: "https.connectivity-error", value: nil)]
+                )
+            }
+            if result.id == .proxy {
+                return NetworkDiagnosticResult(
+                    id: result.id,
+                    status: result.status,
+                    summary: result.summary,
+                    evidence: [.init(code: "proxy.endpoint-unavailable", value: nil)],
+                    proxyFacts: facts
+                )
+            }
+            return result
+        }
+        let independentHTTPSAssessment = assessment(for: independentHTTPS)
+        #expect(independentHTTPSAssessment.conclusion == .needsAttention)
+        #expect(independentHTTPSAssessment.primaryIssue?.id == .proxy)
+
+        let recoveredProxy = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .normal
+        ).map { result in
+            guard result.id == .proxy else { return result }
+            return NetworkDiagnosticResult(
+                id: .proxy,
+                status: .normal,
+                summary: "HTTPS proxy recovered",
+                evidence: [.init(code: "proxy.https.authentication-required", value: "407")],
+                proxyFacts: .init(http: .available, https: .available)
+            )
+        }
+        let recoveredAssessment = assessment(for: recoveredProxy)
+        #expect(recoveredAssessment.conclusion == .networkNormal)
+        #expect(recoveredAssessment.primaryIssue == nil)
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsConfigurationTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsConfigurationTests.swift
@@ -1,0 +1,31 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("all app configurations use the same local-network privacy copy")
+    func localNetworkUsageDescriptionIsUnifiedAcrossAppConfigurations() throws {
+        let descriptions = try appLocalNetworkUsageDescriptions()
+        let expectedDescription = "WiFi Lens uses local networking when you enable its MCP server and when Network Self-Check tests reachability of your configured network proxy. These checks do not collect or transmit your Wi-Fi scan data."
+
+        #expect(descriptions.count == 4)
+        #expect(Set(descriptions.map(\.baseConfiguration)) == ["OSS.xcconfig", "PRO.xcconfig"])
+        #expect(descriptions.filter { $0.baseConfiguration == "OSS.xcconfig" }.count == 2)
+        #expect(descriptions.filter { $0.baseConfiguration == "PRO.xcconfig" }.count == 2)
+        #expect(Set(descriptions.map(\.value)) == [expectedDescription])
+        #expect(descriptions.allSatisfy { $0.value.contains("MCP server") })
+        #expect(descriptions.allSatisfy { $0.value.contains("Network Self-Check") })
+    }
+
+    @Test("production checks run path DNS HTTPS and proxy in dependency order")
+    @MainActor
+    func productionCheckOrder() {
+        #expect(NetworkDiagnosticsViewModel().checkIDs == [.path, .gatewayReachability, .dns, .internet, .proxy, .ipv6])
+        #expect(NetworkDiagnosticCheckID.allCases == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
+        #expect(NetworkDiagnosticCheckID.path != .internet)
+        #expect(Set(NetworkDiagnosticCheckID.allCases).count == 6)
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsControlEndpointTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsControlEndpointTests.swift
@@ -1,0 +1,335 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("IPv6 outcomes preserve optional-check conclusion semantics")
+    func ipv6OutcomeMatrix() async {
+        let ipv6 = await IPv6ControlEndpointCheck(
+            loader: StubIPv6Loader(.noGlobalAddress)
+        ).run()
+
+        #expect(ipv6.id == .ipv6)
+        #expect(ipv6.status == .skipped)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(
+                path: .normal,
+                dns: .normal,
+                internet: .normal,
+                ipv6: ipv6.status,
+                proxy: .normal
+            )
+        ) == .networkNormal)
+
+        let failed = await IPv6ControlEndpointCheck(loader: StubIPv6Loader(.failed)).run()
+
+        #expect(failed.status == .indeterminate)
+        #expect(failed.evidence.contains(.init(code: "ipv6.unavailable", value: nil)))
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            makeResults(
+                path: .normal,
+                dns: .normal,
+                internet: .normal,
+                ipv6: failed.status,
+                proxy: .normal
+            )
+        ) == .networkNormal)
+
+        let succeeded = await IPv6ControlEndpointCheck(loader: StubIPv6Loader(.succeeded)).run()
+
+        #expect(succeeded.status == .normal)
+        #expect(succeeded.evidence.contains(.init(code: "ipv6.available", value: nil)))
+    }
+
+    @Test("IPv6 loader preserves literal, fallback, and precondition behavior")
+    func ipv6LoaderMatrix() async {
+        let recorder = IPv6LoaderTestRecorder()
+        let loader = SystemIPv6ControlEndpointLoader(
+            addressSource: StubGlobalIPv6AddressSource(hasAddress: true),
+            resolver: StubIPv6AddressResolver(addresses: ["2001:db8::42"]),
+            connector: RecordingIPv6HTTPSConnector(succeeds: true, recorder: recorder)
+        )
+        let endpoint = URL(string: "https://control.example/health")!
+
+        let outcome = await loader.load(url: endpoint, timeout: .seconds(4))
+
+        #expect(outcome == .succeeded)
+        let requests = await recorder.requests
+        #expect(requests.count == 1)
+        #expect(requests.first?.url == endpoint)
+        #expect(requests.first?.ipv6Address == "2001:db8::42")
+        #expect(requests.first?.serverName == "control.example")
+        #expect(requests.first.map { $0.timeout > .zero && $0.timeout <= .seconds(4) } == true)
+
+        let connector = SequencedIPv6HTTPSConnector(successfulAddress: "2001:db8::2")
+        let fallbackLoader = SystemIPv6ControlEndpointLoader(
+            addressSource: StubGlobalIPv6AddressSource(hasAddress: true),
+            resolver: StubIPv6AddressResolver(addresses: ["2001:db8::1", "2001:db8::2"]),
+            connector: connector
+        )
+
+        let fallbackOutcome = await fallbackLoader.load(
+            url: URL(string: "https://control.example/health")!,
+            timeout: .seconds(4)
+        )
+
+        #expect(fallbackOutcome == .succeeded)
+        #expect(await connector.addresses == ["2001:db8::1", "2001:db8::2"])
+        let timeouts = await connector.timeouts
+        #expect(timeouts.count == 2)
+        #expect(timeouts.first.map { $0 > .zero && $0 <= .seconds(2) } == true)
+        #expect(timeouts.last.map { $0 > .zero && $0 <= .seconds(4) } == true)
+
+        let resolver = RecordingIPv6AddressResolver(addresses: ["2001:db8::42"])
+        let noAddressLoader = SystemIPv6ControlEndpointLoader(
+            addressSource: StubGlobalIPv6AddressSource(hasAddress: false),
+            resolver: resolver,
+            connector: StubIPv6HTTPSConnector(succeeds: true)
+        )
+
+        let noAddressOutcome = await noAddressLoader.load(
+            url: URL(string: "https://control.example/")!,
+            timeout: .seconds(4)
+        )
+
+        #expect(noAddressOutcome == .noGlobalAddress)
+        #expect(await resolver.hosts.isEmpty)
+    }
+
+    @Test("control endpoint outcomes preserve HTTPS and captive-portal evidence")
+    func controlEndpointOutcomeMatrix() async {
+        let check = HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 204,
+                httpStatus: 200,
+                httpBody: "login"
+            )
+        )
+
+        let result = await check.run()
+
+        #expect(result.id == .internet)
+        #expect(result.evidence.contains(.init(code: "captive-portal.suspected", value: nil)))
+
+        let success = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 200,
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+
+        #expect(success.status == .normal)
+        #expect(success.evidence.contains(.init(code: "https.available", value: "200")))
+        #expect(success.evidence.contains(.init(code: "captive-portal.clear", value: nil)))
+
+        let timeout = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 200,
+                httpStatus: nil,
+                httpBody: nil,
+                httpErrorCode: String(URLError.timedOut.rawValue)
+            )
+        ).run()
+
+        #expect(timeout.status == .indeterminate)
+        #expect(timeout.evidence.contains(.init(code: "https.available", value: "200")))
+        #expect(timeout.evidence.contains(.init(
+            code: "captive-portal.transport-error",
+            value: String(URLError.timedOut.rawValue)
+        )))
+    }
+
+    @Test("independent control endpoints load concurrently and preserve evidence order")
+    func controlEndpointsRunConcurrently() async {
+        let loader = ConcurrentControlLoader()
+        let result = await HTTPSControlEndpointCheck(loader: loader).run()
+
+        #expect(await loader.maximumInFlight == 2)
+        #expect(result.evidence.map(\.code).prefix(2) == ["https.available", "captive-portal.clear"])
+    }
+
+    @Test("control endpoint metrics are redacted to bounded transaction fields")
+    func controlEndpointMetricsAreRedacted() async {
+        let result = await HTTPSControlEndpointCheck(
+            loader: MetricsControlLoader(
+                metrics: .init(
+                    dnsDuration: .milliseconds(12),
+                    connectDuration: .milliseconds(34),
+                    tlsDuration: .milliseconds(56),
+                    negotiatedTLSVersion: "TLSv1.3",
+                    isProxyConnection: true,
+                    remoteAddress: "192.0.2.10:443"
+                )
+            )
+        ).run()
+
+        #expect(result.evidence.contains(.init(code: "https.metrics.dns-ms", value: "12")))
+        #expect(result.evidence.contains(.init(code: "https.metrics.connect-ms", value: "34")))
+        #expect(result.evidence.contains(.init(code: "https.metrics.tls-ms", value: "56")))
+        #expect(result.evidence.contains(.init(code: "https.metrics.tls-version", value: "TLSv1.3")))
+        #expect(result.evidence.contains(.init(code: "https.metrics.proxy", value: "true")))
+        #expect(!result.evidence.contains { $0.value == "192.0.2.10:443" })
+    }
+
+    @Test("control endpoint failures retain distinct evidence")
+    func controlEndpointFailureEvidence() async {
+        let tlsFailure = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: nil,
+                httpsErrorCode: String(URLError.secureConnectionFailed.rawValue),
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+        let certificateTimeFailure = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: nil,
+                httpsErrorCode: String(URLError.serverCertificateNotYetValid.rawValue),
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+        let certificateValidationFailure = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: nil,
+                httpsErrorCode: String(URLError.serverCertificateUntrusted.rawValue),
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+        let connectivityFailure = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: nil,
+                httpsErrorCode: String(URLError.timedOut.rawValue),
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+        let httpsStatusFailure = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 503,
+                httpStatus: 200,
+                httpBody: "Success"
+            )
+        ).run()
+        let captivePortalRedirect = await HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 200,
+                httpStatus: 302,
+                httpBody: nil
+            )
+        ).run()
+
+        #expect(tlsFailure.evidence.contains(.init(
+            code: "https.tls-error",
+            value: String(URLError.secureConnectionFailed.rawValue)
+        )))
+        #expect(certificateTimeFailure.evidence.contains(.init(
+            code: "https.certificate-time-error",
+            value: String(URLError.serverCertificateNotYetValid.rawValue)
+        )))
+        #expect(certificateValidationFailure.evidence.contains(.init(
+            code: "https.certificate-error",
+            value: String(URLError.serverCertificateUntrusted.rawValue)
+        )))
+        #expect(connectivityFailure.evidence.contains(.init(
+            code: "https.connectivity-error",
+            value: String(URLError.timedOut.rawValue)
+        )))
+        #expect(httpsStatusFailure.evidence.contains(.init(code: "https.http-status", value: "503")))
+        #expect(captivePortalRedirect.evidence.contains(.init(code: "captive-portal.redirect", value: "302")))
+        #expect(tlsFailure.summary == String(
+            localized: "network_diagnostics.internet.secure_connection_failure.summary",
+            comment: "Network self-check TLS or certificate failure summary"
+        ))
+        #expect(certificateValidationFailure.summary == tlsFailure.summary)
+        #expect(certificateTimeFailure.summary == String(
+            localized: "network_diagnostics.internet.certificate_time_failure.summary",
+            comment: "Network self-check certificate time failure summary"
+        ))
+        #expect(connectivityFailure.summary == String(
+            localized: "network_diagnostics.internet.connectivity_failure.summary",
+            comment: "Network self-check connectivity failure summary"
+        ))
+
+        let baseResults = [
+            NetworkDiagnosticResult(id: .path, status: .normal, summary: "path"),
+            NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "gateway"),
+            NetworkDiagnosticResult(id: .dns, status: .normal, summary: "dns"),
+        ]
+        let trailingResults = [
+            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: "ipv6"),
+            NetworkDiagnosticResult(id: .proxy, status: .abnormal, summary: "proxy"),
+        ]
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            baseResults + [tlsFailure] + trailingResults
+        ) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            baseResults + [certificateTimeFailure] + trailingResults
+        ) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            baseResults + [certificateValidationFailure] + trailingResults
+        ) == .needsAttention)
+        #expect(NetworkDiagnosticConclusion.evaluate(
+            baseResults + [connectivityFailure] + trailingResults
+        ) == .needsAttention)
+    }
+
+    @Test("control check loads the approved endpoints with an explicit timeout")
+    func controlEndpointRequests() async {
+        let recorder = ControlEndpointTestRecorder()
+        let check = HTTPSControlEndpointCheck(
+            loader: StubControlLoader(
+                httpsStatus: 200,
+                httpStatus: 200,
+                httpBody: "Success",
+                recorder: recorder
+            )
+        )
+
+        _ = await check.run()
+
+        #expect(Set(await recorder.urls) == Set([
+            "https://www.apple.com/",
+            "https://captive.apple.com/hotspot-detect.html",
+        ]))
+        #expect(await recorder.timeouts == [.seconds(5), .seconds(5)])
+    }
+
+    @Test("system control loader disables caching and connectivity waits")
+    func controlEndpointSessionConfiguration() {
+        let configuration = SystemControlEndpointLoader.configuration(timeout: .seconds(5))
+
+        #expect(configuration.requestCachePolicy == .reloadIgnoringLocalCacheData)
+        #expect(configuration.urlCache == nil)
+        #expect(!configuration.waitsForConnectivity)
+        #expect(configuration.timeoutIntervalForRequest == 5)
+        #expect(configuration.timeoutIntervalForResource == 5)
+    }
+
+    @Test("base endpoint configuration does not inherit explicit system proxies")
+    func baseEndpointDisablesExplicitSystemProxy() {
+        let configuration = SystemControlEndpointLoader.configuration(timeout: .seconds(2))
+
+        #expect(configuration.connectionProxyDictionary?.isEmpty == true)
+        #expect(configuration.proxyConfigurations.isEmpty)
+    }
+
+    @Test("app scopes the ATS HTTP exception to the Microsoft captive-portal/proxy endpoint")
+    func temporaryCaptivePortalATSException() {
+        let ats = Bundle.main.object(forInfoDictionaryKey: "NSAppTransportSecurity") as? [String: Any]
+        let domains = ats?["NSExceptionDomains"] as? [String: Any]
+        let exception = domains?["www.msftconnecttest.com"] as? [String: Any]
+
+        #expect(ats?.count == 1)
+        #expect(ats?["NSAllowsArbitraryLoads"] == nil)
+        #expect(domains?.count == 1)
+        #expect(exception?.count == 1)
+        #expect(exception?["NSExceptionAllowsInsecureHTTPLoads"] as? Bool == true)
+        #expect(exception?["NSIncludesSubdomains"] == nil)
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsDNSTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsDNSTests.swift
@@ -1,0 +1,98 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("DNS resolution preserves quorum, evidence, privacy, and fallback outcomes")
+    func dnsOutcomeMatrix() async {
+        let result = await DNSResolutionCheck(resolver: StubDNSResolver(.resolved)).run()
+
+        #expect(result.status == .normal)
+        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "3/3")))
+        #expect(result.evidence.contains(.init(code: "dns.failure-count", value: "0/3")))
+        #expect(result.evidence.contains(.init(code: "dns.indeterminate-count", value: "0/3")))
+
+        let mixed = await DNSResolutionCheck(
+            resolver: StubDNSResolver(outcomes: [.resolved, .failed, .resolved])
+        ).run()
+        #expect(mixed.status == .indeterminate)
+        #expect(mixed.evidence.contains(.init(code: "dns.success-count", value: "2/3")))
+        #expect(mixed.evidence.contains(.init(code: "dns.failure-count", value: "1/3")))
+
+        let mapped = await DNSResolutionCheck(
+            resolver: MappingDNSResolver(outcomes: [
+                "www.apple.com": .resolved,
+                "www.microsoft.com": .failed,
+                "www.msftconnecttest.com": .indeterminate,
+            ])
+        ).run()
+        #expect(mapped.evidence.contains(.init(code: "dns.sample.apple", value: "resolved")))
+        #expect(mapped.evidence.contains(.init(code: "dns.sample.microsoft", value: "failed")))
+        #expect(mapped.evidence.contains(.init(code: "dns.sample.msft-connect-test", value: "indeterminate")))
+        #expect(!mapped.evidence.contains { $0.value == "www.apple.com" })
+
+        let failed = await DNSResolutionCheck(resolver: StubDNSResolver(.failed)).run()
+        #expect(failed.status == .abnormal)
+        #expect(failed.evidence.contains(.init(code: "dns.success-count", value: "0/3")))
+        #expect(failed.evidence.contains(.init(code: "dns.failure-count", value: "3/3")))
+
+        let indeterminate = await DNSResolutionCheck(resolver: StubDNSResolver(.indeterminate)).run()
+        #expect(indeterminate.status == .indeterminate)
+        #expect(indeterminate.evidence.contains(.init(code: "dns.indeterminate-count", value: "3/3")))
+
+        let testDomain = "example.com"
+        let privateSummary = await DNSResolutionCheck(
+            resolver: StubDNSResolver(.resolved),
+            probeTargets: [testDomain, "example.net", "example.org"]
+        ).run()
+        #expect(!privateSummary.summary.localizedCaseInsensitiveContains(testDomain))
+    }
+
+    @Test("DNS uses the three authoritative third-party probe targets")
+    func dnsProbeTargets() {
+        let check = DNSResolutionCheck(resolver: StubDNSResolver(.resolved))
+
+        #expect(check.probeTargets == [
+            "www.apple.com",
+            "www.microsoft.com",
+            "www.msftconnecttest.com",
+        ])
+    }
+
+    @Test("independent DNS samples start concurrently and aggregate in target order")
+    func dnsSamplesRunConcurrently() async {
+        let resolver = ConcurrentDNSResolver()
+        let result = await DNSResolutionCheck(
+            resolver: resolver,
+            timeout: .seconds(1)
+        ).run()
+
+        #expect(await resolver.maximumInFlight == 3)
+        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "3/3")))
+    }
+
+    @Test("an indeterminate DNS sample is retried once")
+    func dnsIndeterminateSampleRetriesOnce() async {
+        let resolver = StubDNSResolver(outcomes: [.indeterminate, .resolved, .resolved, .resolved])
+        let result = await DNSResolutionCheck(resolver: resolver).run()
+
+        #expect(result.status == .normal)
+        #expect(await resolver.invocationCount == 4)
+    }
+
+    @Test("cancelling DNS sampling does not retry or exceed one attempt per host")
+    func dnsCancellationStopsSampling() async {
+        let resolver = CancellationAwareDNSResolver()
+        let check = DNSResolutionCheck(resolver: resolver, timeout: .seconds(30))
+        let task = Task { await check.run() }
+
+        await resolver.waitForInvocation()
+        task.cancel()
+        _ = await task.value
+
+        #expect(await resolver.invocationCount <= 3)
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsPresentationTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsPresentationTests.swift
@@ -1,0 +1,154 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("stage resolver aggregates this mac from path dns and proxy and maps lan to its check")
+    func stageResolverThisMacAndLan() {
+        let resolver = NetworkDiagnosticStageResolver()
+        let abnormalDNS: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .path: .init(id: .path, status: .normal, summary: ""),
+            .dns: .init(id: .dns, status: .abnormal, summary: ""),
+            .proxy: .init(id: .proxy, status: .normal, summary: ""),
+            .gatewayReachability: .init(id: .gatewayReachability, status: .normal, summary: ""),
+        ]
+
+        #expect(resolver.status(for: .thisMac, results: abnormalDNS) == .abnormal)
+        #expect(resolver.status(for: .lan, results: abnormalDNS) == .normal)
+        let proxyOnly: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .path: .init(id: .path, status: .normal, summary: ""),
+            .dns: .init(id: .dns, status: .normal, summary: ""),
+            .proxy: .init(id: .proxy, status: .abnormal, summary: ""),
+            .gatewayReachability: .init(id: .gatewayReachability, status: .normal, summary: ""),
+        ]
+        #expect(resolver.status(for: .thisMac, results: proxyOnly) == .abnormal)
+        #expect(resolver.status(for: .thisMac, results: [:]) == nil)
+        let missingContributors: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .path: .init(id: .path, status: .normal, summary: ""),
+        ]
+        #expect(resolver.status(for: .thisMac, results: missingContributors) == nil)
+
+        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .normal, summary: "")]) == .normal)
+        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .abnormal, summary: "")]) == .abnormal)
+        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .indeterminate, summary: "")]) == .indeterminate)
+        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .blocked, summary: "")]) == .blocked)
+        let extras: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .internet: .init(id: .internet, status: .normal, summary: ""),
+            .dns: .init(id: .dns, status: .abnormal, summary: ""),
+            .ipv6: .init(id: .ipv6, status: .abnormal, summary: ""),
+        ]
+        #expect(resolver.status(for: .internet, results: extras) == .normal)
+        let partial: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .dns: .init(id: .dns, status: .normal, summary: ""),
+        ]
+
+        #expect(resolver.status(for: .internet, results: partial) == nil)
+    }
+
+    @Test("pipeline presentation maps stages to stations and edges")
+    func pipelinePresentation() {
+        let results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
+            .path: .init(id: .path, status: .normal, summary: ""),
+            .gatewayReachability: .init(id: .gatewayReachability, status: .abnormal, summary: ""),
+            .dns: .init(id: .dns, status: .normal, summary: ""),
+            .internet: .init(id: .internet, status: .normal, summary: ""),
+            .ipv6: .init(id: .ipv6, status: .skipped, summary: ""),
+            .proxy: .init(id: .proxy, status: .normal, summary: ""),
+        ]
+        let presentation = NetworkDiagnosticsPipelinePresentation.from(
+            results: results,
+            executionPhases: [:]
+        )
+
+        #expect(presentation.stations.map(\.kind) == [.thisMac, .router, .internet])
+        #expect(presentation.edges.map(\.kind) == [.lan, .internet])
+        #expect(presentation.stations[0].status == .normal)
+        #expect(presentation.stations[1].status == .abnormal)
+        #expect(presentation.stations[1].isUnreachable)
+        #expect(presentation.stations[2].status == .normal)
+        #expect(!presentation.stations[2].isUnreachable)
+        #expect(presentation.edges[0].status == .abnormal)
+        #expect(presentation.edges[1].status == .normal)
+
+        let executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase] = [
+            .gatewayReachability: .checking,
+        ]
+        let activePresentation = NetworkDiagnosticsPipelinePresentation.from(
+            results: [:],
+            executionPhases: executionPhases
+        )
+
+        #expect(activePresentation.edges[0].isActive)
+        #expect(!activePresentation.edges[1].isActive)
+    }
+
+    @Test("workbench items interleave stage headers with check rows")
+    func workbenchItemGrouping() {
+        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 519) == .compact)
+        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 520) == .condensed)
+        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 719) == .condensed)
+        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 720) == .regular)
+
+        let path = NetworkDiagnosticResult(
+            id: .path,
+            status: .normal,
+            summary: "connected"
+        )
+        let executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase] = [
+            .path: .completed,
+            .dns: .checking,
+            .proxy: .waiting,
+        ]
+
+        #expect(NetworkDiagnosticsPresentation.workbenchItems(
+            pagePhase: .idle,
+            executionPhases: executionPhases,
+            results: [:]
+        ).isEmpty)
+
+        let runningItems = NetworkDiagnosticsPresentation.workbenchItems(
+            pagePhase: .running,
+            executionPhases: executionPhases,
+            results: [.path: path],
+            checkIDs: [.path, .dns, .proxy]
+        )
+        #expect(runningItems.map(\.id) == ["header.thisMac", "check.path", "check.dns"])
+        #expect(runningItems[0] == .stageHeader(.thisMac))
+        #expect(runningItems[1] == .check(.init(id: .path, executionPhase: .completed, result: path)))
+
+        let completedResults = Dictionary(uniqueKeysWithValues: makeResults(
+            path: .normal,
+            dns: .abnormal,
+            internet: .normal,
+            proxy: .indeterminate
+        ).map { ($0.id, $0) })
+        let completedItems = NetworkDiagnosticsPresentation.workbenchItems(
+            pagePhase: .completed,
+            executionPhases: executionPhases,
+            results: completedResults,
+            checkIDs: [.path, .dns, .ipv6, .proxy]
+        )
+        #expect(completedItems.map(\.id) == [
+            "header.thisMac", "check.path", "check.dns", "check.proxy",
+            "header.additional", "check.ipv6",
+        ])
+        #expect(completedItems[4] == .additionalHeader)
+
+        let timedOutItems = NetworkDiagnosticsPresentation.workbenchItems(
+            pagePhase: .completed,
+            executionPhases: [.path: .completed, .dns: .waiting],
+            results: [.path: path],
+            checkIDs: [.path, .dns],
+            endReason: .timedOut
+        )
+        #expect(timedOutItems.last == .check(.init(
+            id: .dns,
+            executionPhase: .waiting,
+            result: nil,
+            pendingReason: .timedOut
+        )))
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsProxyTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsProxyTests.swift
@@ -1,0 +1,970 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("proxy configuration and candidate parsing preserve routing semantics")
+    func proxyConfigurationAndCandidateMatrices() {
+        let configuration = SystemProxyConfiguration(settings: [
+            "HTTPEnable": 1,
+            "HTTPProxy": " Proxy.Example ",
+            "HTTPPort": 8080,
+            "HTTPSEnable": 1,
+            "HTTPSProxy": "proxy.example",
+            "HTTPSPort": 8080,
+            "SOCKSEnable": 1,
+            "SOCKSProxy": "socks.example",
+            "SOCKSPort": 1080,
+        ])
+
+        #expect(configuration.endpoints == [
+            ProxyEndpoint(host: "proxy.example", port: 8080),
+            ProxyEndpoint(host: "socks.example", port: 1080),
+        ])
+        #expect(!configuration.hasInvalidExplicitProxy)
+
+        let pacConfiguration = SystemProxyConfiguration(settings: [
+            "ProxyAutoConfigEnable": 1,
+            "ProxyAutoConfigURLString": "https://proxy.example/config.pac",
+            "ProxyAutoDiscoveryEnable": 1,
+        ])
+
+        #expect(pacConfiguration.pacEnabled)
+        #expect(pacConfiguration.pacURL == "https://proxy.example/config.pac")
+        #expect(pacConfiguration.autoDiscoveryEnabled)
+
+        let staticCandidates = SystemProxyResolver.candidates(from: [
+            proxyDictionary(type: kCFProxyTypeHTTP, host: "127.0.0.1", port: 7890),
+            proxyDictionary(type: kCFProxyTypeNone),
+        ])
+        #expect(staticCandidates == [
+            .http(.init(host: "127.0.0.1", port: 7890)),
+            .direct,
+        ])
+
+        let pacCandidates = SystemPACResolver.resolution(from: [
+            proxyDictionary(type: kCFProxyTypeHTTP, host: "proxy.example", port: 8080),
+            proxyDictionary(type: kCFProxyTypeNone),
+        ])
+        #expect(pacCandidates == ProxyCandidateResolution(
+            candidates: [
+                .http(.init(host: "proxy.example", port: 8080)),
+                .direct,
+            ],
+            evidenceCodes: []
+        ))
+
+        let script = "function FindProxyForURL(url, host) { return 'DIRECT'; }"
+        let dictionary: NSDictionary = [
+            kCFProxyTypeKey as String: kCFProxyTypeAutoConfigurationJavaScript,
+            kCFProxyAutoConfigurationJavaScriptKey as String: script,
+        ]
+        #expect(SystemProxyResolver.directive(from: dictionary) == .pacScript(script))
+        #expect(SystemProxyResolver.directive(from: proxyDictionary(
+            type: kCFProxyTypeHTTP,
+            host: " \n\t ",
+            port: 8080
+        )) == .unavailable("proxy-endpoint-invalid"))
+        let directDictionary: NSDictionary = [
+            kCFProxyTypeKey as String: kCFProxyTypeNone,
+        ]
+        #expect(SystemProxyResolver.directive(from: directDictionary) == .direct)
+    }
+
+    @Test("PAC result chooses DIRECT without probing a stale explicit endpoint")
+    func pacCanChooseDirect() async {
+        let controlURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let recorder = PACResolutionTestRecorder()
+        let resolver = SystemProxyResolver(
+            pacTimeout: .milliseconds(25),
+            configurationResolver: StubProxyConfigurationResolver(.pac(pacURL)),
+            pacResolver: StubPACResolver(.direct, recorder: recorder)
+        )
+        let resolution = await resolver.resolve(for: controlURL)
+
+        #expect(resolution == ProxyCandidateResolution(candidates: [.direct], evidenceCodes: []))
+        #expect(await recorder.requests == [
+            .init(pacURL: pacURL, targetURL: controlURL, timeout: .milliseconds(25)),
+        ])
+    }
+
+    @Test("inline PAC scripts execute at their ordered directive position")
+    func inlinePACScriptPreservesDirectiveOrder() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let script = "function FindProxyForURL(url, host) { return 'SOCKS proxy.example:1080'; }"
+        let first = EffectiveProxy.http(.init(host: "first.example", port: 8080))
+        let inline = EffectiveProxy.socks(.init(host: "proxy.example", port: 1080))
+        let executor = ControlledPACCallbackExecutor()
+        let resolver = SystemProxyResolver(
+            configurationResolver: StubProxyConfigurationResolver([
+                .http(.init(host: "first.example", port: 8080)),
+                .pacScript(script),
+                .direct,
+            ]),
+            pacResolver: SystemPACResolver(callbackExecutor: executor)
+        )
+        let task = Task { await resolver.resolve(for: target) }
+
+        let request = await executor.nextRequest()
+        #expect(request == .init(source: .script(script), targetURL: target))
+        executor.complete(.success(.init(candidates: [inline], evidenceCodes: [])))
+        let resolution = await task.value
+
+        #expect(resolution == .init(candidates: [first, inline, .direct], evidenceCodes: []))
+    }
+
+    @Test("PAC callback errors resume with execution-failed evidence")
+    func pacCallbackErrorResumesContinuation() async {
+        let target = URL(string: "https://www.apple.com/")!
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let executor = ControlledPACCallbackExecutor()
+        let resolver = SystemPACResolver(callbackExecutor: executor)
+        let task = Task {
+            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .seconds(30))
+        }
+
+        let request = await executor.nextRequest()
+        #expect(request == .init(source: .url(pacURL), targetURL: target))
+        executor.complete(.failure)
+        let resolution = await task.value
+
+        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-execution-failed"]))
+        #expect(executor.executionWasCancelled)
+    }
+
+    @Test("PAC callback cancellation resumes once with cancellation evidence")
+    func pacCallbackCancellationResumesContinuation() async {
+        let target = URL(string: "https://www.apple.com/")!
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let executor = ControlledPACCallbackExecutor()
+        let resolver = SystemPACResolver(callbackExecutor: executor)
+        let task = Task {
+            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .seconds(30))
+        }
+
+        _ = await executor.nextRequest()
+        task.cancel()
+        let resolution = await task.value
+
+        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-cancelled"]))
+        #expect(executor.executionWasCancelled)
+    }
+
+    @Test("PAC callback timeout resumes once and cancels execution")
+    func pacCallbackTimeoutResumesContinuation() async {
+        let target = URL(string: "https://www.apple.com/")!
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let executor = ControlledPACCallbackExecutor()
+        let resolver = SystemPACResolver(callbackExecutor: executor)
+        let task = Task {
+            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .milliseconds(10))
+        }
+
+        _ = await executor.nextRequest()
+        let resolution = await task.value
+
+        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-timeout"]))
+        #expect(executor.executionWasCancelled)
+    }
+
+    @Test("invalid proxy candidate preserves later valid candidate and evidence")
+    func invalidProxyCandidatePreservesLaterCandidate() async {
+        let validProxy = EffectiveProxy.http(.init(host: "proxy.example", port: 8080))
+        let resolver = SystemProxyResolver(
+            configurationResolver: StubProxyConfigurationResolver(
+                SystemProxyResolver.directives(from: [
+                    proxyDictionary(type: kCFProxyTypeHTTP),
+                    proxyDictionary(
+                        type: kCFProxyTypeHTTP,
+                        host: "proxy.example",
+                        port: 8080
+                    ),
+                ])
+            ),
+            pacResolver: StubPACResolver(.direct)
+        )
+
+        let resolution = await resolver.resolve(
+            for: URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        )
+
+        #expect(resolution.candidates == [validProxy])
+        #expect(resolution.evidenceCodes == ["proxy-endpoint-invalid"])
+    }
+
+    @Test("DIRECT does not probe a stale explicit endpoint or proxy egress")
+    func directSkipsStaleProxy() async {
+        let connectorRecorder = ProxyConnectorTestRecorder()
+        let egressRecorder = ProxyEgressTestRecorder()
+        let check = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: RecordingProxyConnector(reachable: false, recorder: connectorRecorder),
+            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected", recorder: egressRecorder),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let result = await check.run()
+
+        #expect(result.status == .indeterminate)
+        #expect(await connectorRecorder.endpoints.isEmpty)
+        #expect(await egressRecorder.requests.isEmpty)
+    }
+
+    @Test("tunnel route detection preserves source and candidate priority")
+    func tunnelRouteMatrix() async {
+        let check = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: StubProxyConnector(reachable: false),
+            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
+            tunnelReader: StubProxyTunnelStateReader(interface: "utun98")
+        )
+
+        let result = await check.run()
+
+        #expect(result.status == .normal)
+        #expect(result.summary == String(
+            localized: "network_diagnostics.proxy.tunnel_routes.summary",
+            comment: "Network self-check tunneled proxy route result summary"
+        ))
+        #expect(result.evidence.contains(.init(code: "proxy.http.route-type", value: "tunnel")))
+        #expect(result.evidence.contains(.init(code: "proxy.https.route-type", value: "tunnel")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.tunnel-interface", value: "utun98")))
+        #expect(result.evidence.contains(.init(code: "proxy.https.tunnel-interface", value: "utun98")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.tunnel-detection-source", value: "nwpath")))
+        #expect(result.evidence.contains(.init(code: "proxy.https.tunnel-detection-source", value: "nwpath")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.egress-status", value: "base-check")))
+
+        let activeResult = await SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: StubProxyConnector(reachable: false),
+            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
+            tunnelReader: StubProxyTunnelStateReader(
+                interface: "utun98",
+                source: .activeInterface
+            )
+        ).run()
+
+        #expect(activeResult.status == .normal)
+        #expect(activeResult.summary == String(
+            localized: "network_diagnostics.proxy.tunnel_routes_active.summary",
+            comment: "Network self-check active tunnel interface proxy route result summary"
+        ))
+        #expect(activeResult.evidence.contains(.init(code: "proxy.http.route-type", value: "tunnel")))
+        #expect(activeResult.evidence.contains(.init(code: "proxy.http.tunnel-detection-source", value: "active-interface")))
+        #expect(activeResult.evidence.contains(.init(code: "proxy.https.tunnel-detection-source", value: "active-interface")))
+
+        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
+            pathRouted: "utun3",
+            activeIPv4Tunnels: ["utun98"]
+        ) == ProxyTunnelState(interface: "utun3", source: .nwpath))
+        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
+            pathRouted: nil,
+            activeIPv4Tunnels: ["utun98"]
+        ) == ProxyTunnelState(interface: "utun98", source: .activeInterface))
+        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
+            pathRouted: nil,
+            activeIPv4Tunnels: []
+        ) == nil)
+    }
+
+    @Test("tunnel path wait returns nil when the timeout fires before any path")
+    func tunnelPathWaitTimeoutWins() async {
+        let streamTerminated = LockedFlag()
+        let neverEnding = AsyncStream<NWPath> { continuation in
+            continuation.onTermination = { _ in streamTerminated.set() }
+        }
+
+        let path = await SystemProxyTunnelStateReader.firstPath(
+            from: neverEnding,
+            timeout: {}
+        )
+
+        #expect(path == nil)
+        #expect(streamTerminated.isSet)
+    }
+
+    @Test("tunnel path wait cancels the pending timeout when the path side completes first")
+    func tunnelPathWaitCancelsPendingTimeout() async {
+        let probe = TunnelTimeoutCancellationProbe()
+        let finished = AsyncStream<NWPath> { continuation in
+            continuation.finish()
+        }
+
+        let path = await SystemProxyTunnelStateReader.firstPath(
+            from: finished,
+            timeout: { await probe.park() }
+        )
+
+        #expect(path == nil)
+        #expect(probe.didCancel)
+    }
+
+    @Test("failed proxy candidate falls back to DIRECT for the same target")
+    func failedProxyCandidateFallsBackToDirect() async {
+        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let staleEndpoint = ProxyEndpoint(host: "stale.example", port: 8080)
+        let connectorRecorder = ProxyConnectorTestRecorder()
+        let egressRecorder = ProxyEgressTestRecorder()
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [
+                httpURL: .init(candidates: [.http(staleEndpoint), .direct], evidenceCodes: []),
+                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
+            ]),
+            connector: RecordingProxyConnector(reachable: false, recorder: connectorRecorder),
+            egressLoader: StubProxyEgressLoader(
+                statusCode: 200,
+                recorder: egressRecorder
+            ),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let result = await check.run()
+
+        #expect(result.status == .indeterminate)
+        #expect(result.evidence.contains(.init(code: "proxy.http.endpoint-status", value: "unavailable")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.candidate-index", value: "1")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.route-type", value: "direct")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.fallback-used", value: "true")))
+        #expect(await connectorRecorder.endpoints == [staleEndpoint])
+        #expect(await egressRecorder.requests.isEmpty)
+    }
+
+    @Test("failed first proxy tries the next proxy candidate")
+    func failedFirstProxyTriesNextProxy() async {
+        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let staleEndpoint = ProxyEndpoint(host: "stale.example", port: 8080)
+        let workingEndpoint = ProxyEndpoint(host: "working.example", port: 8081)
+        let selectedProxy = EffectiveProxy.http(workingEndpoint)
+        let connector = SequencedProxyConnector(outcomes: [false, true])
+        let egressRecorder = ProxyEgressTestRecorder()
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [
+                httpURL: .init(
+                    candidates: [.http(staleEndpoint), selectedProxy],
+                    evidenceCodes: []
+                ),
+                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
+            ]),
+            connector: connector,
+            egressLoader: StubProxyEgressLoader(statusCode: 204, recorder: egressRecorder),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let result = await check.run()
+
+        #expect(result.status == .indeterminate)
+        #expect(await connector.endpoints == [staleEndpoint, workingEndpoint])
+        #expect(await egressRecorder.requests.map(\.proxy) == [selectedProxy])
+        #expect(result.evidence.contains(.init(code: "proxy.http.candidate-index", value: "1")))
+        #expect(result.evidence.contains(.init(code: "proxy.http.fallback-used", value: "true")))
+    }
+
+    @Test("candidate attempts share one controlled overall timeout")
+    func proxyCandidateAttemptsShareTimeout() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
+        let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
+        let connector = SequencedProxyConnector(outcomes: [true, true])
+        let egressLoader = SequencedProxyEgressLoader(
+            responses: [
+                .init(statusCode: nil, errorCode: "timed-out"),
+                .init(statusCode: 200, errorCode: nil),
+            ],
+            delays: [.zero, .zero]
+        )
+        let clock = SequencedProxyCheckClock(offsets: [
+            .zero,
+            .zero,
+            .milliseconds(250),
+            .milliseconds(1_200),
+            .milliseconds(1_300),
+        ])
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [:]),
+            connector: connector,
+            egressLoader: egressLoader,
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+            timeout: .seconds(2),
+            clock: clock
+        )
+
+        let result = await check.evaluate(
+            target: target,
+            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
+            timeout: .seconds(2)
+        )
+
+        #expect(result.status == .proxied)
+        #expect(result.selectedCandidateIndex == 1)
+        #expect(result.selectedProxy == secondProxy)
+        #expect(await connector.endpoints == [
+            .init(host: "first.example", port: 8080),
+            .init(host: "second.example", port: 8081),
+        ])
+        #expect(await connector.timeouts == [.seconds(1), .milliseconds(800)])
+        #expect(await egressLoader.timeouts == [.milliseconds(750), .milliseconds(700)])
+    }
+
+    @Test("an expired overall proxy timeout does not start another candidate")
+    func expiredProxyTimeoutStopsCandidateFallback() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
+        let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
+        let connector = SequencedProxyConnector(outcomes: [true, true])
+        let egressLoader = SequencedProxyEgressLoader(
+            responses: [.init(statusCode: nil, errorCode: "timed-out")],
+            delays: [.zero]
+        )
+        let clock = SequencedProxyCheckClock(offsets: [
+            .zero,
+            .zero,
+            .milliseconds(250),
+            .milliseconds(2_100),
+        ])
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [:]),
+            connector: connector,
+            egressLoader: egressLoader,
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+            timeout: .seconds(2),
+            clock: clock
+        )
+
+        let result = await check.evaluate(
+            target: target,
+            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
+            timeout: .seconds(2)
+        )
+
+        #expect(result.status == .unavailable)
+        #expect(await connector.endpoints == [.init(host: "first.example", port: 8080)])
+        #expect(await connector.timeouts == [.seconds(1)])
+        #expect(await egressLoader.timeouts == [.milliseconds(750)])
+        #expect(result.evidence.contains(.init(code: "proxy.http.timeout", value: "expired")))
+    }
+
+    @Test("proxy check resolves the HTTP and HTTPS targets independently")
+    func proxyTargetsAreResolvedIndependently() async {
+        let recorder = ProxyResolutionTestRecorder()
+        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let httpsProxy = EffectiveProxy.https(.init(host: "secure-proxy.example", port: 8443))
+        let resolver = RecordingProxyResolver(
+            resolutions: [
+                httpURL: .init(candidates: [.direct], evidenceCodes: []),
+                httpsURL: .init(candidates: [httpsProxy], evidenceCodes: []),
+            ],
+            recorder: recorder
+        )
+        let check = SystemProxyCheck(
+            resolver: resolver,
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let result = await check.run()
+        let resolvedURLs = await recorder.urls
+
+        #expect(resolvedURLs.count == 2)
+        #expect(Set(resolvedURLs) == Set([httpURL.absoluteString, httpsURL.absoluteString]))
+        #expect(result.status == .indeterminate)
+        #expect(result.summary == String(
+            localized: "network_diagnostics.proxy.mixed_routing.summary",
+            comment: "Network self-check mixed target proxy routing result summary"
+        ))
+    }
+
+    @Test("proxy target routes preserve direct, proxied, and unresolved outcome states")
+    func proxyTargetOutcomeMatrix() async {
+        let recorder = ProxyResolutionTestRecorder()
+        let resolver = RecordingProxyResolver(
+            defaultResolution: .init(candidates: [.direct], evidenceCodes: []),
+            recorder: recorder
+        )
+
+        let result = await SystemProxyCheck(
+            resolver: resolver,
+            connector: StubProxyConnector(reachable: false),
+            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(result.status == .indeterminate)
+        #expect(result.summary == String(
+            localized: "network_diagnostics.proxy.direct_routes.summary",
+            comment: "Network self-check direct target routes result summary"
+        ))
+        #expect(result.summary != String(
+            localized: "network_diagnostics.proxy.disabled.summary",
+            comment: "Network self-check system proxy disabled result summary"
+        ))
+        #expect(Set(await recorder.urls) == Set([
+            "http://www.msftconnecttest.com/connecttest.txt",
+            "https://www.apple.com/",
+        ]))
+
+
+        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let proxiedResolver = RecordingProxyResolver(resolutions: [
+            httpURL: .init(
+                candidates: [.http(.init(host: "proxy.example", port: 8080))],
+                evidenceCodes: []
+            ),
+            httpsURL: .init(
+                candidates: [.https(.init(host: "proxy.example", port: 8443))],
+                evidenceCodes: []
+            ),
+        ])
+
+        let proxiedResult = await SystemProxyCheck(
+            resolver: proxiedResolver,
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(proxiedResult.status == .normal)
+        #expect(proxiedResult.proxyFacts == .init(http: .available, https: .available))
+        #expect(proxiedResult.summary == String(
+            localized: "network_diagnostics.proxy.routes_available.summary",
+            comment: "Network self-check proxy target routes available result summary"
+        ))
+
+        let authenticatedResolver = RecordingProxyResolver(resolutions: [
+            httpURL: .init(
+                candidates: [.http(.init(host: "proxy.example", port: 8080))],
+                evidenceCodes: []
+            ),
+            httpsURL: .init(candidates: [.direct], evidenceCodes: []),
+        ])
+
+        let authenticatedResult = await SystemProxyCheck(
+            resolver: authenticatedResolver,
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 407),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(authenticatedResult.status == .abnormal)
+        #expect(authenticatedResult.summary == String(
+            localized: "network_diagnostics.proxy.authentication_required.summary",
+            comment: "Network self-check proxy authentication required result summary"
+        ))
+        #expect(authenticatedResult.evidence.contains(.init(
+            code: "proxy.http.authentication-status",
+            value: "required"
+        )))
+        #expect(authenticatedResult.evidence.contains(.init(code: "proxy.http.egress-status", value: "407")))
+
+        let unavailableResolver = RecordingProxyResolver(defaultResolution: .init(
+            candidates: [.http(.init(host: "stale.example", port: 8080))],
+            evidenceCodes: []
+        ))
+
+        let unavailableResult = await SystemProxyCheck(
+            resolver: unavailableResolver,
+            connector: StubProxyConnector(reachable: false),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(unavailableResult.status == .abnormal)
+        #expect(unavailableResult.summary == String(
+            localized: "network_diagnostics.proxy.route_unavailable.summary",
+            comment: "Network self-check proxy target route unavailable result summary"
+        ))
+        #expect(unavailableResult.evidence.contains(.init(
+            code: "proxy.http.endpoint-status",
+            value: "unavailable"
+        )))
+        #expect(unavailableResult.evidence.contains(.init(
+            code: "proxy.https.endpoint-status",
+            value: "unavailable"
+        )))
+
+        let emptyResolutionResult = await SystemProxyCheck(
+            resolver: RecordingProxyResolver(defaultResolution: .init(
+                candidates: [],
+                evidenceCodes: ["resolution-empty"]
+            )),
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(emptyResolutionResult.status == .indeterminate)
+        #expect(emptyResolutionResult.summary == String(
+            localized: "network_diagnostics.proxy.unable_to_determine.summary",
+            comment: "Network self-check target proxy routing indeterminate result summary"
+        ))
+        #expect(emptyResolutionResult.evidence.contains(.init(
+            code: "proxy.http.resolution",
+            value: "resolution-empty"
+        )))
+        #expect(emptyResolutionResult.evidence.contains(.init(
+            code: "proxy.https.resolution",
+            value: "resolution-empty"
+        )))
+
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let pacTimeoutResult = await SystemProxyCheck(
+            resolver: SystemProxyResolver(
+                configurationResolver: StubProxyConfigurationResolver(.pac(pacURL)),
+                pacResolver: StubPACResolver(.unavailable("pac-timeout"))
+            ),
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(pacTimeoutResult.status == .indeterminate)
+        #expect(pacTimeoutResult.summary == String(
+            localized: "network_diagnostics.proxy.unable_to_determine.summary",
+            comment: "Network self-check target proxy routing indeterminate result summary"
+        ))
+        #expect(pacTimeoutResult.evidence.contains(.init(code: "proxy.http.resolution", value: "pac-timeout")))
+        #expect(pacTimeoutResult.evidence.contains(.init(code: "proxy.https.resolution", value: "pac-timeout")))
+    }
+
+    @Test("proxy failure outcomes preserve endpoint, authentication, timeout, and egress causes")
+    func proxyFailureOutcomeMatrix() async {
+        let egressRecorder = ProxyEgressTestRecorder()
+        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
+        let endpointCheck = SystemProxyCheck(
+            resolver: StubProxyResolver(proxy),
+            connector: StubProxyConnector(reachable: false),
+            egressLoader: StubProxyEgressLoader(statusCode: 200, recorder: egressRecorder),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let endpointResult = await endpointCheck.run()
+
+        #expect(endpointResult.status == .abnormal)
+        #expect(endpointResult.summary == String(
+            localized: "network_diagnostics.proxy.route_unavailable.summary",
+            comment: "Network self-check proxy target route unavailable result summary"
+        ))
+        #expect(endpointResult.evidence.contains(.init(code: "proxy.endpoint-unavailable", value: nil)))
+        #expect(await egressRecorder.requests.isEmpty)
+
+        let authenticationCheck = SystemProxyCheck(
+            resolver: StubProxyResolver(proxy),
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 407),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let authenticationResult = await authenticationCheck.run()
+
+        #expect(authenticationResult.status == .abnormal)
+        #expect(authenticationResult.summary == String(
+            localized: "network_diagnostics.proxy.authentication_required.summary",
+            comment: "Network self-check proxy authentication required result summary"
+        ))
+        #expect(authenticationResult.evidence.contains(.init(code: "proxy.authentication-required", value: "407")))
+        #expect(!authenticationResult.evidence.contains(where: { $0.code == "proxy.endpoint-unavailable" }))
+
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let endpoint = ProxyEndpoint(host: "proxy.example", port: 8080)
+        let connectorRecorder = ProxyConnectorTestRecorder()
+        let timeoutCheck = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: RecordingProxyConnector(reachable: true, recorder: connectorRecorder),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+        let expiredRoute = await timeoutCheck.evaluate(
+            target: target,
+            resolution: .init(candidates: [.http(endpoint)], evidenceCodes: []),
+            timeout: .zero
+        )
+        #expect(expiredRoute.status == .indeterminate)
+        #expect(expiredRoute.selectedCandidateIndex == nil)
+        #expect(expiredRoute.selectedProxy == nil)
+        #expect(expiredRoute.evidence.contains(.init(code: "proxy.http.timeout", value: "expired")))
+        #expect(await connectorRecorder.endpoints.isEmpty)
+    }
+
+    @Test("URL loading authentication challenge remains a proxy 407 result")
+    func proxyAuthenticationChallenge() {
+        let response = SystemProxyEgressLoader.response(
+            for: URLError(.userAuthenticationRequired)
+        )
+
+        #expect(response == ProxyEgressResponse(statusCode: 407, errorCode: nil))
+    }
+
+    @Test("production tunneled egress configuration disables selected proxy failover")
+    func selectedProxyDoesNotFailOver() throws {
+        let proxy = EffectiveProxy.https(ProxyEndpoint(host: "proxy.example", port: 8080))
+        let configuration = try #require(
+            SystemProxyEgressLoader.configuration(for: proxy, timeout: .seconds(3))
+        )
+
+        #expect(configuration.proxyConfigurations.count == 1)
+        #expect(configuration.proxyConfigurations[0].allowFailover == false)
+        #expect(configuration.connectionProxyDictionary?.isEmpty != false)
+        #expect(configuration.urlCredentialStorage == nil)
+    }
+
+    @Test("HTTP forward HTTPS tunnel and SOCKS candidates use distinct transport configurations")
+    func selectedProxyTransportConfigurationsPreserveSemantics() throws {
+        let endpoint = ProxyEndpoint(host: "proxy.example", port: 8080)
+        let httpConfiguration = try #require(SystemProxyEgressLoader.configuration(
+            for: .http(endpoint),
+            timeout: .seconds(3)
+        ))
+        let httpsConfiguration = try #require(SystemProxyEgressLoader.configuration(
+            for: .https(endpoint),
+            timeout: .seconds(3)
+        ))
+        let socksConfiguration = try #require(SystemProxyEgressLoader.configuration(
+            for: .socks(endpoint),
+            timeout: .seconds(3)
+        ))
+
+        let httpDictionary = try #require(httpConfiguration.connectionProxyDictionary)
+        #expect((httpDictionary[kCFNetworkProxiesHTTPEnable as String] as? NSNumber)?.boolValue == true)
+        #expect(httpDictionary[kCFNetworkProxiesHTTPProxy as String] as? String == endpoint.host)
+        #expect((httpDictionary[kCFNetworkProxiesHTTPPort as String] as? NSNumber)?.intValue == Int(endpoint.port))
+        #expect((httpDictionary[kCFNetworkProxiesHTTPSEnable as String] as? NSNumber)?.boolValue == false)
+        #expect((httpDictionary[kCFNetworkProxiesSOCKSEnable as String] as? NSNumber)?.boolValue == false)
+        #expect((httpDictionary[kCFNetworkProxiesProxyAutoConfigEnable as String] as? NSNumber)?.boolValue == false)
+        #expect((httpDictionary[kCFNetworkProxiesProxyAutoDiscoveryEnable as String] as? NSNumber)?.boolValue == false)
+        #expect(httpConfiguration.proxyConfigurations.isEmpty)
+
+        #expect(httpsConfiguration.connectionProxyDictionary?.isEmpty == true)
+        #expect(httpsConfiguration.proxyConfigurations.count == 1)
+        #expect(httpsConfiguration.proxyConfigurations[0].debugDescription.contains("http_connect"))
+        #expect(httpsConfiguration.proxyConfigurations[0].allowFailover == false)
+
+        #expect(socksConfiguration.connectionProxyDictionary?.isEmpty == true)
+        #expect(socksConfiguration.proxyConfigurations.count == 1)
+        #expect(socksConfiguration.proxyConfigurations[0].debugDescription.contains("socksv5"))
+        #expect(socksConfiguration.proxyConfigurations[0].allowFailover == false)
+    }
+
+    @Test("later success after 407 selects that candidate and skips the trailing route")
+    func proxySuccessAfterAuthenticationShortCircuitsTrailingCandidate() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let firstEndpoint = ProxyEndpoint(host: "auth.example", port: 8080)
+        let selectedEndpoint = ProxyEndpoint(host: "working.example", port: 8081)
+        let trailingEndpoint = ProxyEndpoint(host: "unused.example", port: 8082)
+        let first = EffectiveProxy.http(firstEndpoint)
+        let selected = EffectiveProxy.http(selectedEndpoint)
+        let trailing = EffectiveProxy.http(trailingEndpoint)
+        let connector = SequencedProxyConnector(outcomes: [true, true, true])
+        let egress = SequencedProxyEgressLoader(
+            responses: [
+                .init(statusCode: 407, errorCode: nil),
+                .init(statusCode: 204, errorCode: nil),
+                .init(statusCode: 200, errorCode: nil),
+            ],
+            delays: [.zero, .zero, .zero]
+        )
+        let check = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: connector,
+            egressLoader: egress,
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let route = await check.evaluate(
+            target: target,
+            resolution: .init(candidates: [first, selected, trailing], evidenceCodes: []),
+            timeout: .seconds(3)
+        )
+
+        #expect(route.status == .proxied)
+        #expect(route.selectedCandidateIndex == 1)
+        #expect(route.selectedProxy == selected)
+        #expect(await connector.endpoints == [firstEndpoint, selectedEndpoint])
+        #expect(await egress.timeouts.count == 2)
+    }
+
+    @Test("proxy aggregation preserves authentication and egress failure severity")
+    func proxyFailureAggregationMatrix() async {
+        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let httpProxy = EffectiveProxy.http(.init(host: "auth.example", port: 8080))
+        let httpsProxy = EffectiveProxy.https(.init(host: "stale.example", port: 8443))
+        let connector = EndpointSelectiveProxyConnector(reachableHosts: ["auth.example"])
+        let result = await SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [
+                httpURL: .init(candidates: [httpProxy], evidenceCodes: []),
+                httpsURL: .init(candidates: [httpsProxy], evidenceCodes: []),
+            ]),
+            connector: connector,
+            egressLoader: StubProxyEgressLoader(statusCode: 407),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(result.status == .abnormal)
+        #expect(result.summary == String(
+            localized: "network_diagnostics.proxy.authentication_required.summary",
+            comment: "Network self-check proxy authentication required result summary"
+        ))
+        #expect(result.evidence.contains(.init(code: "proxy.http.authentication-status", value: "required")))
+        #expect(result.evidence.contains(.init(code: "proxy.https.endpoint-status", value: "unavailable")))
+
+        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
+        let egressResult = await SystemProxyCheck(
+            resolver: StubProxyResolver(proxy),
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "-1005"),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        ).run()
+
+        #expect(egressResult.status == .abnormal)
+        #expect(egressResult.summary == String(
+            localized: "network_diagnostics.proxy.route_unavailable.summary",
+            comment: "Network self-check proxy target route unavailable result summary"
+        ))
+        #expect(egressResult.evidence.contains(.init(code: "proxy.egress-unavailable", value: "-1005")))
+    }
+
+    @Test("selected HTTP proxy probes the same control URL once")
+    func selectedProxyEgressSuccess() async {
+        let controlURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let httpsURL = URL(string: "https://www.apple.com/")!
+        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
+        let recorder = ProxyEgressTestRecorder()
+        let check = SystemProxyCheck(
+            resolver: RecordingProxyResolver(resolutions: [
+                controlURL: .init(candidates: [proxy], evidenceCodes: []),
+                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
+            ]),
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200, recorder: recorder),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+
+        let result = await check.run()
+
+        #expect(result.status == .indeterminate)
+        #expect(await recorder.requests == [.init(url: controlURL, proxy: proxy)])
+    }
+
+    @Test("cancelled concurrent proxy resolution remains bounded")
+    func proxyCancellationStopsSecondTargetResolution() async {
+        let resolver = CancellationIgnoringProxyResolver()
+        let check = SystemProxyCheck(
+            resolver: resolver,
+            connector: StubProxyConnector(reachable: true),
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+        let task = Task { await check.run() }
+
+        await resolver.waitForInvocation()
+        task.cancel()
+        let result = await task.value
+
+        #expect(await resolver.urls.count <= 2)
+        #expect(result.status == .indeterminate)
+        #expect(result.evidence.contains(.init(
+            code: "proxy.cancelled",
+            value: "after-http-resolution"
+        )))
+    }
+
+    @Test("cancelled PAC resolution does not append later static candidates")
+    func proxyResolverCancellationStopsRemainingDirectives() async {
+        let pacURL = URL(string: "https://proxy.example/config.pac")!
+        let pacResolver = CancellationIgnoringPACResolver()
+        let resolver = SystemProxyResolver(
+            configurationResolver: StubProxyConfigurationResolver([
+                .pac(pacURL),
+                .http(.init(host: "unused.example", port: 8080)),
+            ]),
+            pacResolver: pacResolver
+        )
+        let task = Task {
+            await resolver.resolve(
+                for: URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+            )
+        }
+
+        await pacResolver.waitForInvocation()
+        task.cancel()
+        let resolution = await task.value
+
+        #expect(resolution.candidates.isEmpty)
+        #expect(resolution.evidenceCodes.contains("pac-cancelled"))
+        #expect(resolution.evidenceCodes.contains("resolution-cancelled"))
+    }
+
+    @Test("cancelling an endpoint attempt stops candidate fallback")
+    func proxyCancellationStopsAfterConnector() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let first = ProxyEndpoint(host: "first.example", port: 8080)
+        let second = ProxyEndpoint(host: "second.example", port: 8081)
+        let connector = CancellationIgnoringProxyConnector()
+        let check = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: connector,
+            egressLoader: StubProxyEgressLoader(statusCode: 200),
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+        let task = Task {
+            await check.evaluate(
+                target: target,
+                resolution: .init(candidates: [.http(first), .http(second)], evidenceCodes: []),
+                timeout: .seconds(30)
+            )
+        }
+
+        await connector.waitForInvocation()
+        task.cancel()
+        let route = await task.value
+
+        #expect(await connector.endpoints == [first])
+        #expect(route.status == .indeterminate)
+        #expect(route.evidence.contains(.init(
+            code: "proxy.http.cancelled",
+            value: "endpoint"
+        )))
+    }
+
+    @Test("cancelling proxy egress stops connector and candidate fallback")
+    func proxyCancellationStopsAfterEgress() async {
+        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
+        let first = ProxyEndpoint(host: "first.example", port: 8080)
+        let second = ProxyEndpoint(host: "second.example", port: 8081)
+        let connector = SequencedProxyConnector(outcomes: [true, true])
+        let egress = CancellationIgnoringProxyEgressLoader()
+        let check = SystemProxyCheck(
+            resolver: StubProxyResolver(.direct),
+            connector: connector,
+            egressLoader: egress,
+            tunnelReader: StubProxyTunnelStateReader(interface: nil),
+        )
+        let task = Task {
+            await check.evaluate(
+                target: target,
+                resolution: .init(candidates: [.http(first), .http(second)], evidenceCodes: []),
+                timeout: .seconds(30)
+            )
+        }
+
+        await egress.waitForInvocation()
+        task.cancel()
+        let route = await task.value
+
+        #expect(await connector.endpoints == [first])
+        #expect(await egress.invocationCount == 1)
+        #expect(route.status == .indeterminate)
+        #expect(route.evidence.contains(.init(
+            code: "proxy.http.cancelled",
+            value: "egress"
+        )))
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRouteTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRouteTests.swift
@@ -150,25 +150,27 @@ extension NetworkDiagnosticsTests {
         ])
     }
 
-    @Test("overlapping ping runs preserve the latest cancellation owner")
-    func overlappingPingRunsPreserveCancellationOwnership() async {
-        let runner = SystemGatewayPingProcessRunner()
+    @Test("overlapping gateway pings preserve the latest cancellation owner")
+    func overlappingGatewayPingsPreserveCancellationOwnership() async {
+        let runner = ControlledGatewayPingProcessRunner()
+        let pinger = GatewayPinger(processRunner: runner)
+
         let first = Task {
-            await runner.run(executablePath: "/bin/sleep", arguments: ["0.1"])
+            await pinger.ping(host: "first.example")
         }
+        await runner.waitUntilInvocationCount(1)
 
-        try? await Task.sleep(for: .milliseconds(50))
-        let secondStartedAt = ContinuousClock.now
         let second = Task {
-            await runner.run(executablePath: "/bin/sleep", arguments: ["10"])
+            await pinger.ping(host: "second.example")
         }
+        await runner.waitUntilInvocationCount(2)
 
-        try? await Task.sleep(for: .milliseconds(400))
         await runner.cancel()
 
         #expect(await first.value == nil)
         #expect(await second.value == nil)
-        #expect(secondStartedAt.duration(to: ContinuousClock.now) < .seconds(1))
+        #expect(await runner.invocationCount == 2)
+        #expect(await runner.cancelledInvocationIDs == [1, 2])
     }
 
     @Test("contextual path and gateway checks use one selected interface")
@@ -381,4 +383,3 @@ extension NetworkDiagnosticsTests {
         #expect(!result.evidence.contains { $0.code.hasPrefix("gateway.") })
     }
 }
-

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRouteTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRouteTests.swift
@@ -1,0 +1,384 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("route selection follows the kernel-selected interface")
+    func routeSelectionUsesKernelInterface() {
+        let output = """
+           route to: default
+        destination: default
+               mask: default
+            gateway: 192.0.2.1
+          interface: en7
+              flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
+        """
+
+        let result = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        )
+
+        #expect(result == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+
+        let firstOrder = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        )
+        let reversedOrder = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en7": 12, "en0": 4]
+        )
+
+        #expect(firstOrder == reversedOrder)
+        #expect(firstOrder == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+        #expect(DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        ) == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+    }
+
+    @Test("route parser rejects invalid, ambiguous, and unsupported default routes")
+    func routeParserRejectsInvalidDefaultRoutes() {
+        let ambiguousOutput = """
+        destination: default
+        gateway: 192.0.2.1
+        gateway: 192.0.2.254
+        interface: en7
+        flags: <UP,GATEWAY>
+        """
+
+        #expect(DiagnosticRouteParser.parse(
+            output: ambiguousOutput,
+            interfaceIndices: ["en7": 12]
+        ) == .ambiguous)
+
+        let addresses = ["0.0.0.0", "224.0.0.1", "255.255.255.255", "not-an-ip"]
+
+        for address in addresses {
+            let output = "destination: default\ngateway: \(address)\ninterface: en7\nflags: <UP,GATEWAY>"
+            let result = DiagnosticRouteParser.parse(
+                output: output,
+                interfaceIndices: ["en7": 12]
+            )
+            #expect(result == .unavailable)
+        }
+
+        let linkLayer = "destination: default\ngateway: link#4\ninterface: en7\nflags: <UP,GATEWAY>"
+        let tunnel = "destination: default\ngateway: 192.0.2.1\ninterface: utun3\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: linkLayer,
+            interfaceIndices: ["en7": 12]
+        ) == .unsupported)
+        #expect(DiagnosticRouteParser.parse(
+            output: tunnel,
+            interfaceIndices: ["utun3": 20]
+        ) == .unsupported)
+
+        let missingRouteOutput = "gateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: missingRouteOutput,
+            interfaceIndices: ["en7": 12]
+        ) == .unavailable)
+
+        let records = [
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <GATEWAY>",
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP>",
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <>"
+        ]
+
+        for output in records {
+            #expect(DiagnosticRouteParser.parse(
+                output: output,
+                interfaceIndices: ["en7": 12]
+            ) == .unavailable)
+        }
+
+        #expect(DiagnosticRouteParser.parse(
+            output: "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>",
+            interfaceIndices: ["en0": 4]
+        ) == .unavailable)
+    }
+
+    @Test("route command timeout terminates the child without waiting for EOF")
+    func routeCommandTimeoutDoesNotWaitForChild() async {
+        let execution = DiagnosticRouteProcessExecution(
+            executablePath: "/bin/sleep",
+            arguments: ["5"],
+            environment: [:],
+            outputLimit: 1024
+        )
+        let startedAt = ContinuousClock.now
+        let result = await execution.run(timeout: .milliseconds(50))
+        let elapsed = startedAt.duration(to: ContinuousClock.now)
+
+        #expect(result.timedOut)
+        #expect(elapsed < .seconds(2))
+    }
+
+    @Test("diagnostic gateway ping binds the selected interface")
+    func diagnosticGatewayPingBindsSelectedInterface() async {
+        let runner = RecordingGatewayPingProcessRunner(latency: 2.5)
+        let pinger = GatewayPinger(processRunner: runner)
+        let target = DiagnosticGatewayTarget(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )
+
+        _ = await pinger.ping(target: target)
+
+        #expect(await runner.executablePath == "/sbin/ping")
+        #expect(await runner.arguments == [
+            "-b", "en7", "-c", "1", "-W", "1000", "192.0.2.1"
+        ])
+    }
+
+    @Test("overlapping ping runs preserve the latest cancellation owner")
+    func overlappingPingRunsPreserveCancellationOwnership() async {
+        let runner = SystemGatewayPingProcessRunner()
+        let first = Task {
+            await runner.run(executablePath: "/bin/sleep", arguments: ["0.1"])
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        let secondStartedAt = ContinuousClock.now
+        let second = Task {
+            await runner.run(executablePath: "/bin/sleep", arguments: ["10"])
+        }
+
+        try? await Task.sleep(for: .milliseconds(400))
+        await runner.cancel()
+
+        #expect(await first.value == nil)
+        #expect(await second.value == nil)
+        #expect(secondStartedAt.duration(to: ContinuousClock.now) < .seconds(1))
+    }
+
+    @Test("contextual path and gateway checks use one selected interface")
+    func contextualChecksShareSelectedRouteTarget() async {
+        let context = makeDiagnosticContext(
+            pathState: .satisfied,
+            route: .selected(.init(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                address: "192.0.2.1"
+            )),
+            interfaces: [
+                makeNetworkInterface(name: "en0", router: "192.0.2.1"),
+                makeNetworkInterface(name: "en7", router: "192.0.2.1"),
+            ]
+        )
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+
+        let pathResult = await NetworkConnectivityCheck(context: context).run()
+        let gatewayResult = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway,
+            routeSource: nil
+        ).run()
+
+        #expect(pathResult.evidence.contains(.init(code: "path.interface", value: "en7")))
+        #expect(pathResult.evidence.contains(.init(code: "path.gateway", value: "192.0.2.1")))
+        #expect(gatewayResult.evidence.contains(.init(code: "gateway.interface", value: "en7")))
+        #expect(await gateway.targets == [
+            .init(interfaceName: "en7", interfaceIndex: 12, address: "192.0.2.1")
+        ])
+    }
+
+    @Test("context capture accepts a stable route")
+    func diagnosticContextCaptureAcceptsStableRoute() async {
+        let route = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        ))
+        let routeSource = SequencedDiagnosticRouteSource(values: [route, route])
+        let source = SystemDiagnosticNetworkContextSource(
+            routeSource: routeSource,
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
+        )
+
+        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
+
+        #expect(context?.route == route)
+        #expect(context?.pathState == .satisfied)
+        #expect(await routeSource.invocationCount == 2)
+    }
+
+    @Test("context capture does not publish a conflicting route")
+    func diagnosticContextCaptureRejectsChangingRoute() async {
+        let first = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en0",
+            interfaceIndex: 4,
+            address: "192.0.2.1"
+        ))
+        let second = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        ))
+        let routeSource = SequencedDiagnosticRouteSource(values: [first, second, first, second])
+        let source = SystemDiagnosticNetworkContextSource(
+            routeSource: routeSource,
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
+        )
+
+        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
+
+        #expect(context?.route == .ambiguous)
+        #expect(await routeSource.invocationCount == 4)
+    }
+
+    @Test("route change during gateway ping suppresses the old result")
+    func gatewayRouteChangeSuppressesStaleResult() async {
+        let target = DiagnosticGatewayTarget(
+            interfaceName: "en0",
+            interfaceIndex: 4,
+            address: "192.0.2.1"
+        )
+        let context = makeDiagnosticContext(
+            pathState: .satisfied,
+            route: .selected(target)
+        )
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+        let routeSource = SequencedDiagnosticRouteSource(values: [.unavailable])
+
+        let result = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway,
+            routeSource: routeSource
+        ).run()
+
+        #expect(result.status == .indeterminate)
+        #expect(result.evidence.contains(.init(code: "gateway.route-changed", value: nil)))
+    }
+
+    @Test("missing diagnostic route never starts a gateway ping")
+    func missingDiagnosticRouteDoesNotPing() async {
+        let context = makeDiagnosticContext(pathState: .satisfied, route: .unavailable)
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+
+        let result = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway
+        ).run()
+
+        #expect(result.status == .indeterminate)
+        #expect(await gateway.targets.isEmpty)
+    }
+
+    @Test("system path check maps path states")
+    func pathMapping() async {
+        let satisfied = await NetworkConnectivityCheck(pathSource: StubPathSource(.satisfied)).run()
+        #expect(satisfied.id == .path)
+        #expect(satisfied.status == .normal)
+        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(.unsatisfied)).run().status == .abnormal)
+        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(.requiresConnection)).run().status == .indeterminate)
+        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(nil)).run().status == .indeterminate)
+    }
+
+    @Test("gateway reachability outcomes preserve latency, nonresponse, and missing-router semantics")
+    func gatewayReachabilityOutcomeMatrix() async {
+        let result = await GatewayReachabilityCheck(
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
+            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
+                timestamp: Date(),
+                routerIP: "192.0.2.1",
+                latencyMs: 2.5
+            ))
+        ).run()
+
+        #expect(result.id == .gatewayReachability)
+        #expect(result.status == .normal)
+        #expect(result.evidence.contains(.init(code: "gateway.latency-ms", value: "2.5")))
+
+        let nonresponse = await GatewayReachabilityCheck(
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
+            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
+                timestamp: Date(),
+                routerIP: "192.0.2.1",
+                error: .gatewayPingFailed("192.0.2.1")
+            ))
+        ).run()
+
+        #expect(nonresponse.status == .indeterminate)
+        #expect(nonresponse.evidence.contains(.init(code: "gateway.no-response", value: "192.0.2.1")))
+
+        let missingRouter = await GatewayReachabilityCheck(
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: nil)),
+            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
+                timestamp: Date(),
+                error: .missingRouterIP
+            ))
+        ).run()
+
+        #expect(missingRouter.status == .indeterminate)
+        #expect(missingRouter.evidence.contains(.init(code: "gateway.unavailable", value: nil)))
+    }
+
+    @Test("successful HTTPS access neutralizes gateway ICMP nonresponse")
+    func gatewayNonresponseDoesNotDowngradeSuccessfulHTTPS() {
+        var results = makeResults(
+            path: .normal,
+            gateway: .indeterminate,
+            dns: .normal,
+            internet: .normal,
+            proxy: .normal
+        )
+        results[1] = NetworkDiagnosticResult(
+            id: .gatewayReachability,
+            status: .indeterminate,
+            summary: "gateway did not answer ICMP",
+            evidence: [.init(code: "gateway.no-response", value: "192.0.2.1")]
+        )
+        results[3] = NetworkDiagnosticResult(
+            id: .internet,
+            status: .normal,
+            summary: "HTTPS available",
+            evidence: [.init(code: "https.available", value: "200")]
+        )
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+
+        #expect(assessment.conclusion == .networkNormal)
+        #expect(assessment.primaryIssue == nil)
+        #expect(assessment.stages.first { $0.stage == .lan }?.status == .indeterminate)
+    }
+
+    @Test("path check keeps interface evidence without gateway latency")
+    func pathCheckKeepsInterfaceEvidence() async {
+        let result = await NetworkConnectivityCheck(
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1"))
+        ).run()
+
+        #expect(result.status == .normal)
+        #expect(result.evidence.contains(.init(code: "path.interface", value: "en0")))
+        #expect(result.evidence.contains(.init(code: "path.local-ip", value: "192.0.2.10")))
+        #expect(result.evidence.contains(.init(code: "path.router", value: "192.0.2.1")))
+        #expect(!result.evidence.contains { $0.code.hasPrefix("gateway.") })
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRunnerTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsRunnerTests.swift
@@ -1,0 +1,189 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("remediation follows result status and final proxy facts")
+    func remediationDecisionTable() {
+        let result = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .abnormal,
+            summary: "Proxy authentication required",
+            evidence: [.init(code: "proxy.authentication-required", value: "407")]
+        )
+
+        let remediation = NetworkDiagnosticRemediation.forResult(result)
+
+        #expect(remediation.actionKey == "network_diagnostics.remediation.proxy_authentication.action")
+        #expect(remediation.rerunKey == "network_diagnostics.remediation.rerun")
+
+        let indeterminateResult = NetworkDiagnosticResult(
+            id: .dns,
+            status: .indeterminate,
+            summary: "DNS could not be determined"
+        )
+
+        let indeterminateRemediation = NetworkDiagnosticRemediation.forResult(indeterminateResult)
+
+        #expect(indeterminateRemediation.causeKey == "network_diagnostics.remediation.indeterminate.cause")
+        #expect(indeterminateRemediation.actionKey == "network_diagnostics.remediation.indeterminate.action")
+
+        let recoveredProxy = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .indeterminate,
+            summary: "proxy route recovered",
+            evidence: [.init(code: "proxy.authentication-required", value: "407")],
+            proxyFacts: .init(http: .available, https: .available)
+        )
+
+        #expect(NetworkDiagnosticRemediation.forResult(recoveredProxy).actionKey
+            == "network_diagnostics.remediation.indeterminate.action")
+    }
+
+    @Test("runner applies the path and DNS dependency matrix")
+    func runnerDependencyMatrix() async {
+        let cases: [(overrides: [NetworkDiagnosticCheckID: NetworkDiagnosticStatus], statuses: [NetworkDiagnosticStatus], invocations: [NetworkDiagnosticCheckID])] = [
+            (
+                [.path: .abnormal],
+                [.abnormal, .blocked, .blocked, .blocked, .blocked, .blocked],
+                [.path]
+            ),
+            (
+                [.path: .indeterminate],
+                [.indeterminate, .normal, .normal, .normal, .normal, .normal],
+                NetworkDiagnosticCheckID.allCases
+            ),
+            (
+                [.dns: .indeterminate],
+                [.normal, .normal, .indeterminate, .normal, .normal, .normal],
+                NetworkDiagnosticCheckID.allCases
+            ),
+            (
+                [.dns: .abnormal],
+                [.normal, .normal, .abnormal, .normal, .normal, .normal],
+                NetworkDiagnosticCheckID.allCases
+            ),
+            (
+                [.gatewayReachability: .abnormal],
+                [.normal, .abnormal, .normal, .normal, .normal, .normal],
+                NetworkDiagnosticCheckID.allCases
+            ),
+        ]
+
+        for testCase in cases {
+            let recorder = DiagnosticTestRecorder()
+            let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
+                StubDiagnosticCheck(
+                    id: id,
+                    result: NetworkDiagnosticResult(
+                        id: id,
+                        status: testCase.overrides[id] ?? .normal,
+                        summary: id.rawValue
+                    ),
+                    recorder: recorder
+                )
+            }
+
+            let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
+
+            #expect(results.map(\.status) == testCase.statuses)
+            #expect(await recorder.values == testCase.invocations)
+            if testCase.overrides[.path] == .abnormal {
+                #expect(results[1].evidence.contains(.init(code: "blocked.by", value: "path")))
+            }
+        }
+    }
+
+    @Test("runner executes checks and publishes results in order")
+    func runnerOrder() async {
+        let invocations = DiagnosticTestRecorder()
+        let publications = DiagnosticTestRecorder()
+        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
+            StubDiagnosticCheck(
+                id: id,
+                result: NetworkDiagnosticResult(id: id, status: .normal, summary: id.rawValue),
+                recorder: invocations
+            )
+        }
+
+        let results = (await DiagnosticRunner(checks: checks).run { result in
+            await publications.record(result.id)
+        }).results
+
+        #expect(results.map(\.id) == NetworkDiagnosticCheckID.allCases)
+        #expect(await invocations.values == NetworkDiagnosticCheckID.allCases)
+        #expect(await publications.values == NetworkDiagnosticCheckID.allCases)
+    }
+
+    @Test("runner enforces an overall session budget")
+    func runnerEnforcesOverallBudget() async {
+        let probe = BudgetAwareDiagnosticProbe()
+        let clock = ManualDiagnosticClock()
+        let task = Task {
+            await DiagnosticRunner(
+                checks: [BudgetAwareDiagnosticCheck(probe: probe)],
+                sessionBudget: .seconds(1),
+                clock: clock
+            ).run { _ in }
+        }
+
+        await probe.waitForInvocation()
+        await clock.waitForSleeperCount(1)
+        await clock.set(clock.origin.advanced(by: .seconds(1)))
+
+        let outcome = await task.value
+
+        #expect(await probe.wasCancelled)
+        #expect(outcome.results.map(\.id) == [.path])
+        #expect(outcome.results.first?.status == .indeterminate)
+        #expect(outcome.results.first?.evidence == [.init(code: "check.timeout", value: nil)])
+        #expect(outcome.pendingIDs.isEmpty)
+        #expect(outcome.endReason == .timedOut)
+    }
+
+    @Test("runner returns when a cancelled check ignores cancellation")
+    func runnerDoesNotWaitForCancellationIgnoringCheck() async {
+        let probe = CancellationIgnoringDiagnosticProbe()
+        let task = Task {
+            await DiagnosticRunner(
+                checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
+                sessionBudget: .seconds(30)
+            ).run { _ in }
+        }
+
+        await probe.waitForInvocationCount(1)
+        task.cancel()
+        let outcome = await task.value
+
+        #expect(outcome.results.isEmpty)
+        #expect(outcome.pendingIDs == [.path])
+        #expect(outcome.endReason == .cancelled)
+        await probe.release(invocation: 1)
+    }
+
+    @Test("runner preserves completed results and identifies pending checks on cancellation")
+    func runnerReturnsPartialCancelledOutcome() async {
+        let probe = BlockingDiagnosticProbe()
+        let checks: [any DiagnosticCheck] = [
+            StubDiagnosticCheck(
+                id: .path,
+                result: .init(id: .path, status: .normal, summary: "path"),
+                recorder: DiagnosticTestRecorder()
+            ),
+            BlockingProbeDiagnosticCheck(id: .gatewayReachability, probe: probe),
+        ]
+        let runner = DiagnosticRunner(checks: checks)
+        let task = Task { await runner.run { _ in } }
+
+        await probe.waitForInvocationCount(1)
+        task.cancel()
+        let outcome = await task.value
+
+        #expect(outcome.results.map(\.id) == [.path])
+        #expect(outcome.pendingIDs == [.gatewayReachability])
+        #expect(outcome.endReason == .cancelled)
+    }
+}
+

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -177,7 +177,7 @@ struct NetworkDiagnosticsTests {
     func routeCommandTimeoutDoesNotWaitForChild() async {
         let execution = DiagnosticRouteProcessExecution(
             executablePath: "/bin/sleep",
-            arguments: ["2"],
+            arguments: ["5"],
             environment: [:],
             outputLimit: 1024
         )
@@ -186,7 +186,7 @@ struct NetworkDiagnosticsTests {
         let elapsed = startedAt.duration(to: ContinuousClock.now)
 
         #expect(result.timedOut)
-        #expect(elapsed < .seconds(1))
+        #expect(elapsed < .seconds(2))
     }
 
     @Test("diagnostic gateway ping binds the selected interface")
@@ -205,6 +205,27 @@ struct NetworkDiagnosticsTests {
         #expect(await runner.arguments == [
             "-b", "en7", "-c", "1", "-W", "1000", "192.0.2.1"
         ])
+    }
+
+    @Test("overlapping ping runs preserve the latest cancellation owner")
+    func overlappingPingRunsPreserveCancellationOwnership() async {
+        let runner = SystemGatewayPingProcessRunner()
+        let first = Task {
+            await runner.run(executablePath: "/bin/sleep", arguments: ["0.1"])
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        let secondStartedAt = ContinuousClock.now
+        let second = Task {
+            await runner.run(executablePath: "/bin/sleep", arguments: ["10"])
+        }
+
+        try? await Task.sleep(for: .milliseconds(400))
+        await runner.cancel()
+
+        #expect(await first.value == nil)
+        #expect(await second.value == nil)
+        #expect(secondStartedAt.duration(to: ContinuousClock.now) < .seconds(1))
     }
 
     @Test("contextual path and gateway checks use one selected interface")
@@ -396,7 +417,7 @@ struct NetworkDiagnosticsTests {
             StubDiagnosticCheck(id: .gatewayReachability, result: NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "unused"), recorder: recorder),
             StubDiagnosticCheck(id: .dns, result: NetworkDiagnosticResult(id: .dns, status: .normal, summary: "unused"), recorder: recorder),
         ]
-        let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
+        let runner = DiagnosticRunner(checks: checks)
 
         let results = (await runner.run { _ in }).results
 
@@ -412,7 +433,7 @@ struct NetworkDiagnosticsTests {
             let status: NetworkDiagnosticStatus = id == .gatewayReachability ? .abnormal : .normal
             return StubDiagnosticCheck(id: id, result: NetworkDiagnosticResult(id: id, status: status, summary: id.rawValue), recorder: recorder)
         }
-        let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
+        let runner = DiagnosticRunner(checks: checks)
 
         let results = (await runner.run { _ in }).results
 
@@ -554,10 +575,20 @@ struct NetworkDiagnosticsTests {
     @Test("runner enforces an overall session budget")
     func runnerEnforcesOverallBudget() async {
         let probe = BudgetAwareDiagnosticProbe()
-        let outcome = await DiagnosticRunner(
-            checks: [BudgetAwareDiagnosticCheck(probe: probe)],
-            sessionBudget: .milliseconds(50)
-        ).run { _ in }
+        let clock = ManualDiagnosticClock()
+        let task = Task {
+            await DiagnosticRunner(
+                checks: [BudgetAwareDiagnosticCheck(probe: probe)],
+                sessionBudget: .seconds(1),
+                clock: clock
+            ).run { _ in }
+        }
+
+        await probe.waitForInvocation()
+        await clock.waitForSleeperCount(1)
+        await clock.set(clock.origin.advanced(by: .seconds(1)))
+
+        let outcome = await task.value
 
         #expect(await probe.wasCancelled)
         #expect(outcome.results.map(\.id) == [.path])
@@ -608,7 +639,7 @@ struct NetworkDiagnosticsTests {
             ),
             BlockingProbeDiagnosticCheck(id: .gatewayReachability, probe: probe),
         ]
-        let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
+        let runner = DiagnosticRunner(checks: checks)
         let task = Task { await runner.run { _ in } }
 
         await probe.waitForInvocationCount(1)
@@ -702,27 +733,6 @@ struct NetworkDiagnosticsTests {
 
         #expect(results.map(\.status) == [.abnormal, .blocked, .blocked, .blocked, .blocked, .blocked])
         #expect(await invocations.values == [.path])
-    }
-
-    @Test("runner does not delay the next operation for presentation")
-    func runnerMinimumPresentationDuration() async {
-        let check = StubDiagnosticCheck(
-            id: .path,
-            result: NetworkDiagnosticResult(id: .path, status: .normal, summary: "ok"),
-            recorder: DiagnosticTestRecorder()
-        )
-        let outcome = await DiagnosticRunner(
-            checks: [check],
-            minimumStepDuration: .milliseconds(50)
-        ).run { _ in }
-
-        #expect(outcome.endReason == .completed)
-    }
-
-    @Test("production diagnostics present each check for at least 0.8 seconds")
-    @MainActor
-    func productionMinimumPresentationDuration() {
-        #expect(NetworkDiagnosticsViewModel.defaultMinimumStepDuration == .milliseconds(800))
     }
 
     @Test("system path failure makes the network unavailable")
@@ -2744,7 +2754,6 @@ struct NetworkDiagnosticsTests {
         let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: recorder),
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
             guidance: guidance.coordinator
         )
@@ -2761,6 +2770,31 @@ struct NetworkDiagnosticsTests {
         #expect(viewModel.conclusion == .networkNormal)
         #expect(viewModel.results.count == 3)
         #expect(viewModel.executionPhases.values.allSatisfy { $0 == .completed })
+    }
+
+    @Test("fingerprint observation timeout does not wait for a cancellation-ignoring monitor")
+    @MainActor
+    func fingerprintObservationTimeoutIsBounded() async {
+        let monitor = CancellationIgnoringNetworkFingerprintMonitor()
+        let clock = ManualDiagnosticClock()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [],
+            fingerprintMonitor: monitor,
+            clock: clock
+        )
+
+        #expect(viewModel.start())
+        await monitor.waitForInvocation()
+        await clock.set(clock.origin.advanced(by: .seconds(1)))
+
+        for _ in 0..<100 {
+            if !viewModel.fingerprintMonitoringAvailable { break }
+            await Task.yield()
+        }
+
+        #expect(!viewModel.fingerprintMonitoringAvailable)
+        await monitor.release()
+        await viewModel.waitForCompletion()
     }
 
     @Test("network diagnostics keeps an isolated resettable log buffer")
@@ -2825,7 +2859,6 @@ struct NetworkDiagnosticsTests {
     func viewModelPublishesDiagnosticLogs() async {
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: DiagnosticTestRecorder()),
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor()
         )
 
@@ -2871,7 +2904,6 @@ struct NetworkDiagnosticsTests {
         let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: recorder),
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
             guidance: guidance.coordinator
         )
@@ -2910,7 +2942,6 @@ struct NetworkDiagnosticsTests {
         ]
         let viewModel = NetworkDiagnosticsViewModel(
             checks: checks,
-            minimumStepDuration: .zero,
             fingerprintMonitor: fingerprintMonitor,
             guidance: guidance.coordinator
         )
@@ -2946,7 +2977,6 @@ struct NetworkDiagnosticsTests {
                     probe: probe
                 ),
             ],
-            minimumStepDuration: .zero,
             fingerprintMonitor: fingerprintMonitor,
             guidance: guidance.coordinator
         )
@@ -2970,7 +3000,6 @@ struct NetworkDiagnosticsTests {
         let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            minimumStepDuration: .zero,
             fingerprintMonitor: fingerprintMonitor,
             guidance: guidance.coordinator
         )
@@ -3001,45 +3030,37 @@ struct NetworkDiagnosticsTests {
     @Test("stability window starts from the latest network change")
     func stabilityWindowUsesLatestChange() async {
         let controller = NetworkDiagnosticRestartController()
-        let base = ContinuousClock.now
+        let clock = ManualDiagnosticClock()
+        let base = clock.origin
         let first = makeFingerprint(interfaceName: "en1", dnsHash: 2)
         let second = makeFingerprint(interfaceName: "en2", dnsHash: 3)
+        let completion = OptionalBoolRecorder()
 
         #expect(await controller.observe(first, at: base))
         let waitTask = Task {
-            await controller.waitForStability(
-                using: ContinuousDiagnosticClock(),
+            let result = await controller.waitForStability(
+                using: clock,
                 until: base.advanced(by: .seconds(2))
             )
+            await completion.record(result)
+            return result
         }
 
-        try? await Task.sleep(for: .milliseconds(400))
+        await clock.waitForSleeperCount(1)
+        await clock.set(base.advanced(by: .milliseconds(400)))
         #expect(await controller.observe(
             second,
             at: base.advanced(by: .milliseconds(400))
         ))
 
-        let completedBeforeLatestWindow = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await waitTask.value
-                return true
-            }
-            group.addTask {
-                do {
-                    try await Task.sleep(for: .milliseconds(400))
-                } catch {
-                    return false
-                }
-                return false
-            }
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+        await clock.waitForSleeperCount(1)
+        await clock.set(base.advanced(by: .milliseconds(800)))
+        await Task.yield()
+        #expect(await completion.value == nil)
 
-        #expect(!completedBeforeLatestWindow)
-        await controller.cancelCurrentRun()
-        _ = await waitTask.value
+        await clock.set(base.advanced(by: .milliseconds(900)))
+        #expect(await waitTask.value)
+        #expect(await completion.value == true)
     }
 
     @Test("explicit cancellation is latched before a run is installed")
@@ -3120,7 +3141,6 @@ struct NetworkDiagnosticsTests {
         let probe = BlockingDiagnosticProbe()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor()
         )
 
@@ -3140,7 +3160,6 @@ struct NetworkDiagnosticsTests {
         let probe = CancellationIgnoringDiagnosticProbe()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor()
         )
 
@@ -3179,7 +3198,6 @@ struct NetworkDiagnosticsTests {
                 ),
                 BlockingProbeDiagnosticCheck(id: .dns, probe: blockingProbe),
             ],
-            minimumStepDuration: .zero,
             fingerprintMonitor: fingerprintMonitor,
             clock: clock
         )
@@ -3204,7 +3222,6 @@ struct NetworkDiagnosticsTests {
         let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: makeStubChecks(recorder: recorder),
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
             guidance: guidance.coordinator
         )
@@ -3227,7 +3244,6 @@ struct NetworkDiagnosticsTests {
         let guidance = IsolatedGuidance()
         let viewModel = NetworkDiagnosticsViewModel(
             checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            minimumStepDuration: .zero,
             fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
             guidance: guidance.coordinator
         )
@@ -3852,13 +3868,31 @@ private struct MetricsControlLoader: ControlEndpointLoading {
 }
 
 private actor BudgetAwareDiagnosticProbe {
+    private var didStart = false
+    private var invocationContinuation: CheckedContinuation<Void, Never>?
     private(set) var wasCancelled = false
 
     func run() async {
+        didStart = true
+        invocationContinuation?.resume()
+        invocationContinuation = nil
         do {
             try await Task.sleep(for: .seconds(30))
         } catch {
             wasCancelled = true
+        }
+    }
+
+    func waitForInvocation() async {
+        if didStart {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if didStart {
+                continuation.resume()
+            } else {
+                invocationContinuation = continuation
+            }
         }
     }
 }
@@ -3906,9 +3940,23 @@ private actor ManualDiagnosticClock: DiagnosticClock {
         }
     }
 
+    func waitForSleeperCount(_ count: Int) async {
+        while sleepers.count < count {
+            await Task.yield()
+        }
+    }
+
     private func cancelSleep(id: UUID) {
         guard let sleeper = sleepers.removeValue(forKey: id) else { return }
         sleeper.continuation.resume()
+    }
+}
+
+private actor OptionalBoolRecorder {
+    private(set) var value: Bool?
+
+    func record(_ value: Bool) {
+        self.value = value
     }
 }
 
@@ -4845,6 +4893,27 @@ private actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring 
             continuation.yield(fingerprint)
         }
         pending = []
+    }
+}
+
+private actor CancellationIgnoringNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
+    private var continuation: CheckedContinuation<NetworkFingerprintObservation?, Never>?
+
+    func observation() async -> NetworkFingerprintObservation? {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitForInvocation() async {
+        while continuation == nil {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        continuation?.resume(returning: nil)
+        continuation = nil
     }
 }
 

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -173,6 +173,22 @@ struct NetworkDiagnosticsTests {
         }
     }
 
+    @Test("route command timeout terminates the child without waiting for EOF")
+    func routeCommandTimeoutDoesNotWaitForChild() async {
+        let execution = DiagnosticRouteProcessExecution(
+            executablePath: "/bin/sleep",
+            arguments: ["2"],
+            environment: [:],
+            outputLimit: 1024
+        )
+        let startedAt = ContinuousClock.now
+        let result = await execution.run(timeout: .milliseconds(50))
+        let elapsed = startedAt.duration(to: ContinuousClock.now)
+
+        #expect(result.timedOut)
+        #expect(elapsed < .seconds(1))
+    }
+
     @Test("diagnostic gateway ping binds the selected interface")
     func diagnosticGatewayPingBindsSelectedInterface() async {
         let runner = RecordingGatewayPingProcessRunner(latency: 2.5)
@@ -725,7 +741,7 @@ struct NetworkDiagnosticsTests {
         ) == .needsAttention)
     }
 
-    @Test("failed base HTTPS suppresses proxy endpoint symptom")
+    @Test("failed base HTTPS suppresses proxy endpoint symptom without declaring outage")
     func conclusionSuppressesProxySymptom() {
         var results = makeResults(
             path: .normal,
@@ -743,7 +759,7 @@ struct NetworkDiagnosticsTests {
             )]
         )
 
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkUnavailable)
+        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
     }
 
     @Test("failed direct path with a usable HTTPS proxy needs attention")
@@ -764,7 +780,7 @@ struct NetworkDiagnosticsTests {
         #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
     }
 
-    @Test("DIRECT routing without direct egress still reports network unavailable")
+    @Test("DIRECT routing without direct egress needs attention")
     func directRouteDecisionDoesNotProveConnectivity() {
         var results = makeResults(
             path: .normal,
@@ -788,7 +804,7 @@ struct NetworkDiagnosticsTests {
             evidence: [.init(code: "proxy.https.egress-status", value: "base-check")]
         )
 
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkUnavailable)
+        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
     }
 
     @Test("base HTTPS success and explicit proxy failure needs attention")
@@ -859,6 +875,77 @@ struct NetworkDiagnosticsTests {
         )
 
         #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkNormal)
+    }
+
+    @Test("PAC resolution failures are not neutralized as explicit DIRECT")
+    func pacResolutionFailureDoesNotBecomeNormal() {
+        let results = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .indeterminate
+        ).map { result in
+            guard result.id == .proxy else { return result }
+            return NetworkDiagnosticResult(
+                id: .proxy,
+                status: .indeterminate,
+                summary: "proxy resolution failed",
+                evidence: [
+                    .init(code: "proxy.http.resolution", value: "pac-timeout"),
+                    .init(code: "proxy.https.resolution", value: "pac-timeout"),
+                ],
+                proxyFacts: .init(http: .unverified, https: .unverified)
+            )
+        }
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+
+        #expect(assessment.conclusion == .needsAttention)
+    }
+
+    @Test("a single HTTPS target failure is needs attention, not universal outage")
+    func singleHTTPSFailureIsNotNetworkUnavailable() {
+        var results = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .indeterminate
+        )
+        results[3] = NetworkDiagnosticResult(
+            id: .internet,
+            status: .abnormal,
+            summary: "one HTTPS target failed",
+            evidence: [.init(code: "https.connectivity-error", value: nil)]
+        )
+
+        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
+    }
+
+    @Test("DNS uncertainty is not hidden by a neutral DIRECT proxy")
+    func dnsUncertaintyRemainsVisibleAlongsideDirectProxy() {
+        var results = makeResults(
+            path: .normal,
+            dns: .indeterminate,
+            internet: .normal,
+            proxy: .indeterminate
+        )
+        results[5] = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .indeterminate,
+            summary: "direct routing selected",
+            proxyFacts: .init(http: .unverified, https: .unverified)
+        )
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+
+        #expect(assessment.conclusion == .needsAttention)
+        #expect(assessment.stages.first { $0.stage == .thisMac }?.status == .indeterminate)
     }
 
     @Test("HTTPS availability is retained even when HTTP proxy routing fails")
@@ -1447,7 +1534,7 @@ struct NetworkDiagnosticsTests {
         ) == .needsAttention)
         #expect(NetworkDiagnosticConclusion.evaluate(
             baseResults + [connectivityFailure] + trailingResults
-        ) == .networkUnavailable)
+        ) == .needsAttention)
     }
 
     @Test("control check loads the approved endpoints with an explicit timeout")
@@ -2911,6 +2998,50 @@ struct NetworkDiagnosticsTests {
         #expect(await controller.observe(fingerprint) == false)
     }
 
+    @Test("stability window starts from the latest network change")
+    func stabilityWindowUsesLatestChange() async {
+        let controller = NetworkDiagnosticRestartController()
+        let base = ContinuousClock.now
+        let first = makeFingerprint(interfaceName: "en1", dnsHash: 2)
+        let second = makeFingerprint(interfaceName: "en2", dnsHash: 3)
+
+        #expect(await controller.observe(first, at: base))
+        let waitTask = Task {
+            await controller.waitForStability(
+                using: ContinuousDiagnosticClock(),
+                until: base.advanced(by: .seconds(2))
+            )
+        }
+
+        try? await Task.sleep(for: .milliseconds(400))
+        #expect(await controller.observe(
+            second,
+            at: base.advanced(by: .milliseconds(400))
+        ))
+
+        let completedBeforeLatestWindow = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await waitTask.value
+                return true
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: .milliseconds(400))
+                } catch {
+                    return false
+                }
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+
+        #expect(!completedBeforeLatestWindow)
+        await controller.cancelCurrentRun()
+        _ = await waitTask.value
+    }
+
     @Test("explicit cancellation is latched before a run is installed")
     func restartControllerLatchesCancellationBeforeInstall() async {
         let controller = NetworkDiagnosticRestartController()
@@ -3032,6 +3163,40 @@ struct NetworkDiagnosticsTests {
         #expect(viewModel.results[.path]?.status == .normal)
     }
 
+    @Test("unstable network changes do not restore invalidated results")
+    @MainActor
+    func unstableNetworkChangeDoesNotRestoreOldResults() async {
+        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
+        let blockingProbe = BlockingDiagnosticProbe()
+        let clock = ManualDiagnosticClock()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [
+                StubDiagnosticCheck(
+                    id: .path,
+                    result: .init(id: .path, status: .normal, summary: "old path"),
+                    recorder: DiagnosticTestRecorder()
+                ),
+                BlockingProbeDiagnosticCheck(id: .dns, probe: blockingProbe),
+            ],
+            minimumStepDuration: .zero,
+            fingerprintMonitor: fingerprintMonitor,
+            clock: clock
+        )
+
+        #expect(viewModel.start())
+        await blockingProbe.waitForInvocationCount(1)
+        await clock.set(clock.origin.advanced(by: .milliseconds(29_800)))
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 1))
+        await clock.set(clock.origin.advanced(by: .milliseconds(30_100)))
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.endReason == .superseded)
+        #expect(viewModel.results.isEmpty)
+        #expect(viewModel.pendingCheckIDs == [.path, .dns])
+    }
+
     @Test("a successful diagnostics run reports the completion moment exactly once")
     @MainActor
     func successfulRunReportsDiagnosticsMomentOnce() async {
@@ -3104,6 +3269,53 @@ struct NetworkDiagnosticsTests {
         #expect(changedFingerprint?.interfaceName == "en0")
         #expect(changedFingerprint?.dnsSettingsHash == 2)
         #expect(changedFingerprint?.staticProxySettingsHash == 7)
+    }
+
+    @Test("system fingerprint monitor detects route changes without DNS or proxy changes")
+    func fingerprintDetectsRouteOnlyChange() async throws {
+        let baselinePath = NetworkPathFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied
+        )
+        let routeSource = SequencedFingerprintRouteStateSource(values: [
+            NetworkFingerprintRouteState(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                gateway: "192.0.2.1",
+                addresses: ["192.0.2.10"],
+                subnets: ["255.255.255.0"]
+            ),
+            NetworkFingerprintRouteState(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                gateway: "192.0.2.254",
+                addresses: ["192.0.2.10"],
+                subnets: ["255.255.255.0"]
+            ),
+            NetworkFingerprintRouteState(
+                interfaceName: nil,
+                interfaceIndex: nil,
+                gateway: nil
+            ),
+        ])
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath]),
+            settingsPoller: FixedCountNetworkFingerprintSettingsPoller(count: 2),
+            routeStateSource: routeSource
+        )
+
+        let observation = try #require(await monitor.observation())
+        var iterator = observation.changes.makeAsyncIterator()
+        let change = await iterator.next()
+        let disappeared = await iterator.next()
+
+        #expect(observation.baseline.selectedGateway == "192.0.2.1")
+        #expect(change?.selectedGateway == "192.0.2.254")
+        #expect(disappeared?.selectedGateway == nil)
+        #expect(disappeared?.selectedInterfaceIndex == nil)
+        #expect(disappeared?.selectedInterfaceAddresses.isEmpty == true)
     }
 
     @Test("proxy fingerprint includes PAC and automatic discovery settings")
@@ -3648,6 +3860,55 @@ private actor BudgetAwareDiagnosticProbe {
         } catch {
             wasCancelled = true
         }
+    }
+}
+
+private actor ManualDiagnosticClock: DiagnosticClock {
+    let origin: ContinuousClock.Instant
+    private var current: ContinuousClock.Instant
+    private var sleepers: [UUID: (deadline: ContinuousClock.Instant, continuation: CheckedContinuation<Void, Never>)] = [:]
+
+    init(origin: ContinuousClock.Instant = ContinuousClock.now) {
+        self.origin = origin
+        current = origin
+    }
+
+    func now() async -> ContinuousClock.Instant {
+        current
+    }
+
+    func sleep(until deadline: ContinuousClock.Instant) async throws {
+        try Task.checkCancellation()
+        guard current < deadline else { return }
+        let sleeperID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                if current >= deadline || Task.isCancelled {
+                    continuation.resume()
+                } else {
+                    sleepers[sleeperID] = (deadline, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelSleep(id: sleeperID) }
+        }
+        try Task.checkCancellation()
+    }
+
+    func set(_ value: ContinuousClock.Instant) {
+        current = value
+        let readyIDs = sleepers.compactMap { id, sleeper in
+            sleeper.deadline <= value ? id : nil
+        }
+        let readySleepers = readyIDs.compactMap { sleepers.removeValue(forKey: $0) }
+        for sleeper in readySleepers {
+            sleeper.continuation.resume()
+        }
+    }
+
+    private func cancelSleep(id: UUID) {
+        guard let sleeper = sleepers.removeValue(forKey: id) else { return }
+        sleeper.continuation.resume()
     }
 }
 
@@ -4635,6 +4896,19 @@ private struct ImmediateNetworkFingerprintSettingsPoller: NetworkFingerprintSett
     }
 }
 
+private struct FixedCountNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
+    let count: Int
+
+    func ticks(every interval: Duration) -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            for _ in 0..<count {
+                continuation.yield(())
+            }
+            continuation.finish()
+        }
+    }
+}
+
 private struct SilentNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
     func ticks(every interval: Duration) -> AsyncStream<Void> {
         AsyncStream { $0.finish() }
@@ -4661,6 +4935,21 @@ private final class MutableFingerprintSettingsReader: NetworkFingerprintSettings
 
     func setDNSHash(_ value: UInt64) {
         lock.withLock { dnsHash = value }
+    }
+}
+
+private actor SequencedFingerprintRouteStateSource: NetworkFingerprintRouteStateSourcing {
+    private let values: [NetworkFingerprintRouteState]
+    private var index = 0
+
+    init(values: [NetworkFingerprintRouteState]) {
+        precondition(!values.isEmpty)
+        self.values = values
+    }
+
+    func currentState() async -> NetworkFingerprintRouteState? {
+        defer { index += 1 }
+        return values[min(index, values.endIndex - 1)]
     }
 }
 

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -35,6 +35,277 @@ struct NetworkDiagnosticsTests {
         #expect(Set(NetworkDiagnosticCheckID.allCases).count == 6)
     }
 
+    @Test("route selection follows the kernel-selected interface")
+    func routeSelectionUsesKernelInterface() {
+        let output = """
+           route to: default
+        destination: default
+               mask: default
+            gateway: 192.0.2.1
+          interface: en7
+              flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
+        """
+
+        let result = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        )
+
+        #expect(result == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+    }
+
+    @Test("missing selected interface does not fall back to another adapter")
+    func missingInterfaceCannotSelectAnotherAdapter() {
+        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4]
+        ) == .unavailable)
+    }
+
+    @Test("route parsing is independent of interface enumeration order")
+    func routeSelectionIgnoresInterfaceEnumerationOrder() {
+        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
+        let firstOrder = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        )
+        let reversedOrder = DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en7": 12, "en0": 4]
+        )
+
+        #expect(firstOrder == reversedOrder)
+        #expect(firstOrder == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+    }
+
+    @Test("same gateway address remains tied to the selected interface")
+    func sameGatewayAddressDoesNotCollapseInterfaceIdentity() {
+        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en0": 4, "en7": 12]
+        ) == .selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )))
+    }
+
+    @Test("duplicate route fields cannot produce a selected target")
+    func duplicateRouteFieldsAreRejected() {
+        let output = """
+        destination: default
+        gateway: 192.0.2.1
+        gateway: 192.0.2.254
+        interface: en7
+        flags: <UP,GATEWAY>
+        """
+
+        #expect(DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en7": 12]
+        ) == .ambiguous)
+    }
+
+    @Test("invalid gateway addresses cannot be selected")
+    func invalidGatewayAddressesAreRejected() {
+        let addresses = ["0.0.0.0", "224.0.0.1", "255.255.255.255", "not-an-ip"]
+
+        for address in addresses {
+            let output = "destination: default\ngateway: \(address)\ninterface: en7\nflags: <UP,GATEWAY>"
+            let result = DiagnosticRouteParser.parse(
+                output: output,
+                interfaceIndices: ["en7": 12]
+            )
+            #expect(result == .unavailable)
+        }
+    }
+
+    @Test("link-layer gateways and tunnel interfaces are unsupported")
+    func unsupportedRouteTargetsAreRejected() {
+        let linkLayer = "destination: default\ngateway: link#4\ninterface: en7\nflags: <UP,GATEWAY>"
+        let tunnel = "destination: default\ngateway: 192.0.2.1\ninterface: utun3\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: linkLayer,
+            interfaceIndices: ["en7": 12]
+        ) == .unsupported)
+        #expect(DiagnosticRouteParser.parse(
+            output: tunnel,
+            interfaceIndices: ["utun3": 20]
+        ) == .unsupported)
+    }
+
+    @Test("missing default route is unavailable")
+    func missingDefaultRouteIsUnavailable() {
+        let output = "gateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
+
+        #expect(DiagnosticRouteParser.parse(
+            output: output,
+            interfaceIndices: ["en7": 12]
+        ) == .unavailable)
+    }
+
+    @Test("route parser requires both UP and GATEWAY flags")
+    func routeParserRequiresUsableDefaultFlags() {
+        let records = [
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <GATEWAY>",
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP>",
+            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <>"
+        ]
+
+        for output in records {
+            #expect(DiagnosticRouteParser.parse(
+                output: output,
+                interfaceIndices: ["en7": 12]
+            ) == .unavailable)
+        }
+    }
+
+    @Test("diagnostic gateway ping binds the selected interface")
+    func diagnosticGatewayPingBindsSelectedInterface() async {
+        let runner = RecordingGatewayPingProcessRunner(latency: 2.5)
+        let pinger = GatewayPinger(processRunner: runner)
+        let target = DiagnosticGatewayTarget(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        )
+
+        _ = await pinger.ping(target: target)
+
+        #expect(await runner.executablePath == "/sbin/ping")
+        #expect(await runner.arguments == [
+            "-b", "en7", "-c", "1", "-W", "1000", "192.0.2.1"
+        ])
+    }
+
+    @Test("contextual path and gateway checks use one selected interface")
+    func contextualChecksShareSelectedRouteTarget() async {
+        let context = makeDiagnosticContext(
+            pathState: .satisfied,
+            route: .selected(.init(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                address: "192.0.2.1"
+            )),
+            interfaces: [
+                makeNetworkInterface(name: "en0", router: "192.0.2.1"),
+                makeNetworkInterface(name: "en7", router: "192.0.2.1"),
+            ]
+        )
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+
+        let pathResult = await NetworkConnectivityCheck(context: context).run()
+        let gatewayResult = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway,
+            routeSource: nil
+        ).run()
+
+        #expect(pathResult.evidence.contains(.init(code: "path.interface", value: "en7")))
+        #expect(pathResult.evidence.contains(.init(code: "path.gateway", value: "192.0.2.1")))
+        #expect(gatewayResult.evidence.contains(.init(code: "gateway.interface", value: "en7")))
+        #expect(await gateway.targets == [
+            .init(interfaceName: "en7", interfaceIndex: 12, address: "192.0.2.1")
+        ])
+    }
+
+    @Test("context capture accepts a stable route")
+    func diagnosticContextCaptureAcceptsStableRoute() async {
+        let route = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        ))
+        let routeSource = SequencedDiagnosticRouteSource(values: [route, route])
+        let source = SystemDiagnosticNetworkContextSource(
+            routeSource: routeSource,
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
+        )
+
+        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
+
+        #expect(context?.route == route)
+        #expect(context?.pathState == .satisfied)
+        #expect(await routeSource.invocationCount == 2)
+    }
+
+    @Test("context capture does not publish a conflicting route")
+    func diagnosticContextCaptureRejectsChangingRoute() async {
+        let first = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en0",
+            interfaceIndex: 4,
+            address: "192.0.2.1"
+        ))
+        let second = DiagnosticRouteSelection.selected(.init(
+            interfaceName: "en7",
+            interfaceIndex: 12,
+            address: "192.0.2.1"
+        ))
+        let routeSource = SequencedDiagnosticRouteSource(values: [first, second, first, second])
+        let source = SystemDiagnosticNetworkContextSource(
+            routeSource: routeSource,
+            pathSource: StubPathSource(.satisfied),
+            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
+        )
+
+        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
+
+        #expect(context?.route == .ambiguous)
+        #expect(await routeSource.invocationCount == 4)
+    }
+
+    @Test("route change during gateway ping suppresses the old result")
+    func gatewayRouteChangeSuppressesStaleResult() async {
+        let target = DiagnosticGatewayTarget(
+            interfaceName: "en0",
+            interfaceIndex: 4,
+            address: "192.0.2.1"
+        )
+        let context = makeDiagnosticContext(
+            pathState: .satisfied,
+            route: .selected(target)
+        )
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+        let routeSource = SequencedDiagnosticRouteSource(values: [.unavailable])
+
+        let result = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway,
+            routeSource: routeSource
+        ).run()
+
+        #expect(result.status == .indeterminate)
+        #expect(result.evidence.contains(.init(code: "gateway.route-changed", value: nil)))
+    }
+
+    @Test("missing diagnostic route never starts a gateway ping")
+    func missingDiagnosticRouteDoesNotPing() async {
+        let context = makeDiagnosticContext(pathState: .satisfied, route: .unavailable)
+        let gateway = RecordingDiagnosticGatewayMeasurer()
+
+        let result = await GatewayReachabilityCheck(
+            context: context,
+            gatewayMeasuring: gateway
+        ).run()
+
+        #expect(result.status == .indeterminate)
+        #expect(await gateway.targets.isEmpty)
+    }
+
     @Test("blocked and skipped statuses have distinct presentations")
     func blockedAndSkippedPresentation() {
         #expect(NetworkDiagnosticStatus.blocked.presentation == .init(
@@ -80,6 +351,20 @@ struct NetworkDiagnosticsTests {
         #expect(remediation.actionKey == "network_diagnostics.remediation.indeterminate.action")
     }
 
+    @Test("proxy remediation follows final route facts instead of failed candidates")
+    func proxyRemediationUsesFinalRouteFacts() {
+        let result = NetworkDiagnosticResult(
+            id: .proxy,
+            status: .indeterminate,
+            summary: "proxy route recovered",
+            evidence: [.init(code: "proxy.authentication-required", value: "407")],
+            proxyFacts: .init(http: .available, https: .available)
+        )
+
+        #expect(NetworkDiagnosticRemediation.forResult(result).actionKey
+            == "network_diagnostics.remediation.indeterminate.action")
+    }
+
     @Test("a blocked probe does not become an independent network fault")
     func blockedProbeIsNotAbnormal() {
         let result = NetworkDiagnosticResult.blocked(id: .internet, summary: "DNS is unavailable")
@@ -97,7 +382,7 @@ struct NetworkDiagnosticsTests {
         ]
         let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
 
-        let results = await runner.run { _ in }
+        let results = (await runner.run { _ in }).results
 
         #expect(results.map(\.id) == [.path, .gatewayReachability, .dns])
         #expect(results[1].status == .blocked)
@@ -113,7 +398,7 @@ struct NetworkDiagnosticsTests {
         }
         let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
 
-        let results = await runner.run { _ in }
+        let results = (await runner.run { _ in }).results
 
         #expect(results.map(\.id) == NetworkDiagnosticCheckID.allCases)
         #expect(results[1].status == .abnormal)
@@ -241,9 +526,9 @@ struct NetworkDiagnosticsTests {
             )
         }
 
-        let results = await DiagnosticRunner(checks: checks).run { result in
+        let results = (await DiagnosticRunner(checks: checks).run { result in
             await publications.record(result.id)
-        }
+        }).results
 
         #expect(results.map(\.id) == NetworkDiagnosticCheckID.allCases)
         #expect(await invocations.values == NetworkDiagnosticCheckID.allCases)
@@ -253,13 +538,70 @@ struct NetworkDiagnosticsTests {
     @Test("runner enforces an overall session budget")
     func runnerEnforcesOverallBudget() async {
         let probe = BudgetAwareDiagnosticProbe()
-        let results = await DiagnosticRunner(
+        let outcome = await DiagnosticRunner(
             checks: [BudgetAwareDiagnosticCheck(probe: probe)],
             sessionBudget: .milliseconds(50)
         ).run { _ in }
 
         #expect(await probe.wasCancelled)
-        #expect(results.isEmpty)
+        #expect(outcome.results.map(\.id) == [.path])
+        #expect(outcome.results.first?.status == .indeterminate)
+        #expect(outcome.results.first?.evidence == [.init(code: "check.timeout", value: nil)])
+        #expect(outcome.pendingIDs.isEmpty)
+        #expect(outcome.endReason == .timedOut)
+    }
+
+    @Test("runner returns when a cancelled check ignores cancellation")
+    func runnerDoesNotWaitForCancellationIgnoringCheck() async {
+        let probe = CancellationIgnoringDiagnosticProbe()
+        let task = Task {
+            await DiagnosticRunner(
+                checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
+                sessionBudget: .seconds(30)
+            ).run { _ in }
+        }
+
+        await probe.waitForInvocationCount(1)
+        task.cancel()
+        let outcome = await task.value
+
+        #expect(outcome.results.isEmpty)
+        #expect(outcome.pendingIDs == [.path])
+        #expect(outcome.endReason == .cancelled)
+        await probe.release(invocation: 1)
+    }
+
+    @Test("publication gate rejects an old run after a replacement starts")
+    func oldRunCannotPublishIntoNewRun() {
+        let oldID = UUID()
+        let newID = UUID()
+        let gate = DiagnosticPublicationGate(activeRunID: newID)
+
+        #expect(!gate.accepts(oldID))
+        #expect(gate.accepts(newID))
+    }
+
+    @Test("runner preserves completed results and identifies pending checks on cancellation")
+    func runnerReturnsPartialCancelledOutcome() async {
+        let probe = BlockingDiagnosticProbe()
+        let checks: [any DiagnosticCheck] = [
+            StubDiagnosticCheck(
+                id: .path,
+                result: .init(id: .path, status: .normal, summary: "path"),
+                recorder: DiagnosticTestRecorder()
+            ),
+            BlockingProbeDiagnosticCheck(id: .gatewayReachability, probe: probe),
+        ]
+        let runner = DiagnosticRunner(checks: checks, minimumStepDuration: .zero)
+        let task = Task { await runner.run { _ in } }
+
+        await probe.waitForInvocationCount(1)
+        task.cancel()
+        let outcome = await task.value
+
+        #expect(outcome.results.map(\.id) == [.path])
+        #expect(outcome.pendingIDs == [.gatewayReachability])
+        #expect(outcome.endReason == .cancelled)
     }
 
     @Test("indeterminate DNS does not block internet or IPv6")
@@ -277,14 +619,14 @@ struct NetworkDiagnosticsTests {
             )
         }
 
-        let results = await DiagnosticRunner(checks: checks).run { _ in }
+        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
 
         #expect(results.map(\.status) == [.normal, .normal, .indeterminate, .normal, .normal, .normal])
         #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
     }
 
-    @Test("abnormal DNS blocks hostname-dependent internet and IPv6 checks")
-    func abnormalDNSBlocksHostnameDependentChecks() async {
+    @Test("abnormal DNS does not block independent hostname checks")
+    func abnormalDNSDoesNotBlockHostnameDependentChecks() async {
         let invocations = DiagnosticTestRecorder()
         let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
             StubDiagnosticCheck(
@@ -298,10 +640,10 @@ struct NetworkDiagnosticsTests {
             )
         }
 
-        let results = await DiagnosticRunner(checks: checks).run { _ in }
+        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
 
-        #expect(results.map(\.status) == [.normal, .normal, .abnormal, .blocked, .blocked, .normal])
-        #expect(await invocations.values == [.path, .gatewayReachability, .dns, .proxy])
+        #expect(results.map(\.status) == [.normal, .normal, .abnormal, .normal, .normal, .normal])
+        #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
     }
 
     @Test("indeterminate path continues independent evidence probes")
@@ -319,7 +661,7 @@ struct NetworkDiagnosticsTests {
             )
         }
 
-        let results = await DiagnosticRunner(checks: checks).run { _ in }
+        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
 
         #expect(results.map(\.status) == [.indeterminate, .normal, .normal, .normal, .normal, .normal])
         #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
@@ -340,32 +682,25 @@ struct NetworkDiagnosticsTests {
             )
         }
 
-        let results = await DiagnosticRunner(checks: checks).run { _ in }
+        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
 
         #expect(results.map(\.status) == [.abnormal, .blocked, .blocked, .blocked, .blocked, .blocked])
         #expect(await invocations.values == [.path])
     }
 
-    @Test("runner keeps each check visible for its minimum presentation duration")
+    @Test("runner does not delay the next operation for presentation")
     func runnerMinimumPresentationDuration() async {
         let check = StubDiagnosticCheck(
             id: .path,
             result: NetworkDiagnosticResult(id: .path, status: .normal, summary: "ok"),
             recorder: DiagnosticTestRecorder()
         )
-        let clock = ContinuousClock()
-        let started = clock.now
-
-        _ = await DiagnosticRunner(
+        let outcome = await DiagnosticRunner(
             checks: [check],
             minimumStepDuration: .milliseconds(50)
         ).run { _ in }
 
-        // The runner targets a 50 ms minimum presentation duration, but the
-        // lower bound is intentionally relaxed below that target to absorb
-        // scheduler noise under CI load. 30 ms stays far above the near-zero
-        // elapsed time that would indicate the minimum duration was skipped.
-        #expect(started.duration(to: clock.now) >= .milliseconds(30))
+        #expect(outcome.endReason == .completed)
     }
 
     @Test("production diagnostics present each check for at least 0.8 seconds")
@@ -458,7 +793,7 @@ struct NetworkDiagnosticsTests {
 
     @Test("base HTTPS success and explicit proxy failure needs attention")
     func proxyIsIndependentWhenBasePathWorks() {
-        let results = makeResults(
+        let results: [NetworkDiagnosticResult] = makeResults(
             path: .normal,
             dns: .normal,
             internet: .normal,
@@ -488,6 +823,11 @@ struct NetworkDiagnosticsTests {
         ]
 
         #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+        #expect(assessment.primaryIssue?.id == .internet)
     }
 
     @Test("an indeterminate result needs attention")
@@ -514,10 +854,76 @@ struct NetworkDiagnosticsTests {
             id: .proxy,
             status: .indeterminate,
             summary: "direct routing selected",
-            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")]
+            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")],
+            proxyFacts: .init(http: .unverified, https: .unverified)
         )
 
         #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkNormal)
+    }
+
+    @Test("HTTPS availability is retained even when HTTP proxy routing fails")
+    func httpsAvailabilityDoesNotDependOnHTTP() {
+        let facts = DiagnosticProxyFacts(http: .unavailable, https: .available)
+        #expect(facts.https == .available)
+
+        let results: [NetworkDiagnosticResult] = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .abnormal,
+            proxy: .abnormal
+        ).map { result in
+            if result.id == .internet {
+                return NetworkDiagnosticResult(
+                    id: result.id,
+                    status: result.status,
+                    summary: result.summary,
+                    evidence: [.init(code: "https.connectivity-error", value: nil)]
+                )
+            }
+            if result.id == .proxy {
+                return NetworkDiagnosticResult(
+                    id: result.id,
+                    status: result.status,
+                    summary: result.summary,
+                    evidence: [.init(code: "proxy.endpoint-unavailable", value: nil)],
+                    proxyFacts: facts
+                )
+            }
+            return result
+        }
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+        #expect(assessment.conclusion == .needsAttention)
+        #expect(assessment.primaryIssue?.id == .proxy)
+    }
+
+    @Test("recovered proxy candidates do not leave an authentication action")
+    func recoveredProxyCandidateDoesNotRemainActionable() {
+        let results: [NetworkDiagnosticResult] = makeResults(
+            path: .normal,
+            dns: .normal,
+            internet: .normal,
+            proxy: .normal
+        ).map { result in
+            guard result.id == .proxy else { return result }
+            return NetworkDiagnosticResult(
+                id: .proxy,
+                status: .normal,
+                summary: "HTTPS proxy recovered",
+                evidence: [.init(code: "proxy.https.authentication-required", value: "407")],
+                proxyFacts: .init(http: .available, https: .available)
+            )
+        }
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+        #expect(assessment.conclusion == .networkNormal)
+        #expect(assessment.primaryIssue == nil)
     }
 
     @Test("no global IPv6 address is skipped without changing a normal conclusion")
@@ -703,6 +1109,20 @@ struct NetworkDiagnosticsTests {
             "header.additional", "check.ipv6",
         ])
         #expect(completedItems[4] == .additionalHeader)
+
+        let timedOutItems = NetworkDiagnosticsPresentation.workbenchItems(
+            pagePhase: .completed,
+            executionPhases: [.path: .completed, .dns: .waiting],
+            results: [.path: path],
+            checkIDs: [.path, .dns],
+            endReason: .timedOut
+        )
+        #expect(timedOutItems.last == .check(.init(
+            id: .dns,
+            executionPhase: .waiting,
+            result: nil,
+            pendingReason: .timedOut
+        )))
     }
 
     @Test("system path check maps path states")
@@ -743,8 +1163,8 @@ struct NetworkDiagnosticsTests {
         #expect(result.evidence.contains(.init(code: "gateway.latency-ms", value: "2.5")))
     }
 
-    @Test("gateway nonresponse fails the gateway reachability check")
-    func gatewayNonresponseFailsCheck() async {
+    @Test("gateway nonresponse remains indeterminate")
+    func gatewayNonresponseIsIndeterminate() async {
         let result = await GatewayReachabilityCheck(
             interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
             gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
@@ -754,8 +1174,40 @@ struct NetworkDiagnosticsTests {
             ))
         ).run()
 
-        #expect(result.status == .abnormal)
-        #expect(result.evidence.contains(.init(code: "gateway.unreachable", value: "192.0.2.1")))
+        #expect(result.status == .indeterminate)
+        #expect(result.evidence.contains(.init(code: "gateway.no-response", value: "192.0.2.1")))
+    }
+
+    @Test("successful HTTPS access neutralizes gateway ICMP nonresponse")
+    func gatewayNonresponseDoesNotDowngradeSuccessfulHTTPS() {
+        var results = makeResults(
+            path: .normal,
+            gateway: .indeterminate,
+            dns: .normal,
+            internet: .normal,
+            proxy: .normal
+        )
+        results[1] = NetworkDiagnosticResult(
+            id: .gatewayReachability,
+            status: .indeterminate,
+            summary: "gateway did not answer ICMP",
+            evidence: [.init(code: "gateway.no-response", value: "192.0.2.1")]
+        )
+        results[3] = NetworkDiagnosticResult(
+            id: .internet,
+            status: .normal,
+            summary: "HTTPS available",
+            evidence: [.init(code: "https.available", value: "200")]
+        )
+
+        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
+            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
+            complete: true
+        )
+
+        #expect(assessment.conclusion == .networkNormal)
+        #expect(assessment.primaryIssue == nil)
+        #expect(assessment.stages.first { $0.stage == .lan }?.status == .indeterminate)
     }
 
     @Test("gateway reachability is indeterminate without a router IP")
@@ -1055,7 +1507,7 @@ struct NetworkDiagnosticsTests {
     @Test("production checks run path DNS HTTPS and proxy in dependency order")
     @MainActor
     func productionCheckOrder() {
-        #expect(NetworkDiagnosticsViewModel().checkIDs == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
+        #expect(NetworkDiagnosticsViewModel().checkIDs == [.path, .gatewayReachability, .dns, .internet, .proxy, .ipv6])
     }
 
     @Test("all successful DNS samples are available")
@@ -1102,6 +1554,22 @@ struct NetworkDiagnosticsTests {
         #expect(result.status == .indeterminate)
         #expect(result.evidence.contains(.init(code: "dns.success-count", value: "2/3")))
         #expect(result.evidence.contains(.init(code: "dns.failure-count", value: "1/3")))
+    }
+
+    @Test("DNS evidence preserves each sample outcome without exposing host names")
+    func dnsEvidencePreservesSampleOutcomes() async {
+        let result = await DNSResolutionCheck(
+            resolver: MappingDNSResolver(outcomes: [
+                "www.apple.com": .resolved,
+                "www.microsoft.com": .failed,
+                "www.msftconnecttest.com": .indeterminate,
+            ])
+        ).run()
+
+        #expect(result.evidence.contains(.init(code: "dns.sample.apple", value: "resolved")))
+        #expect(result.evidence.contains(.init(code: "dns.sample.microsoft", value: "failed")))
+        #expect(result.evidence.contains(.init(code: "dns.sample.msft-connect-test", value: "indeterminate")))
+        #expect(!result.evidence.contains { $0.value == "www.apple.com" })
     }
 
     @Test("all failed DNS samples are unavailable")
@@ -1716,6 +2184,7 @@ struct NetworkDiagnosticsTests {
         ).run()
 
         #expect(result.status == .normal)
+        #expect(result.proxyFacts == .init(http: .available, https: .available))
         #expect(result.summary == String(
             localized: "network_diagnostics.proxy.routes_available.summary",
             comment: "Network self-check proxy target routes available result summary"
@@ -2223,6 +2692,47 @@ struct NetworkDiagnosticsTests {
         #expect(store.text.isEmpty)
     }
 
+    @Test("diagnostics log store keeps a bounded history and truncation marker")
+    func diagnosticsLogStoreHasFiniteCapacity() {
+        var store = NetworkDiagnosticsLogStore()
+
+        for index in 0..<501 {
+            store.append("event \(index)")
+        }
+
+        #expect(store.lines.count == NetworkDiagnosticsLogStore.capacity)
+        #expect(store.lines.contains(NetworkDiagnosticsLogStore.truncationMarker))
+        #expect(!store.text.contains("event 0\n"))
+        #expect(store.text.contains("event 500"))
+
+        var typedStore = NetworkDiagnosticsLogStore()
+        for index in 0..<501 {
+            typedStore.append(NetworkDiagnosticEvent(
+                runID: UUID(),
+                elapsedMilliseconds: Int64(index),
+                kind: .checkFinished,
+                checkID: .path,
+                reasonCode: nil
+            ))
+        }
+        #expect(typedStore.lines.count == NetworkDiagnosticsLogStore.capacity)
+        #expect(typedStore.events.count == NetworkDiagnosticsLogStore.capacity - 1)
+    }
+
+    @Test("typed diagnostic events only format allowlisted restart reasons")
+    func diagnosticEventFormattingAllowlist() {
+        let event = NetworkDiagnosticEvent(
+            runID: UUID(),
+            elapsedMilliseconds: 42,
+            kind: .restarted,
+            checkID: nil,
+            reasonCode: "raw-sensitive-value"
+        )
+
+        #expect(event.formatted() == "42ms · Network changed; restarting (network state)")
+        #expect(!event.formatted().contains("raw-sensitive-value"))
+    }
+
     @Test("view model publishes its own diagnostic result logs")
     @MainActor
     func viewModelPublishesDiagnosticLogs() async {
@@ -2236,11 +2746,31 @@ struct NetworkDiagnosticsTests {
         #expect(viewModel.start())
         await viewModel.waitForCompletion()
 
-        #expect(viewModel.logStore.lines == [
-            "Checking…",
-            "Network Path: Normal",
-            "DNS Resolution: Normal",
-            "System Proxy: Normal",
+        let stableLogLines = viewModel.logStore.lines.map { line in
+            guard let separator = line.range(of: " · ") else { return line }
+            return String(line[separator.upperBound...])
+        }
+        #expect(stableLogLines == [
+            "Session started",
+            "Run started",
+            "Checking Network Path…",
+            "Network Path finished",
+            "Checking DNS Resolution…",
+            "DNS Resolution finished",
+            "Checking System Proxy…",
+            "System Proxy finished",
+            "Check completed",
+        ])
+        #expect(viewModel.logStore.events.map(\.kind) == [
+            .sessionStarted,
+            .runStarted,
+            .checkStarted,
+            .checkFinished,
+            .checkStarted,
+            .checkFinished,
+            .checkStarted,
+            .checkFinished,
+            .completed,
         ])
 
         viewModel.clearLogs()
@@ -2468,8 +2998,38 @@ struct NetworkDiagnosticsTests {
         viewModel.cancel()
         await viewModel.waitForCompletion()
 
-        #expect(viewModel.phase == .idle)
+        #expect(viewModel.phase == .completed)
         #expect(viewModel.conclusion == nil)
+        #expect(viewModel.endReason == .cancelled)
+    }
+
+    @Test("a cancelled run cannot overwrite a replacement run")
+    @MainActor
+    func cancelledRunCannotOverwriteReplacementRun() async {
+        let probe = CancellationIgnoringDiagnosticProbe()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
+            minimumStepDuration: .zero,
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        viewModel.cancel()
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(2)
+
+        await probe.release(invocation: 1)
+        try? await Task.sleep(for: .milliseconds(10))
+        #expect(viewModel.phase == .running)
+        #expect(viewModel.results.isEmpty)
+
+        await probe.release(invocation: 2)
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.endReason == .completed)
+        #expect(viewModel.results[.path]?.status == .normal)
     }
 
     @Test("a successful diagnostics run reports the completion moment exactly once")
@@ -2512,8 +3072,9 @@ struct NetworkDiagnosticsTests {
         viewModel.cancel()
         await viewModel.waitForCompletion()
 
-        #expect(viewModel.phase == .idle)
+        #expect(viewModel.phase == .completed)
         #expect(viewModel.conclusion == nil)
+        #expect(viewModel.endReason == .cancelled)
         #expect(guidance.store.load().meaningfulCompletionCount == 0)
         #expect(guidance.events.isEmpty)
     }
@@ -2613,6 +3174,79 @@ struct NetworkDiagnosticsTests {
         #expect(observation.baseline.tunnelInterfaces.isEmpty)
         #expect(change?.tunnelInterfaces == ["utun3"])
         #expect(change?.routedTunnelInterface == "utun3")
+    }
+
+    @Test("gateway target identity includes interface index and address state")
+    func fingerprintIncludesRouteAndAddressIdentity() {
+        let first = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.1",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+        let changedAddress = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.11"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.1",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+        let changedRoute = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.254",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+
+        #expect(first != changedAddress)
+        #expect(first != changedRoute)
+    }
+
+    @Test("fingerprint comparison ignores address and tunnel collection order")
+    func fingerprintNormalizesUnorderedCollections() {
+        let first = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            tunnelInterfaces: ["utun3", "utun2"],
+            selectedInterfaceAddresses: ["192.0.2.11", "192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0", "255.255.0.0"]
+        )
+        let reordered = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            tunnelInterfaces: ["utun2", "utun3"],
+            selectedInterfaceAddresses: ["192.0.2.10", "192.0.2.11"],
+            selectedInterfaceSubnets: ["255.255.0.0", "255.255.255.0"]
+        )
+
+        #expect(first == reordered)
+        #expect(first.restartReason(comparedWith: reordered) == .path)
     }
 
     private func makeResults(
@@ -3045,6 +3679,14 @@ private actor StubDNSResolver: DNSResolving {
         invocationCount += 1
         defer { outcomeIndex += 1 }
         return outcomes[min(outcomeIndex, outcomes.endIndex - 1)]
+    }
+}
+
+private struct MappingDNSResolver: DNSResolving {
+    let outcomes: [String: DNSResolutionOutcome]
+
+    func resolve(host: String, timeout: Duration) async -> DNSResolutionOutcome {
+        outcomes[host] ?? .indeterminate
     }
 }
 
@@ -3870,6 +4512,45 @@ private struct BlockingProbeDiagnosticCheck: DiagnosticCheck {
     }
 }
 
+private actor CancellationIgnoringDiagnosticProbe {
+    private var continuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private(set) var invocationCount = 0
+
+    func run() async {
+        invocationCount += 1
+        let invocation = invocationCount
+        let readyWaiters = invocationWaiters.filter { $0.count <= invocation }
+        invocationWaiters.removeAll { $0.count <= invocation }
+        readyWaiters.forEach { $0.continuation.resume() }
+
+        await withCheckedContinuation { continuation in
+            continuations[invocation] = continuation
+        }
+    }
+
+    func waitForInvocationCount(_ expectedCount: Int) async {
+        guard invocationCount < expectedCount else { return }
+        await withCheckedContinuation {
+            invocationWaiters.append((expectedCount, $0))
+        }
+    }
+
+    func release(invocation: Int) {
+        continuations.removeValue(forKey: invocation)?.resume()
+    }
+}
+
+private struct CancellationIgnoringProbeDiagnosticCheck: DiagnosticCheck {
+    let id: NetworkDiagnosticCheckID = .path
+    let probe: CancellationIgnoringDiagnosticProbe
+
+    func run() async -> NetworkDiagnosticResult {
+        await probe.run()
+        return .init(id: id, status: .normal, summary: id.rawValue)
+    }
+}
+
 private actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
     let initial: NetworkFingerprint
     private var lastFingerprint: NetworkFingerprint
@@ -4016,6 +4697,66 @@ private struct StubNetworkInterfaceSource: NetworkInterfaceInfoSourcing {
     }
 }
 
+private actor RecordingGatewayPingProcessRunner: GatewayPingProcessRunning {
+    let latency: Double?
+    private(set) var executablePath: String?
+    private(set) var arguments: [String] = []
+
+    init(latency: Double?) {
+        self.latency = latency
+    }
+
+    func run(executablePath: String, arguments: [String]) async -> Double? {
+        self.executablePath = executablePath
+        self.arguments = arguments
+        return latency
+    }
+
+    func cancel() async {}
+}
+
+private actor RecordingDiagnosticGatewayMeasurer: DiagnosticGatewayMeasuring {
+    private(set) var targets: [DiagnosticGatewayTarget] = []
+
+    func measure(target: DiagnosticGatewayTarget) async -> GatewayLatencyResult {
+        targets.append(target)
+        return GatewayLatencyResult(
+            timestamp: Date(),
+            routerIP: target.address,
+            latencyMs: 2.5
+        )
+    }
+}
+
+private actor SequencedDiagnosticRouteSource: DiagnosticRouteSourcing {
+    private let values: [DiagnosticRouteSelection]
+    private var index = 0
+    private(set) var invocationCount = 0
+
+    init(values: [DiagnosticRouteSelection]) {
+        precondition(!values.isEmpty)
+        self.values = values
+    }
+
+    func currentRoute(timeout: Duration) async -> DiagnosticRouteSelection {
+        invocationCount += 1
+        defer { index += 1 }
+        return values[min(index, values.endIndex - 1)]
+    }
+}
+
+private struct StubNetworkInterfaceSnapshotSource: NetworkInterfaceSnapshotSourcing {
+    let interfaces: [NetworkInterfaceInfo]
+
+    func capture(cycleID: UUID) async -> NetworkInterfaceSnapshot {
+        NetworkInterfaceSnapshot(
+            cycleID: cycleID,
+            capturedAt: Date(),
+            interfaces: interfaces
+        )
+    }
+}
+
 private struct StubGatewayLatencyProvider: GatewayLatencyProviding {
     let result: GatewayLatencyResult
 
@@ -4024,9 +4765,9 @@ private struct StubGatewayLatencyProvider: GatewayLatencyProviding {
     }
 }
 
-private func makeNetworkInterface(router: String?) -> NetworkInterfaceInfo {
+private func makeNetworkInterface(name: String = "en0", router: String?) -> NetworkInterfaceInfo {
     NetworkInterfaceInfo(
-        interfaceName: "en0",
+        interfaceName: name,
         hardwareMAC: "00:11:22:33:44:55",
         ipv4Addresses: ["192.0.2.10"],
         subnetMasks: ["255.255.255.0"],
@@ -4040,5 +4781,23 @@ private func makeNetworkInterface(router: String?) -> NetworkInterfaceInfo {
         txRate: nil,
         phyMode: nil,
         security: "WPA2"
+    )
+}
+
+private func makeDiagnosticContext(
+    pathState: NetworkPathState?,
+    route: DiagnosticRouteSelection,
+    interfaces: [NetworkInterfaceInfo] = []
+) -> DiagnosticNetworkContext {
+    DiagnosticNetworkContext(
+        runID: UUID(),
+        capturedAt: Date(),
+        pathState: pathState,
+        route: route,
+        interfaces: NetworkInterfaceSnapshot(
+            cycleID: UUID(),
+            capturedAt: Date(),
+            interfaces: interfaces
+        )
     )
 }

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -2207,6 +2207,46 @@ struct NetworkDiagnosticsTests {
         #expect(viewModel.executionPhases.values.allSatisfy { $0 == .completed })
     }
 
+    @Test("network diagnostics keeps an isolated resettable log buffer")
+    func networkDiagnosticsLogStoreIsResettable() {
+        var store = NetworkDiagnosticsLogStore()
+
+        store.append("self-check started")
+        store.append("DNS resolved")
+
+        #expect(store.lines == ["self-check started", "DNS resolved"])
+        #expect(store.text == "self-check started\nDNS resolved")
+
+        store.reset()
+
+        #expect(store.lines.isEmpty)
+        #expect(store.text.isEmpty)
+    }
+
+    @Test("view model publishes its own diagnostic result logs")
+    @MainActor
+    func viewModelPublishesDiagnosticLogs() async {
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: DiagnosticTestRecorder()),
+            minimumStepDuration: .zero,
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+        )
+
+        #expect(viewModel.logText.isEmpty)
+        #expect(viewModel.start())
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.logStore.lines == [
+            "Checking…",
+            "Network Path: Normal",
+            "DNS Resolution: Normal",
+            "System Proxy: Normal",
+        ])
+
+        viewModel.clearLogs()
+        #expect(viewModel.logText.isEmpty)
+    }
+
     @Test("view model clears the previous conclusion before a rerun")
     @MainActor
     func viewModelRerun() async {

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -4,3480 +4,10 @@ import Network
 import Testing
 @testable import WiFi_Lens
 
-@Suite("Network diagnostics models and runner")
+@Suite("Network diagnostics")
 struct NetworkDiagnosticsTests {
-    @Test("all app configurations use the same local-network privacy copy")
-    func localNetworkUsageDescriptionIsUnifiedAcrossAppConfigurations() throws {
-        let descriptions = try appLocalNetworkUsageDescriptions()
-        let expectedDescription = "WiFi Lens uses local networking when you enable its MCP server and when Network Self-Check tests reachability of your configured network proxy. These checks do not collect or transmit your Wi-Fi scan data."
 
-        #expect(descriptions.count == 4)
-        #expect(Set(descriptions.map(\.baseConfiguration)) == ["OSS.xcconfig", "PRO.xcconfig"])
-        #expect(descriptions.filter { $0.baseConfiguration == "OSS.xcconfig" }.count == 2)
-        #expect(descriptions.filter { $0.baseConfiguration == "PRO.xcconfig" }.count == 2)
-        #expect(Set(descriptions.map(\.value)) == [expectedDescription])
-        #expect(descriptions.allSatisfy { $0.value.contains("MCP server") })
-        #expect(descriptions.allSatisfy { $0.value.contains("Network Self-Check") })
-    }
-
-    @Test("privacy copy selection excludes decoy non-app configurations")
-    func localNetworkUsageDescriptionSelectionExcludesDecoyConfiguration() throws {
-        let descriptions = try appLocalNetworkUsageDescriptions(from: privacyCopyProjectFixture)
-
-        #expect(descriptions.count == 4)
-        #expect(descriptions.allSatisfy { $0.value == "expected app copy" })
-    }
-
-    @Test("diagnostic identifiers keep path and internet distinct in execution order")
-    func diagnosticIdentifierOrder() {
-        #expect(NetworkDiagnosticCheckID.allCases == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
-        #expect(NetworkDiagnosticCheckID.path != .internet)
-        #expect(Set(NetworkDiagnosticCheckID.allCases).count == 6)
-    }
-
-    @Test("route selection follows the kernel-selected interface")
-    func routeSelectionUsesKernelInterface() {
-        let output = """
-           route to: default
-        destination: default
-               mask: default
-            gateway: 192.0.2.1
-          interface: en7
-              flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
-        """
-
-        let result = DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en0": 4, "en7": 12]
-        )
-
-        #expect(result == .selected(.init(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        )))
-    }
-
-    @Test("missing selected interface does not fall back to another adapter")
-    func missingInterfaceCannotSelectAnotherAdapter() {
-        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
-
-        #expect(DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en0": 4]
-        ) == .unavailable)
-    }
-
-    @Test("route parsing is independent of interface enumeration order")
-    func routeSelectionIgnoresInterfaceEnumerationOrder() {
-        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
-        let firstOrder = DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en0": 4, "en7": 12]
-        )
-        let reversedOrder = DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en7": 12, "en0": 4]
-        )
-
-        #expect(firstOrder == reversedOrder)
-        #expect(firstOrder == .selected(.init(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        )))
-    }
-
-    @Test("same gateway address remains tied to the selected interface")
-    func sameGatewayAddressDoesNotCollapseInterfaceIdentity() {
-        let output = "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
-
-        #expect(DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en0": 4, "en7": 12]
-        ) == .selected(.init(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        )))
-    }
-
-    @Test("duplicate route fields cannot produce a selected target")
-    func duplicateRouteFieldsAreRejected() {
-        let output = """
-        destination: default
-        gateway: 192.0.2.1
-        gateway: 192.0.2.254
-        interface: en7
-        flags: <UP,GATEWAY>
-        """
-
-        #expect(DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en7": 12]
-        ) == .ambiguous)
-    }
-
-    @Test("invalid gateway addresses cannot be selected")
-    func invalidGatewayAddressesAreRejected() {
-        let addresses = ["0.0.0.0", "224.0.0.1", "255.255.255.255", "not-an-ip"]
-
-        for address in addresses {
-            let output = "destination: default\ngateway: \(address)\ninterface: en7\nflags: <UP,GATEWAY>"
-            let result = DiagnosticRouteParser.parse(
-                output: output,
-                interfaceIndices: ["en7": 12]
-            )
-            #expect(result == .unavailable)
-        }
-    }
-
-    @Test("link-layer gateways and tunnel interfaces are unsupported")
-    func unsupportedRouteTargetsAreRejected() {
-        let linkLayer = "destination: default\ngateway: link#4\ninterface: en7\nflags: <UP,GATEWAY>"
-        let tunnel = "destination: default\ngateway: 192.0.2.1\ninterface: utun3\nflags: <UP,GATEWAY>"
-
-        #expect(DiagnosticRouteParser.parse(
-            output: linkLayer,
-            interfaceIndices: ["en7": 12]
-        ) == .unsupported)
-        #expect(DiagnosticRouteParser.parse(
-            output: tunnel,
-            interfaceIndices: ["utun3": 20]
-        ) == .unsupported)
-    }
-
-    @Test("missing default route is unavailable")
-    func missingDefaultRouteIsUnavailable() {
-        let output = "gateway: 192.0.2.1\ninterface: en7\nflags: <UP,GATEWAY>"
-
-        #expect(DiagnosticRouteParser.parse(
-            output: output,
-            interfaceIndices: ["en7": 12]
-        ) == .unavailable)
-    }
-
-    @Test("route parser requires both UP and GATEWAY flags")
-    func routeParserRequiresUsableDefaultFlags() {
-        let records = [
-            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <GATEWAY>",
-            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <UP>",
-            "destination: default\ngateway: 192.0.2.1\ninterface: en7\nflags: <>"
-        ]
-
-        for output in records {
-            #expect(DiagnosticRouteParser.parse(
-                output: output,
-                interfaceIndices: ["en7": 12]
-            ) == .unavailable)
-        }
-    }
-
-    @Test("route command timeout terminates the child without waiting for EOF")
-    func routeCommandTimeoutDoesNotWaitForChild() async {
-        let execution = DiagnosticRouteProcessExecution(
-            executablePath: "/bin/sleep",
-            arguments: ["5"],
-            environment: [:],
-            outputLimit: 1024
-        )
-        let startedAt = ContinuousClock.now
-        let result = await execution.run(timeout: .milliseconds(50))
-        let elapsed = startedAt.duration(to: ContinuousClock.now)
-
-        #expect(result.timedOut)
-        #expect(elapsed < .seconds(2))
-    }
-
-    @Test("diagnostic gateway ping binds the selected interface")
-    func diagnosticGatewayPingBindsSelectedInterface() async {
-        let runner = RecordingGatewayPingProcessRunner(latency: 2.5)
-        let pinger = GatewayPinger(processRunner: runner)
-        let target = DiagnosticGatewayTarget(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        )
-
-        _ = await pinger.ping(target: target)
-
-        #expect(await runner.executablePath == "/sbin/ping")
-        #expect(await runner.arguments == [
-            "-b", "en7", "-c", "1", "-W", "1000", "192.0.2.1"
-        ])
-    }
-
-    @Test("overlapping ping runs preserve the latest cancellation owner")
-    func overlappingPingRunsPreserveCancellationOwnership() async {
-        let runner = SystemGatewayPingProcessRunner()
-        let first = Task {
-            await runner.run(executablePath: "/bin/sleep", arguments: ["0.1"])
-        }
-
-        try? await Task.sleep(for: .milliseconds(50))
-        let secondStartedAt = ContinuousClock.now
-        let second = Task {
-            await runner.run(executablePath: "/bin/sleep", arguments: ["10"])
-        }
-
-        try? await Task.sleep(for: .milliseconds(400))
-        await runner.cancel()
-
-        #expect(await first.value == nil)
-        #expect(await second.value == nil)
-        #expect(secondStartedAt.duration(to: ContinuousClock.now) < .seconds(1))
-    }
-
-    @Test("contextual path and gateway checks use one selected interface")
-    func contextualChecksShareSelectedRouteTarget() async {
-        let context = makeDiagnosticContext(
-            pathState: .satisfied,
-            route: .selected(.init(
-                interfaceName: "en7",
-                interfaceIndex: 12,
-                address: "192.0.2.1"
-            )),
-            interfaces: [
-                makeNetworkInterface(name: "en0", router: "192.0.2.1"),
-                makeNetworkInterface(name: "en7", router: "192.0.2.1"),
-            ]
-        )
-        let gateway = RecordingDiagnosticGatewayMeasurer()
-
-        let pathResult = await NetworkConnectivityCheck(context: context).run()
-        let gatewayResult = await GatewayReachabilityCheck(
-            context: context,
-            gatewayMeasuring: gateway,
-            routeSource: nil
-        ).run()
-
-        #expect(pathResult.evidence.contains(.init(code: "path.interface", value: "en7")))
-        #expect(pathResult.evidence.contains(.init(code: "path.gateway", value: "192.0.2.1")))
-        #expect(gatewayResult.evidence.contains(.init(code: "gateway.interface", value: "en7")))
-        #expect(await gateway.targets == [
-            .init(interfaceName: "en7", interfaceIndex: 12, address: "192.0.2.1")
-        ])
-    }
-
-    @Test("context capture accepts a stable route")
-    func diagnosticContextCaptureAcceptsStableRoute() async {
-        let route = DiagnosticRouteSelection.selected(.init(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        ))
-        let routeSource = SequencedDiagnosticRouteSource(values: [route, route])
-        let source = SystemDiagnosticNetworkContextSource(
-            routeSource: routeSource,
-            pathSource: StubPathSource(.satisfied),
-            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
-        )
-
-        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
-
-        #expect(context?.route == route)
-        #expect(context?.pathState == .satisfied)
-        #expect(await routeSource.invocationCount == 2)
-    }
-
-    @Test("context capture does not publish a conflicting route")
-    func diagnosticContextCaptureRejectsChangingRoute() async {
-        let first = DiagnosticRouteSelection.selected(.init(
-            interfaceName: "en0",
-            interfaceIndex: 4,
-            address: "192.0.2.1"
-        ))
-        let second = DiagnosticRouteSelection.selected(.init(
-            interfaceName: "en7",
-            interfaceIndex: 12,
-            address: "192.0.2.1"
-        ))
-        let routeSource = SequencedDiagnosticRouteSource(values: [first, second, first, second])
-        let source = SystemDiagnosticNetworkContextSource(
-            routeSource: routeSource,
-            pathSource: StubPathSource(.satisfied),
-            interfaceSource: StubNetworkInterfaceSnapshotSource(interfaces: [])
-        )
-
-        let context = await source.capture(runID: UUID(), timeout: .seconds(1))
-
-        #expect(context?.route == .ambiguous)
-        #expect(await routeSource.invocationCount == 4)
-    }
-
-    @Test("route change during gateway ping suppresses the old result")
-    func gatewayRouteChangeSuppressesStaleResult() async {
-        let target = DiagnosticGatewayTarget(
-            interfaceName: "en0",
-            interfaceIndex: 4,
-            address: "192.0.2.1"
-        )
-        let context = makeDiagnosticContext(
-            pathState: .satisfied,
-            route: .selected(target)
-        )
-        let gateway = RecordingDiagnosticGatewayMeasurer()
-        let routeSource = SequencedDiagnosticRouteSource(values: [.unavailable])
-
-        let result = await GatewayReachabilityCheck(
-            context: context,
-            gatewayMeasuring: gateway,
-            routeSource: routeSource
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "gateway.route-changed", value: nil)))
-    }
-
-    @Test("missing diagnostic route never starts a gateway ping")
-    func missingDiagnosticRouteDoesNotPing() async {
-        let context = makeDiagnosticContext(pathState: .satisfied, route: .unavailable)
-        let gateway = RecordingDiagnosticGatewayMeasurer()
-
-        let result = await GatewayReachabilityCheck(
-            context: context,
-            gatewayMeasuring: gateway
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(await gateway.targets.isEmpty)
-    }
-
-    @Test("blocked and skipped statuses have distinct presentations")
-    func blockedAndSkippedPresentation() {
-        #expect(NetworkDiagnosticStatus.blocked.presentation == .init(
-            labelKey: "network_diagnostics.status.blocked",
-            icon: "lock.fill",
-            tone: .informational
-        ))
-        #expect(NetworkDiagnosticStatus.skipped.presentation == .init(
-            labelKey: "network_diagnostics.status.skipped",
-            icon: "forward.fill",
-            tone: .muted
-        ))
-        #expect(NetworkDiagnosticStatus.blocked.presentation != NetworkDiagnosticStatus.indeterminate.presentation)
-        #expect(NetworkDiagnosticStatus.skipped.presentation != NetworkDiagnosticStatus.indeterminate.presentation)
-    }
-
-    @Test("proxy authentication evidence maps to a credential remediation")
-    func proxyAuthenticationRemediation() {
-        let result = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .abnormal,
-            summary: "Proxy authentication required",
-            evidence: [.init(code: "proxy.authentication-required", value: "407")]
-        )
-
-        let remediation = NetworkDiagnosticRemediation.forResult(result)
-
-        #expect(remediation.actionKey == "network_diagnostics.remediation.proxy_authentication.action")
-        #expect(remediation.rerunKey == "network_diagnostics.remediation.rerun")
-    }
-
-    @Test("indeterminate remediation does not claim a confirmed cause")
-    func indeterminateRemediationIsTentative() {
-        let result = NetworkDiagnosticResult(
-            id: .dns,
-            status: .indeterminate,
-            summary: "DNS could not be determined"
-        )
-
-        let remediation = NetworkDiagnosticRemediation.forResult(result)
-
-        #expect(remediation.causeKey == "network_diagnostics.remediation.indeterminate.cause")
-        #expect(remediation.actionKey == "network_diagnostics.remediation.indeterminate.action")
-    }
-
-    @Test("proxy remediation follows final route facts instead of failed candidates")
-    func proxyRemediationUsesFinalRouteFacts() {
-        let result = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .indeterminate,
-            summary: "proxy route recovered",
-            evidence: [.init(code: "proxy.authentication-required", value: "407")],
-            proxyFacts: .init(http: .available, https: .available)
-        )
-
-        #expect(NetworkDiagnosticRemediation.forResult(result).actionKey
-            == "network_diagnostics.remediation.indeterminate.action")
-    }
-
-    @Test("a blocked probe does not become an independent network fault")
-    func blockedProbeIsNotAbnormal() {
-        let result = NetworkDiagnosticResult.blocked(id: .internet, summary: "DNS is unavailable")
-        #expect(result.status == .blocked)
-        #expect(result.detail == "DNS is unavailable")
-    }
-
-    @Test("runner blocks gateway reachability after a hard path failure")
-    func runnerBlocksGatewayReachabilityAfterPathFailure() async {
-        let recorder = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = [
-            StubDiagnosticCheck(id: .path, result: NetworkDiagnosticResult(id: .path, status: .abnormal, summary: "no path"), recorder: recorder),
-            StubDiagnosticCheck(id: .gatewayReachability, result: NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "unused"), recorder: recorder),
-            StubDiagnosticCheck(id: .dns, result: NetworkDiagnosticResult(id: .dns, status: .normal, summary: "unused"), recorder: recorder),
-        ]
-        let runner = DiagnosticRunner(checks: checks)
-
-        let results = (await runner.run { _ in }).results
-
-        #expect(results.map(\.id) == [.path, .gatewayReachability, .dns])
-        #expect(results[1].status == .blocked)
-        #expect(results[1].evidence.contains(.init(code: "blocked.by", value: "path")))
-    }
-
-    @Test("gateway reachability abnormal does not block downstream checks")
-    func gatewayReachabilityAbnormalDoesNotBlockDownstream() async {
-        let recorder = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            let status: NetworkDiagnosticStatus = id == .gatewayReachability ? .abnormal : .normal
-            return StubDiagnosticCheck(id: id, result: NetworkDiagnosticResult(id: id, status: status, summary: id.rawValue), recorder: recorder)
-        }
-        let runner = DiagnosticRunner(checks: checks)
-
-        let results = (await runner.run { _ in }).results
-
-        #expect(results.map(\.id) == NetworkDiagnosticCheckID.allCases)
-        #expect(results[1].status == .abnormal)
-        #expect(results[2].status == .normal)
-        #expect(results[3].status == .normal)
-        #expect(results[4].status == .normal)
-    }
-
-    @Test("gateway reachability abnormal drives the needs attention conclusion")
-    func gatewayReachabilityDrivesNeedsAttention() {
-        let results = [
-            NetworkDiagnosticResult(id: .path, status: .normal, summary: ""),
-            NetworkDiagnosticResult(id: .gatewayReachability, status: .abnormal, summary: ""),
-            NetworkDiagnosticResult(id: .dns, status: .normal, summary: ""),
-            NetworkDiagnosticResult(id: .internet, status: .normal, summary: ""),
-            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: ""),
-            NetworkDiagnosticResult(id: .proxy, status: .normal, summary: ""),
-        ]
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-        #expect(NetworkDiagnosticConclusion.primaryIssue(in: results)?.id == .gatewayReachability)
-    }
-
-    @Test("stage resolver aggregates this mac from path dns and proxy and maps lan to its check")
-    func stageResolverThisMacAndLan() {
-        let resolver = NetworkDiagnosticStageResolver()
-        let abnormalDNS: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .path: .init(id: .path, status: .normal, summary: ""),
-            .dns: .init(id: .dns, status: .abnormal, summary: ""),
-            .proxy: .init(id: .proxy, status: .normal, summary: ""),
-            .gatewayReachability: .init(id: .gatewayReachability, status: .normal, summary: ""),
-        ]
-
-        #expect(resolver.status(for: .thisMac, results: abnormalDNS) == .abnormal)
-        #expect(resolver.status(for: .lan, results: abnormalDNS) == .normal)
-        let proxyOnly: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .path: .init(id: .path, status: .normal, summary: ""),
-            .dns: .init(id: .dns, status: .normal, summary: ""),
-            .proxy: .init(id: .proxy, status: .abnormal, summary: ""),
-            .gatewayReachability: .init(id: .gatewayReachability, status: .normal, summary: ""),
-        ]
-        #expect(resolver.status(for: .thisMac, results: proxyOnly) == .abnormal)
-        #expect(resolver.status(for: .thisMac, results: [:]) == nil)
-        let missingContributors: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .path: .init(id: .path, status: .normal, summary: ""),
-        ]
-        #expect(resolver.status(for: .thisMac, results: missingContributors) == nil)
-    }
-
-    @Test("internet stage follows the internet check and ignores dns and ipv6")
-    func stageResolverInternet() {
-        let resolver = NetworkDiagnosticStageResolver()
-
-        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .normal, summary: "")]) == .normal)
-        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .abnormal, summary: "")]) == .abnormal)
-        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .indeterminate, summary: "")]) == .indeterminate)
-        #expect(resolver.status(for: .internet, results: [.internet: .init(id: .internet, status: .blocked, summary: "")]) == .blocked)
-        let extras: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .internet: .init(id: .internet, status: .normal, summary: ""),
-            .dns: .init(id: .dns, status: .abnormal, summary: ""),
-            .ipv6: .init(id: .ipv6, status: .abnormal, summary: ""),
-        ]
-        #expect(resolver.status(for: .internet, results: extras) == .normal)
-    }
-
-    @Test("internet stage requires the internet result")
-    func stageResolverRequiresInternetResult() {
-        let resolver = NetworkDiagnosticStageResolver()
-        let partial: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .dns: .init(id: .dns, status: .normal, summary: ""),
-        ]
-
-        #expect(resolver.status(for: .internet, results: partial) == nil)
-    }
-
-    @Test("pipeline presentation maps stages to stations and edges")
-    func pipelinePresentation() {
-        let results: [NetworkDiagnosticCheckID: NetworkDiagnosticResult] = [
-            .path: .init(id: .path, status: .normal, summary: ""),
-            .gatewayReachability: .init(id: .gatewayReachability, status: .abnormal, summary: ""),
-            .dns: .init(id: .dns, status: .normal, summary: ""),
-            .internet: .init(id: .internet, status: .normal, summary: ""),
-            .ipv6: .init(id: .ipv6, status: .skipped, summary: ""),
-            .proxy: .init(id: .proxy, status: .normal, summary: ""),
-        ]
-        let presentation = NetworkDiagnosticsPipelinePresentation.from(
-            results: results,
-            executionPhases: [:]
-        )
-
-        #expect(presentation.stations.map(\.kind) == [.thisMac, .router, .internet])
-        #expect(presentation.edges.map(\.kind) == [.lan, .internet])
-        #expect(presentation.stations[0].status == .normal)
-        #expect(presentation.stations[1].status == .abnormal)
-        #expect(presentation.stations[1].isUnreachable)
-        #expect(presentation.stations[2].status == .normal)
-        #expect(!presentation.stations[2].isUnreachable)
-        #expect(presentation.edges[0].status == .abnormal)
-        #expect(presentation.edges[1].status == .normal)
-    }
-
-    @Test("pipeline edge becomes active while its checks are running")
-    func pipelineEdgeActive() {
-        let executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase] = [
-            .gatewayReachability: .checking,
-        ]
-        let presentation = NetworkDiagnosticsPipelinePresentation.from(
-            results: [:],
-            executionPhases: executionPhases
-        )
-
-        #expect(presentation.edges[0].isActive)
-        #expect(!presentation.edges[1].isActive)
-    }
-
-    @Test("runner executes checks and publishes results in order")
-    func runnerOrder() async {
-        let invocations = DiagnosticTestRecorder()
-        let publications = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            StubDiagnosticCheck(
-                id: id,
-                result: NetworkDiagnosticResult(id: id, status: .normal, summary: id.rawValue),
-                recorder: invocations
-            )
-        }
-
-        let results = (await DiagnosticRunner(checks: checks).run { result in
-            await publications.record(result.id)
-        }).results
-
-        #expect(results.map(\.id) == NetworkDiagnosticCheckID.allCases)
-        #expect(await invocations.values == NetworkDiagnosticCheckID.allCases)
-        #expect(await publications.values == NetworkDiagnosticCheckID.allCases)
-    }
-
-    @Test("runner enforces an overall session budget")
-    func runnerEnforcesOverallBudget() async {
-        let probe = BudgetAwareDiagnosticProbe()
-        let clock = ManualDiagnosticClock()
-        let task = Task {
-            await DiagnosticRunner(
-                checks: [BudgetAwareDiagnosticCheck(probe: probe)],
-                sessionBudget: .seconds(1),
-                clock: clock
-            ).run { _ in }
-        }
-
-        await probe.waitForInvocation()
-        await clock.waitForSleeperCount(1)
-        await clock.set(clock.origin.advanced(by: .seconds(1)))
-
-        let outcome = await task.value
-
-        #expect(await probe.wasCancelled)
-        #expect(outcome.results.map(\.id) == [.path])
-        #expect(outcome.results.first?.status == .indeterminate)
-        #expect(outcome.results.first?.evidence == [.init(code: "check.timeout", value: nil)])
-        #expect(outcome.pendingIDs.isEmpty)
-        #expect(outcome.endReason == .timedOut)
-    }
-
-    @Test("runner returns when a cancelled check ignores cancellation")
-    func runnerDoesNotWaitForCancellationIgnoringCheck() async {
-        let probe = CancellationIgnoringDiagnosticProbe()
-        let task = Task {
-            await DiagnosticRunner(
-                checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
-                sessionBudget: .seconds(30)
-            ).run { _ in }
-        }
-
-        await probe.waitForInvocationCount(1)
-        task.cancel()
-        let outcome = await task.value
-
-        #expect(outcome.results.isEmpty)
-        #expect(outcome.pendingIDs == [.path])
-        #expect(outcome.endReason == .cancelled)
-        await probe.release(invocation: 1)
-    }
-
-    @Test("publication gate rejects an old run after a replacement starts")
-    func oldRunCannotPublishIntoNewRun() {
-        let oldID = UUID()
-        let newID = UUID()
-        let gate = DiagnosticPublicationGate(activeRunID: newID)
-
-        #expect(!gate.accepts(oldID))
-        #expect(gate.accepts(newID))
-    }
-
-    @Test("runner preserves completed results and identifies pending checks on cancellation")
-    func runnerReturnsPartialCancelledOutcome() async {
-        let probe = BlockingDiagnosticProbe()
-        let checks: [any DiagnosticCheck] = [
-            StubDiagnosticCheck(
-                id: .path,
-                result: .init(id: .path, status: .normal, summary: "path"),
-                recorder: DiagnosticTestRecorder()
-            ),
-            BlockingProbeDiagnosticCheck(id: .gatewayReachability, probe: probe),
-        ]
-        let runner = DiagnosticRunner(checks: checks)
-        let task = Task { await runner.run { _ in } }
-
-        await probe.waitForInvocationCount(1)
-        task.cancel()
-        let outcome = await task.value
-
-        #expect(outcome.results.map(\.id) == [.path])
-        #expect(outcome.pendingIDs == [.gatewayReachability])
-        #expect(outcome.endReason == .cancelled)
-    }
-
-    @Test("indeterminate DNS does not block internet or IPv6")
-    func indeterminateDNSDoesNotBlockInternetOrIPv6() async {
-        let invocations = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            StubDiagnosticCheck(
-                id: id,
-                result: NetworkDiagnosticResult(
-                    id: id,
-                    status: id == .dns ? .indeterminate : .normal,
-                    summary: id.rawValue
-                ),
-                recorder: invocations
-            )
-        }
-
-        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
-
-        #expect(results.map(\.status) == [.normal, .normal, .indeterminate, .normal, .normal, .normal])
-        #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
-    }
-
-    @Test("abnormal DNS does not block independent hostname checks")
-    func abnormalDNSDoesNotBlockHostnameDependentChecks() async {
-        let invocations = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            StubDiagnosticCheck(
-                id: id,
-                result: NetworkDiagnosticResult(
-                    id: id,
-                    status: id == .dns ? .abnormal : .normal,
-                    summary: id.rawValue
-                ),
-                recorder: invocations
-            )
-        }
-
-        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
-
-        #expect(results.map(\.status) == [.normal, .normal, .abnormal, .normal, .normal, .normal])
-        #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
-    }
-
-    @Test("indeterminate path continues independent evidence probes")
-    func indeterminatePathContinuesIndependentEvidenceProbes() async {
-        let invocations = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            StubDiagnosticCheck(
-                id: id,
-                result: NetworkDiagnosticResult(
-                    id: id,
-                    status: id == .path ? .indeterminate : .normal,
-                    summary: id.rawValue
-                ),
-                recorder: invocations
-            )
-        }
-
-        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
-
-        #expect(results.map(\.status) == [.indeterminate, .normal, .normal, .normal, .normal, .normal])
-        #expect(await invocations.values == [.path, .gatewayReachability, .dns, .internet, .ipv6, .proxy])
-    }
-
-    @Test("abnormal path blocks network probes")
-    func abnormalPathBlocksNetworkProbes() async {
-        let invocations = DiagnosticTestRecorder()
-        let checks: [any DiagnosticCheck] = NetworkDiagnosticCheckID.allCases.map { id in
-            StubDiagnosticCheck(
-                id: id,
-                result: NetworkDiagnosticResult(
-                    id: id,
-                    status: id == .path ? .abnormal : .normal,
-                    summary: id.rawValue
-                ),
-                recorder: invocations
-            )
-        }
-
-        let results = (await DiagnosticRunner(checks: checks).run { _ in }).results
-
-        #expect(results.map(\.status) == [.abnormal, .blocked, .blocked, .blocked, .blocked, .blocked])
-        #expect(await invocations.values == [.path])
-    }
-
-    @Test("system path failure makes the network unavailable")
-    func unavailableConclusion() {
-        let results = makeResults(path: .abnormal, dns: .normal, internet: .normal, proxy: .normal)
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkUnavailable)
-    }
-
-    @Test("DNS or proxy failure needs attention")
-    func abnormalConclusion() {
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            makeResults(path: .normal, dns: .abnormal, internet: .normal, proxy: .normal)
-        ) == .needsAttention)
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            makeResults(path: .normal, dns: .normal, internet: .normal, proxy: .abnormal)
-        ) == .needsAttention)
-    }
-
-    @Test("failed base HTTPS suppresses proxy endpoint symptom without declaring outage")
-    func conclusionSuppressesProxySymptom() {
-        var results = makeResults(
-            path: .normal,
-            dns: .indeterminate,
-            internet: .abnormal,
-            proxy: .abnormal
-        )
-        results[3] = NetworkDiagnosticResult(
-            id: .internet,
-            status: .abnormal,
-            summary: "internet",
-            evidence: [.init(
-                code: "https.connectivity-error",
-                value: String(URLError.timedOut.rawValue)
-            )]
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("failed direct path with a usable HTTPS proxy needs attention")
-    func usableProxyPreventsNetworkUnavailableConclusion() {
-        var results = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .abnormal,
-            proxy: .normal
-        )
-        results[5] = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .normal,
-            summary: "proxy",
-            evidence: [.init(code: "proxy.https.egress-status", value: "200")]
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("DIRECT routing without direct egress needs attention")
-    func directRouteDecisionDoesNotProveConnectivity() {
-        var results = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .abnormal,
-            proxy: .normal
-        )
-        results[3] = NetworkDiagnosticResult(
-            id: .internet,
-            status: .abnormal,
-            summary: "internet",
-            evidence: [.init(
-                code: "https.connectivity-error",
-                value: String(URLError.notConnectedToInternet.rawValue)
-            )]
-        )
-        results[5] = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .normal,
-            summary: "proxy",
-            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")]
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("base HTTPS success and explicit proxy failure needs attention")
-    func proxyIsIndependentWhenBasePathWorks() {
-        let results: [NetworkDiagnosticResult] = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .normal,
-            proxy: .abnormal
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("captive portal symptom after HTTPS success needs attention")
-    func captivePortalSymptomAfterHTTPSSuccess() {
-        let results = [
-            NetworkDiagnosticResult(id: .path, status: .normal, summary: "path"),
-            NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "gateway"),
-            NetworkDiagnosticResult(id: .dns, status: .normal, summary: "dns"),
-            NetworkDiagnosticResult(
-                id: .internet,
-                status: .abnormal,
-                summary: "internet",
-                evidence: [
-                    .init(code: "https.available", value: "200"),
-                    .init(code: "captive-portal.suspected", value: nil),
-                ]
-            ),
-            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: "ipv6"),
-            NetworkDiagnosticResult(id: .proxy, status: .normal, summary: "proxy"),
-        ]
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-        #expect(assessment.primaryIssue?.id == .internet)
-    }
-
-    @Test("an indeterminate result needs attention")
-    func indeterminateConclusion() {
-        let results = makeResults(path: .normal, dns: .indeterminate, internet: .normal, proxy: .normal)
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("normal required results and skipped optional IPv6 make the network normal")
-    func fourResultNormalConclusion() {
-        let results = makeResults(path: .normal, dns: .normal, internet: .normal, proxy: .normal)
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkNormal)
-    }
-
-    @Test("verified base connectivity keeps an unverified DIRECT proxy route neutral")
-    func verifiedBaseConnectivityKeepsDirectRouteNeutral() {
-        var results = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .normal,
-            proxy: .indeterminate
-        )
-        results[5] = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .indeterminate,
-            summary: "direct routing selected",
-            evidence: [.init(code: "proxy.https.egress-status", value: "base-check")],
-            proxyFacts: .init(http: .unverified, https: .unverified)
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .networkNormal)
-    }
-
-    @Test("PAC resolution failures are not neutralized as explicit DIRECT")
-    func pacResolutionFailureDoesNotBecomeNormal() {
-        let results = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .normal,
-            proxy: .indeterminate
-        ).map { result in
-            guard result.id == .proxy else { return result }
-            return NetworkDiagnosticResult(
-                id: .proxy,
-                status: .indeterminate,
-                summary: "proxy resolution failed",
-                evidence: [
-                    .init(code: "proxy.http.resolution", value: "pac-timeout"),
-                    .init(code: "proxy.https.resolution", value: "pac-timeout"),
-                ],
-                proxyFacts: .init(http: .unverified, https: .unverified)
-            )
-        }
-
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-
-        #expect(assessment.conclusion == .needsAttention)
-    }
-
-    @Test("a single HTTPS target failure is needs attention, not universal outage")
-    func singleHTTPSFailureIsNotNetworkUnavailable() {
-        var results = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .abnormal,
-            proxy: .indeterminate
-        )
-        results[3] = NetworkDiagnosticResult(
-            id: .internet,
-            status: .abnormal,
-            summary: "one HTTPS target failed",
-            evidence: [.init(code: "https.connectivity-error", value: nil)]
-        )
-
-        #expect(NetworkDiagnosticConclusion.evaluate(results) == .needsAttention)
-    }
-
-    @Test("DNS uncertainty is not hidden by a neutral DIRECT proxy")
-    func dnsUncertaintyRemainsVisibleAlongsideDirectProxy() {
-        var results = makeResults(
-            path: .normal,
-            dns: .indeterminate,
-            internet: .normal,
-            proxy: .indeterminate
-        )
-        results[5] = NetworkDiagnosticResult(
-            id: .proxy,
-            status: .indeterminate,
-            summary: "direct routing selected",
-            proxyFacts: .init(http: .unverified, https: .unverified)
-        )
-
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-
-        #expect(assessment.conclusion == .needsAttention)
-        #expect(assessment.stages.first { $0.stage == .thisMac }?.status == .indeterminate)
-    }
-
-    @Test("HTTPS availability is retained even when HTTP proxy routing fails")
-    func httpsAvailabilityDoesNotDependOnHTTP() {
-        let facts = DiagnosticProxyFacts(http: .unavailable, https: .available)
-        #expect(facts.https == .available)
-
-        let results: [NetworkDiagnosticResult] = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .abnormal,
-            proxy: .abnormal
-        ).map { result in
-            if result.id == .internet {
-                return NetworkDiagnosticResult(
-                    id: result.id,
-                    status: result.status,
-                    summary: result.summary,
-                    evidence: [.init(code: "https.connectivity-error", value: nil)]
-                )
-            }
-            if result.id == .proxy {
-                return NetworkDiagnosticResult(
-                    id: result.id,
-                    status: result.status,
-                    summary: result.summary,
-                    evidence: [.init(code: "proxy.endpoint-unavailable", value: nil)],
-                    proxyFacts: facts
-                )
-            }
-            return result
-        }
-
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-        #expect(assessment.conclusion == .needsAttention)
-        #expect(assessment.primaryIssue?.id == .proxy)
-    }
-
-    @Test("recovered proxy candidates do not leave an authentication action")
-    func recoveredProxyCandidateDoesNotRemainActionable() {
-        let results: [NetworkDiagnosticResult] = makeResults(
-            path: .normal,
-            dns: .normal,
-            internet: .normal,
-            proxy: .normal
-        ).map { result in
-            guard result.id == .proxy else { return result }
-            return NetworkDiagnosticResult(
-                id: .proxy,
-                status: .normal,
-                summary: "HTTPS proxy recovered",
-                evidence: [.init(code: "proxy.https.authentication-required", value: "407")],
-                proxyFacts: .init(http: .available, https: .available)
-            )
-        }
-
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-        #expect(assessment.conclusion == .networkNormal)
-        #expect(assessment.primaryIssue == nil)
-    }
-
-    @Test("no global IPv6 address is skipped without changing a normal conclusion")
-    func ipv6SkippedIsConclusionNeutral() async {
-        let ipv6 = await IPv6ControlEndpointCheck(
-            loader: StubIPv6Loader(.noGlobalAddress)
-        ).run()
-
-        #expect(ipv6.id == .ipv6)
-        #expect(ipv6.status == .skipped)
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            makeResults(
-                path: .normal,
-                dns: .normal,
-                internet: .normal,
-                ipv6: ipv6.status,
-                proxy: .normal
-            )
-        ) == .networkNormal)
-    }
-
-    @Test("IPv6 failure does not affect the overall conclusion")
-    func ipv6IsConclusionNeutral() async {
-        let ipv6 = await IPv6ControlEndpointCheck(loader: StubIPv6Loader(.failed)).run()
-
-        #expect(ipv6.status == .indeterminate)
-        #expect(ipv6.evidence.contains(.init(code: "ipv6.unavailable", value: nil)))
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            makeResults(
-                path: .normal,
-                dns: .normal,
-                internet: .normal,
-                ipv6: ipv6.status,
-                proxy: .normal
-            )
-        ) == .networkNormal)
-    }
-
-    @Test("IPv6 control endpoint success is normal")
-    func ipv6Success() async {
-        let result = await IPv6ControlEndpointCheck(loader: StubIPv6Loader(.succeeded)).run()
-
-        #expect(result.status == .normal)
-        #expect(result.evidence.contains(.init(code: "ipv6.available", value: nil)))
-    }
-
-    @Test("system IPv6 loader connects only to a resolved IPv6 literal")
-    func ipv6LoaderForcesResolvedAddress() async {
-        let recorder = IPv6LoaderTestRecorder()
-        let loader = SystemIPv6ControlEndpointLoader(
-            addressSource: StubGlobalIPv6AddressSource(hasAddress: true),
-            resolver: StubIPv6AddressResolver(addresses: ["2001:db8::42"]),
-            connector: RecordingIPv6HTTPSConnector(succeeds: true, recorder: recorder)
-        )
-        let endpoint = URL(string: "https://control.example/health")!
-
-        let outcome = await loader.load(url: endpoint, timeout: .seconds(4))
-
-        #expect(outcome == .succeeded)
-        let requests = await recorder.requests
-        #expect(requests.count == 1)
-        #expect(requests.first?.url == endpoint)
-        #expect(requests.first?.ipv6Address == "2001:db8::42")
-        #expect(requests.first?.serverName == "control.example")
-        #expect(requests.first.map { $0.timeout > .zero && $0.timeout <= .seconds(4) } == true)
-    }
-
-    @Test("system IPv6 loader tries later resolved addresses")
-    func ipv6LoaderFallsBackAcrossAddresses() async {
-        let connector = SequencedIPv6HTTPSConnector(successfulAddress: "2001:db8::2")
-        let loader = SystemIPv6ControlEndpointLoader(
-            addressSource: StubGlobalIPv6AddressSource(hasAddress: true),
-            resolver: StubIPv6AddressResolver(addresses: ["2001:db8::1", "2001:db8::2"]),
-            connector: connector
-        )
-
-        let outcome = await loader.load(
-            url: URL(string: "https://control.example/health")!,
-            timeout: .seconds(4)
-        )
-
-        #expect(outcome == .succeeded)
-        #expect(await connector.addresses == ["2001:db8::1", "2001:db8::2"])
-        let timeouts = await connector.timeouts
-        #expect(timeouts.count == 2)
-        #expect(timeouts.first.map { $0 > .zero && $0 <= .seconds(2) } == true)
-        #expect(timeouts.last.map { $0 > .zero && $0 <= .seconds(4) } == true)
-    }
-
-    @Test("system IPv6 loader skips resolution when no global address is present")
-    func ipv6LoaderSkipsWithoutGlobalAddress() async {
-        let resolver = RecordingIPv6AddressResolver(addresses: ["2001:db8::42"])
-        let loader = SystemIPv6ControlEndpointLoader(
-            addressSource: StubGlobalIPv6AddressSource(hasAddress: false),
-            resolver: resolver,
-            connector: StubIPv6HTTPSConnector(succeeds: true)
-        )
-
-        let outcome = await loader.load(
-            url: URL(string: "https://control.example/")!,
-            timeout: .seconds(4)
-        )
-
-        #expect(outcome == .noGlobalAddress)
-        #expect(await resolver.hosts.isEmpty)
-    }
-
-    @Test("IPv6 DNS configures delivery before the resolver context owns the service")
-    func ipv6DNSActivationOrder() {
-        var events: [String] = []
-
-        IPv6DNSServiceActivation.configureThenInstall(
-            configureDelivery: { events.append("configure") },
-            installOwnership: { events.append("install") }
-        )
-
-        #expect(events == ["configure", "install"])
-    }
-
-    @Test("an incomplete run has no conclusion")
-    func incompleteConclusion() {
-        let result = NetworkDiagnosticResult(id: .path, status: .normal, summary: "ok")
-        #expect(NetworkDiagnosticConclusion.evaluate([result]) == nil)
-    }
-
-    @Test("workbench table adapts columns to available width")
-    func adaptiveWorkbenchLayoutMode() {
-        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 519) == .compact)
-        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 520) == .condensed)
-        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 719) == .condensed)
-        #expect(NetworkDiagnosticsWorkbenchLayout.mode(for: 720) == .regular)
-    }
-
-    @Test("result table uses comfortable rows without alternating empty backgrounds")
-    func comfortableResultTablePresentation() {
-        #expect(NetworkDiagnosticsTablePresentation.minimumRowHeight == 54)
-        #expect(NetworkDiagnosticsTablePresentation.usesAlternatingRowBackgrounds == false)
-    }
-
-    @Test("workbench items interleave stage headers with check rows")
-    func workbenchItemGrouping() {
-        let path = NetworkDiagnosticResult(
-            id: .path,
-            status: .normal,
-            summary: "connected"
-        )
-        let executionPhases: [NetworkDiagnosticCheckID: NetworkDiagnosticExecutionPhase] = [
-            .path: .completed,
-            .dns: .checking,
-            .proxy: .waiting,
-        ]
-
-        #expect(NetworkDiagnosticsPresentation.workbenchItems(
-            pagePhase: .idle,
-            executionPhases: executionPhases,
-            results: [:]
-        ).isEmpty)
-
-        let runningItems = NetworkDiagnosticsPresentation.workbenchItems(
-            pagePhase: .running,
-            executionPhases: executionPhases,
-            results: [.path: path],
-            checkIDs: [.path, .dns, .proxy]
-        )
-        #expect(runningItems.map(\.id) == ["header.thisMac", "check.path", "check.dns"])
-        #expect(runningItems[0] == .stageHeader(.thisMac))
-        #expect(runningItems[1] == .check(.init(id: .path, executionPhase: .completed, result: path)))
-
-        let completedResults = Dictionary(uniqueKeysWithValues: makeResults(
-            path: .normal,
-            dns: .abnormal,
-            internet: .normal,
-            proxy: .indeterminate
-        ).map { ($0.id, $0) })
-        let completedItems = NetworkDiagnosticsPresentation.workbenchItems(
-            pagePhase: .completed,
-            executionPhases: executionPhases,
-            results: completedResults,
-            checkIDs: [.path, .dns, .ipv6, .proxy]
-        )
-        #expect(completedItems.map(\.id) == [
-            "header.thisMac", "check.path", "check.dns", "check.proxy",
-            "header.additional", "check.ipv6",
-        ])
-        #expect(completedItems[4] == .additionalHeader)
-
-        let timedOutItems = NetworkDiagnosticsPresentation.workbenchItems(
-            pagePhase: .completed,
-            executionPhases: [.path: .completed, .dns: .waiting],
-            results: [.path: path],
-            checkIDs: [.path, .dns],
-            endReason: .timedOut
-        )
-        #expect(timedOutItems.last == .check(.init(
-            id: .dns,
-            executionPhase: .waiting,
-            result: nil,
-            pendingReason: .timedOut
-        )))
-    }
-
-    @Test("system path check maps path states")
-    func pathMapping() async {
-        let satisfied = await NetworkConnectivityCheck(pathSource: StubPathSource(.satisfied)).run()
-        #expect(satisfied.id == .path)
-        #expect(satisfied.status == .normal)
-        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(.unsatisfied)).run().status == .abnormal)
-        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(.requiresConnection)).run().status == .indeterminate)
-        #expect(await NetworkConnectivityCheck(pathSource: StubPathSource(nil)).run().status == .indeterminate)
-    }
-
-    @Test("a satisfied system path is not an internet-success result")
-    func pathCheckReportsPathOnly() async {
-        let result = await NetworkConnectivityCheck(pathSource: StubPathSource(.satisfied)).run()
-
-        #expect(result.id == .path)
-        #expect(result.id != .internet)
-        #expect(result.detail == String(
-            localized: "network_diagnostics.path.normal.summary",
-            comment: "Network self-check system path success detail"
-        ))
-    }
-
-    @Test("gateway reachability check succeeds with latency evidence")
-    func gatewayReachabilitySuccess() async {
-        let result = await GatewayReachabilityCheck(
-            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
-            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
-                timestamp: Date(),
-                routerIP: "192.0.2.1",
-                latencyMs: 2.5
-            ))
-        ).run()
-
-        #expect(result.id == .gatewayReachability)
-        #expect(result.status == .normal)
-        #expect(result.evidence.contains(.init(code: "gateway.latency-ms", value: "2.5")))
-    }
-
-    @Test("gateway nonresponse remains indeterminate")
-    func gatewayNonresponseIsIndeterminate() async {
-        let result = await GatewayReachabilityCheck(
-            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1")),
-            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
-                timestamp: Date(),
-                routerIP: "192.0.2.1",
-                error: .gatewayPingFailed("192.0.2.1")
-            ))
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "gateway.no-response", value: "192.0.2.1")))
-    }
-
-    @Test("successful HTTPS access neutralizes gateway ICMP nonresponse")
-    func gatewayNonresponseDoesNotDowngradeSuccessfulHTTPS() {
-        var results = makeResults(
-            path: .normal,
-            gateway: .indeterminate,
-            dns: .normal,
-            internet: .normal,
-            proxy: .normal
-        )
-        results[1] = NetworkDiagnosticResult(
-            id: .gatewayReachability,
-            status: .indeterminate,
-            summary: "gateway did not answer ICMP",
-            evidence: [.init(code: "gateway.no-response", value: "192.0.2.1")]
-        )
-        results[3] = NetworkDiagnosticResult(
-            id: .internet,
-            status: .normal,
-            summary: "HTTPS available",
-            evidence: [.init(code: "https.available", value: "200")]
-        )
-
-        let assessment = NetworkDiagnosticAssessmentResolver().resolve(
-            results: Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) }),
-            complete: true
-        )
-
-        #expect(assessment.conclusion == .networkNormal)
-        #expect(assessment.primaryIssue == nil)
-        #expect(assessment.stages.first { $0.stage == .lan }?.status == .indeterminate)
-    }
-
-    @Test("gateway reachability is indeterminate without a router IP")
-    func gatewayReachabilityWithoutRouterIP() async {
-        let result = await GatewayReachabilityCheck(
-            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: nil)),
-            gatewayLatency: StubGatewayLatencyProvider(result: GatewayLatencyResult(
-                timestamp: Date(),
-                error: .missingRouterIP
-            ))
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "gateway.unavailable", value: nil)))
-    }
-
-    @Test("path check keeps interface evidence without gateway latency")
-    func pathCheckKeepsInterfaceEvidence() async {
-        let result = await NetworkConnectivityCheck(
-            pathSource: StubPathSource(.satisfied),
-            interfaceSource: StubNetworkInterfaceSource(interface: makeNetworkInterface(router: "192.0.2.1"))
-        ).run()
-
-        #expect(result.status == .normal)
-        #expect(result.evidence.contains(.init(code: "path.interface", value: "en0")))
-        #expect(result.evidence.contains(.init(code: "path.local-ip", value: "192.0.2.10")))
-        #expect(result.evidence.contains(.init(code: "path.router", value: "192.0.2.1")))
-        #expect(!result.evidence.contains { $0.code.hasPrefix("gateway.") })
-    }
-
-    @Test("captive-portal probe rejects a rewritten response")
-    func captivePortalProbeRejectsRewrittenResponse() async {
-        let check = HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 204,
-                httpStatus: 200,
-                httpBody: "login"
-            )
-        )
-
-        let result = await check.run()
-
-        #expect(result.id == .internet)
-        #expect(result.evidence.contains(.init(code: "captive-portal.suspected", value: nil)))
-    }
-
-    @Test("control endpoint success verifies HTTPS and Apple's captive-portal Success body")
-    func controlEndpointSuccess() async {
-        let check = HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 200,
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .normal)
-        #expect(result.evidence.contains(.init(code: "https.available", value: "200")))
-        #expect(result.evidence.contains(.init(code: "captive-portal.clear", value: nil)))
-    }
-
-    @Test("independent control endpoints load concurrently and preserve evidence order")
-    func controlEndpointsRunConcurrently() async {
-        let loader = ConcurrentControlLoader()
-        let result = await HTTPSControlEndpointCheck(loader: loader).run()
-
-        #expect(await loader.maximumInFlight == 2)
-        #expect(result.evidence.map(\.code).prefix(2) == ["https.available", "captive-portal.clear"])
-    }
-
-    @Test("control endpoint metrics are redacted to bounded transaction fields")
-    func controlEndpointMetricsAreRedacted() async {
-        let result = await HTTPSControlEndpointCheck(
-            loader: MetricsControlLoader(
-                metrics: .init(
-                    dnsDuration: .milliseconds(12),
-                    connectDuration: .milliseconds(34),
-                    tlsDuration: .milliseconds(56),
-                    negotiatedTLSVersion: "TLSv1.3",
-                    isProxyConnection: true,
-                    remoteAddress: "192.0.2.10:443"
-                )
-            )
-        ).run()
-
-        #expect(result.evidence.contains(.init(code: "https.metrics.dns-ms", value: "12")))
-        #expect(result.evidence.contains(.init(code: "https.metrics.connect-ms", value: "34")))
-        #expect(result.evidence.contains(.init(code: "https.metrics.tls-ms", value: "56")))
-        #expect(result.evidence.contains(.init(code: "https.metrics.tls-version", value: "TLSv1.3")))
-        #expect(result.evidence.contains(.init(code: "https.metrics.proxy", value: "true")))
-        #expect(!result.evidence.contains { $0.value == "192.0.2.10:443" })
-    }
-
-    @Test("control endpoint success and captive-portal timeout is indeterminate")
-    func controlEndpointMicrosoftTimeoutIsIndeterminate() async {
-        let result = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 200,
-                httpStatus: nil,
-                httpBody: nil,
-                httpErrorCode: String(URLError.timedOut.rawValue)
-            )
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "https.available", value: "200")))
-        #expect(result.evidence.contains(.init(
-            code: "captive-portal.transport-error",
-            value: String(URLError.timedOut.rawValue)
-        )))
-    }
-
-    @Test("control endpoint success and captive-portal timeout needs attention")
-    func controlEndpointMicrosoftTimeoutConclusion() async {
-        let internet = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 200,
-                httpStatus: nil,
-                httpBody: nil,
-                httpErrorCode: String(URLError.timedOut.rawValue)
-            )
-        ).run()
-
-        let conclusion = NetworkDiagnosticConclusion.evaluate([
-            NetworkDiagnosticResult(id: .path, status: .normal, summary: "path"),
-            NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "gateway"),
-            NetworkDiagnosticResult(id: .dns, status: .normal, summary: "dns"),
-            internet,
-            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: "ipv6"),
-            NetworkDiagnosticResult(id: .proxy, status: .normal, summary: "proxy"),
-        ])
-
-        #expect(conclusion == .needsAttention)
-        #expect(conclusion != .networkUnavailable)
-    }
-
-    @Test("control endpoint failures retain distinct evidence")
-    func controlEndpointFailureEvidence() async {
-        let tlsFailure = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: nil,
-                httpsErrorCode: String(URLError.secureConnectionFailed.rawValue),
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        ).run()
-        let certificateTimeFailure = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: nil,
-                httpsErrorCode: String(URLError.serverCertificateNotYetValid.rawValue),
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        ).run()
-        let certificateValidationFailure = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: nil,
-                httpsErrorCode: String(URLError.serverCertificateUntrusted.rawValue),
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        ).run()
-        let connectivityFailure = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: nil,
-                httpsErrorCode: String(URLError.timedOut.rawValue),
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        ).run()
-        let httpsStatusFailure = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 503,
-                httpStatus: 200,
-                httpBody: "Success"
-            )
-        ).run()
-        let captivePortalRedirect = await HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 200,
-                httpStatus: 302,
-                httpBody: nil
-            )
-        ).run()
-
-        #expect(tlsFailure.evidence.contains(.init(
-            code: "https.tls-error",
-            value: String(URLError.secureConnectionFailed.rawValue)
-        )))
-        #expect(certificateTimeFailure.evidence.contains(.init(
-            code: "https.certificate-time-error",
-            value: String(URLError.serverCertificateNotYetValid.rawValue)
-        )))
-        #expect(certificateValidationFailure.evidence.contains(.init(
-            code: "https.certificate-error",
-            value: String(URLError.serverCertificateUntrusted.rawValue)
-        )))
-        #expect(connectivityFailure.evidence.contains(.init(
-            code: "https.connectivity-error",
-            value: String(URLError.timedOut.rawValue)
-        )))
-        #expect(httpsStatusFailure.evidence.contains(.init(code: "https.http-status", value: "503")))
-        #expect(captivePortalRedirect.evidence.contains(.init(code: "captive-portal.redirect", value: "302")))
-        #expect(tlsFailure.summary == String(
-            localized: "network_diagnostics.internet.secure_connection_failure.summary",
-            comment: "Network self-check TLS or certificate failure summary"
-        ))
-        #expect(certificateValidationFailure.summary == tlsFailure.summary)
-        #expect(certificateTimeFailure.summary == String(
-            localized: "network_diagnostics.internet.certificate_time_failure.summary",
-            comment: "Network self-check certificate time failure summary"
-        ))
-        #expect(connectivityFailure.summary == String(
-            localized: "network_diagnostics.internet.connectivity_failure.summary",
-            comment: "Network self-check connectivity failure summary"
-        ))
-
-        let baseResults = [
-            NetworkDiagnosticResult(id: .path, status: .normal, summary: "path"),
-            NetworkDiagnosticResult(id: .gatewayReachability, status: .normal, summary: "gateway"),
-            NetworkDiagnosticResult(id: .dns, status: .normal, summary: "dns"),
-        ]
-        let trailingResults = [
-            NetworkDiagnosticResult(id: .ipv6, status: .skipped, summary: "ipv6"),
-            NetworkDiagnosticResult(id: .proxy, status: .abnormal, summary: "proxy"),
-        ]
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            baseResults + [tlsFailure] + trailingResults
-        ) == .needsAttention)
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            baseResults + [certificateTimeFailure] + trailingResults
-        ) == .needsAttention)
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            baseResults + [certificateValidationFailure] + trailingResults
-        ) == .needsAttention)
-        #expect(NetworkDiagnosticConclusion.evaluate(
-            baseResults + [connectivityFailure] + trailingResults
-        ) == .needsAttention)
-    }
-
-    @Test("control check loads the approved endpoints with an explicit timeout")
-    func controlEndpointRequests() async {
-        let recorder = ControlEndpointTestRecorder()
-        let check = HTTPSControlEndpointCheck(
-            loader: StubControlLoader(
-                httpsStatus: 200,
-                httpStatus: 200,
-                httpBody: "Success",
-                recorder: recorder
-            )
-        )
-
-        _ = await check.run()
-
-        #expect(Set(await recorder.urls) == Set([
-            "https://www.apple.com/",
-            "https://captive.apple.com/hotspot-detect.html",
-        ]))
-        #expect(await recorder.timeouts == [.seconds(5), .seconds(5)])
-    }
-
-    @Test("system control loader disables caching and connectivity waits")
-    func controlEndpointSessionConfiguration() {
-        let configuration = SystemControlEndpointLoader.configuration(timeout: .seconds(5))
-
-        #expect(configuration.requestCachePolicy == .reloadIgnoringLocalCacheData)
-        #expect(configuration.urlCache == nil)
-        #expect(!configuration.waitsForConnectivity)
-        #expect(configuration.timeoutIntervalForRequest == 5)
-        #expect(configuration.timeoutIntervalForResource == 5)
-    }
-
-    @Test("base endpoint configuration does not inherit explicit system proxies")
-    func baseEndpointDisablesExplicitSystemProxy() {
-        let configuration = SystemControlEndpointLoader.configuration(timeout: .seconds(2))
-
-        #expect(configuration.connectionProxyDictionary?.isEmpty == true)
-        #expect(configuration.proxyConfigurations.isEmpty)
-    }
-
-    @Test("app scopes the ATS HTTP exception to the Microsoft captive-portal/proxy endpoint")
-    func temporaryCaptivePortalATSException() {
-        let ats = Bundle.main.object(forInfoDictionaryKey: "NSAppTransportSecurity") as? [String: Any]
-        let domains = ats?["NSExceptionDomains"] as? [String: Any]
-        let exception = domains?["www.msftconnecttest.com"] as? [String: Any]
-
-        #expect(ats?.count == 1)
-        #expect(ats?["NSAllowsArbitraryLoads"] == nil)
-        #expect(domains?.count == 1)
-        #expect(exception?.count == 1)
-        #expect(exception?["NSExceptionAllowsInsecureHTTPLoads"] as? Bool == true)
-        #expect(exception?["NSIncludesSubdomains"] == nil)
-    }
-
-    @Test("production checks run path DNS HTTPS and proxy in dependency order")
-    @MainActor
-    func productionCheckOrder() {
-        #expect(NetworkDiagnosticsViewModel().checkIDs == [.path, .gatewayReachability, .dns, .internet, .proxy, .ipv6])
-    }
-
-    @Test("all successful DNS samples are available")
-    func dnsAllSamplesResolved() async {
-        let result = await DNSResolutionCheck(resolver: StubDNSResolver(.resolved)).run()
-
-        #expect(result.status == .normal)
-        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "3/3")))
-        #expect(result.evidence.contains(.init(code: "dns.failure-count", value: "0/3")))
-        #expect(result.evidence.contains(.init(code: "dns.indeterminate-count", value: "0/3")))
-    }
-
-    @Test("DNS uses the three authoritative third-party probe targets")
-    func dnsProbeTargets() {
-        let check = DNSResolutionCheck(resolver: StubDNSResolver(.resolved))
-
-        #expect(check.probeTargets == [
-            "www.apple.com",
-            "www.microsoft.com",
-            "www.msftconnecttest.com",
-        ])
-    }
-
-    @Test("independent DNS samples start concurrently and aggregate in target order")
-    func dnsSamplesRunConcurrently() async {
-        let resolver = ConcurrentDNSResolver()
-        let result = await DNSResolutionCheck(
-            resolver: resolver,
-            timeout: .seconds(1)
-        ).run()
-
-        #expect(await resolver.maximumInFlight == 3)
-        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "3/3")))
-    }
-
-    @Test("one failed lookup among successful samples is unstable, not unavailable")
-    func dnsQuorum() async {
-        let check = DNSResolutionCheck(
-            resolver: StubDNSResolver(outcomes: [.resolved, .failed, .resolved])
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "2/3")))
-        #expect(result.evidence.contains(.init(code: "dns.failure-count", value: "1/3")))
-    }
-
-    @Test("DNS evidence preserves each sample outcome without exposing host names")
-    func dnsEvidencePreservesSampleOutcomes() async {
-        let result = await DNSResolutionCheck(
-            resolver: MappingDNSResolver(outcomes: [
-                "www.apple.com": .resolved,
-                "www.microsoft.com": .failed,
-                "www.msftconnecttest.com": .indeterminate,
-            ])
-        ).run()
-
-        #expect(result.evidence.contains(.init(code: "dns.sample.apple", value: "resolved")))
-        #expect(result.evidence.contains(.init(code: "dns.sample.microsoft", value: "failed")))
-        #expect(result.evidence.contains(.init(code: "dns.sample.msft-connect-test", value: "indeterminate")))
-        #expect(!result.evidence.contains { $0.value == "www.apple.com" })
-    }
-
-    @Test("all failed DNS samples are unavailable")
-    func dnsAllSamplesFailed() async {
-        let result = await DNSResolutionCheck(resolver: StubDNSResolver(.failed)).run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.evidence.contains(.init(code: "dns.success-count", value: "0/3")))
-        #expect(result.evidence.contains(.init(code: "dns.failure-count", value: "3/3")))
-    }
-
-    @Test("an indeterminate DNS sample is retried once")
-    func dnsIndeterminateSampleRetriesOnce() async {
-        let resolver = StubDNSResolver(outcomes: [.indeterminate, .resolved, .resolved, .resolved])
-        let result = await DNSResolutionCheck(resolver: resolver).run()
-
-        #expect(result.status == .normal)
-        #expect(await resolver.invocationCount == 4)
-    }
-
-    @Test("cancelling DNS sampling does not retry or exceed one attempt per host")
-    func dnsCancellationStopsSampling() async {
-        let resolver = CancellationAwareDNSResolver()
-        let check = DNSResolutionCheck(resolver: resolver, timeout: .seconds(30))
-        let task = Task { await check.run() }
-
-        await resolver.waitForInvocation()
-        task.cancel()
-        _ = await task.value
-
-        #expect(await resolver.invocationCount <= 3)
-    }
-
-    @Test("all indeterminate DNS samples cannot be determined")
-    func dnsAllSamplesIndeterminate() async {
-        let result = await DNSResolutionCheck(resolver: StubDNSResolver(.indeterminate)).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "dns.indeterminate-count", value: "3/3")))
-    }
-
-    @Test("DNS success result does not expose the test domain")
-    func dnsResultHidesTestDomain() async {
-        let testDomain = "example.com"
-        let result = await DNSResolutionCheck(
-            resolver: StubDNSResolver(.resolved),
-            probeTargets: [testDomain, "example.net", "example.org"]
-        ).run()
-
-        #expect(!result.summary.localizedCaseInsensitiveContains(testDomain))
-    }
-
-    @Test("proxy parser deduplicates HTTP HTTPS and SOCKS endpoints")
-    func proxyParsing() {
-        let configuration = SystemProxyConfiguration(settings: [
-            "HTTPEnable": 1,
-            "HTTPProxy": " Proxy.Example ",
-            "HTTPPort": 8080,
-            "HTTPSEnable": 1,
-            "HTTPSProxy": "proxy.example",
-            "HTTPSPort": 8080,
-            "SOCKSEnable": 1,
-            "SOCKSProxy": "socks.example",
-            "SOCKSPort": 1080,
-        ])
-
-        #expect(configuration.endpoints == [
-            ProxyEndpoint(host: "proxy.example", port: 8080),
-            ProxyEndpoint(host: "socks.example", port: 1080),
-        ])
-        #expect(!configuration.hasInvalidExplicitProxy)
-    }
-
-    @Test("proxy parser reads PAC URL and automatic discovery")
-    func pacParsing() {
-        let configuration = SystemProxyConfiguration(settings: [
-            "ProxyAutoConfigEnable": 1,
-            "ProxyAutoConfigURLString": "https://proxy.example/config.pac",
-            "ProxyAutoDiscoveryEnable": 1,
-        ])
-
-        #expect(configuration.pacEnabled)
-        #expect(configuration.pacURL == "https://proxy.example/config.pac")
-        #expect(configuration.autoDiscoveryEnabled)
-    }
-
-    @Test("PAC result chooses DIRECT without probing a stale explicit endpoint")
-    func pacCanChooseDirect() async {
-        let controlURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let recorder = PACResolutionTestRecorder()
-        let resolver = SystemProxyResolver(
-            pacTimeout: .milliseconds(25),
-            configurationResolver: StubProxyConfigurationResolver(.pac(pacURL)),
-            pacResolver: StubPACResolver(.direct, recorder: recorder)
-        )
-        let resolution = await resolver.resolve(for: controlURL)
-
-        #expect(resolution == ProxyCandidateResolution(candidates: [.direct], evidenceCodes: []))
-        #expect(await recorder.requests == [
-            .init(pacURL: pacURL, targetURL: controlURL, timeout: .milliseconds(25)),
-        ])
-    }
-
-    @Test("static proxy candidates preserve HTTP then DIRECT order")
-    func staticProxyCandidateOrder() {
-        let candidates = SystemProxyResolver.candidates(from: [
-            proxyDictionary(type: kCFProxyTypeHTTP, host: "127.0.0.1", port: 7890),
-            proxyDictionary(type: kCFProxyTypeNone),
-        ])
-
-        #expect(candidates == [
-            .http(.init(host: "127.0.0.1", port: 7890)),
-            .direct,
-        ])
-    }
-
-    @Test("PAC proxy candidates preserve PROXY then DIRECT order")
-    func pacProxyCandidateOrder() {
-        let resolution = SystemPACResolver.resolution(from: [
-            proxyDictionary(type: kCFProxyTypeHTTP, host: "proxy.example", port: 8080),
-            proxyDictionary(type: kCFProxyTypeNone),
-        ])
-
-        #expect(resolution == ProxyCandidateResolution(
-            candidates: [
-                .http(.init(host: "proxy.example", port: 8080)),
-                .direct,
-            ],
-            evidenceCodes: []
-        ))
-    }
-
-    @Test("inline PAC scripts execute at their ordered directive position")
-    func inlinePACScriptPreservesDirectiveOrder() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let script = "function FindProxyForURL(url, host) { return 'SOCKS proxy.example:1080'; }"
-        let first = EffectiveProxy.http(.init(host: "first.example", port: 8080))
-        let inline = EffectiveProxy.socks(.init(host: "proxy.example", port: 1080))
-        let executor = ControlledPACCallbackExecutor()
-        let resolver = SystemProxyResolver(
-            configurationResolver: StubProxyConfigurationResolver([
-                .http(.init(host: "first.example", port: 8080)),
-                .pacScript(script),
-                .direct,
-            ]),
-            pacResolver: SystemPACResolver(callbackExecutor: executor)
-        )
-        let task = Task { await resolver.resolve(for: target) }
-
-        let request = await executor.nextRequest()
-        #expect(request == .init(source: .script(script), targetURL: target))
-        executor.complete(.success(.init(candidates: [inline], evidenceCodes: [])))
-        let resolution = await task.value
-
-        #expect(resolution == .init(candidates: [first, inline, .direct], evidenceCodes: []))
-    }
-
-    @Test("inline PAC dictionaries preserve their JavaScript source")
-    func inlinePACDictionaryPreservesScript() {
-        let script = "function FindProxyForURL(url, host) { return 'DIRECT'; }"
-        let dictionary: NSDictionary = [
-            kCFProxyTypeKey as String: kCFProxyTypeAutoConfigurationJavaScript,
-            kCFProxyAutoConfigurationJavaScriptKey as String: script,
-        ]
-
-        #expect(SystemProxyResolver.directive(from: dictionary) == .pacScript(script))
-    }
-
-    @Test("PAC callback errors resume with execution-failed evidence")
-    func pacCallbackErrorResumesContinuation() async {
-        let target = URL(string: "https://www.apple.com/")!
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let executor = ControlledPACCallbackExecutor()
-        let resolver = SystemPACResolver(callbackExecutor: executor)
-        let task = Task {
-            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .seconds(30))
-        }
-
-        let request = await executor.nextRequest()
-        #expect(request == .init(source: .url(pacURL), targetURL: target))
-        executor.complete(.failure)
-        let resolution = await task.value
-
-        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-execution-failed"]))
-        #expect(executor.executionWasCancelled)
-    }
-
-    @Test("PAC callback cancellation resumes once with cancellation evidence")
-    func pacCallbackCancellationResumesContinuation() async {
-        let target = URL(string: "https://www.apple.com/")!
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let executor = ControlledPACCallbackExecutor()
-        let resolver = SystemPACResolver(callbackExecutor: executor)
-        let task = Task {
-            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .seconds(30))
-        }
-
-        _ = await executor.nextRequest()
-        task.cancel()
-        let resolution = await task.value
-
-        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-cancelled"]))
-        #expect(executor.executionWasCancelled)
-    }
-
-    @Test("PAC callback timeout resumes once and cancels execution")
-    func pacCallbackTimeoutResumesContinuation() async {
-        let target = URL(string: "https://www.apple.com/")!
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let executor = ControlledPACCallbackExecutor()
-        let resolver = SystemPACResolver(callbackExecutor: executor)
-        let task = Task {
-            await resolver.resolve(pacURL: pacURL, targetURL: target, timeout: .milliseconds(10))
-        }
-
-        _ = await executor.nextRequest()
-        let resolution = await task.value
-
-        #expect(resolution == .init(candidates: [], evidenceCodes: ["pac-timeout"]))
-        #expect(executor.executionWasCancelled)
-    }
-
-    @Test("invalid proxy candidate preserves later valid candidate and evidence")
-    func invalidProxyCandidatePreservesLaterCandidate() async {
-        let validProxy = EffectiveProxy.http(.init(host: "proxy.example", port: 8080))
-        let resolver = SystemProxyResolver(
-            configurationResolver: StubProxyConfigurationResolver(
-                SystemProxyResolver.directives(from: [
-                    proxyDictionary(type: kCFProxyTypeHTTP),
-                    proxyDictionary(
-                        type: kCFProxyTypeHTTP,
-                        host: "proxy.example",
-                        port: 8080
-                    ),
-                ])
-            ),
-            pacResolver: StubPACResolver(.direct)
-        )
-
-        let resolution = await resolver.resolve(
-            for: URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        )
-
-        #expect(resolution.candidates == [validProxy])
-        #expect(resolution.evidenceCodes == ["proxy-endpoint-invalid"])
-    }
-
-    @Test("whitespace-only proxy hosts are invalid resolution entries")
-    func whitespaceOnlyProxyHostIsInvalid() {
-        let directive = SystemProxyResolver.directive(from: proxyDictionary(
-            type: kCFProxyTypeHTTP,
-            host: " \n\t ",
-            port: 8080
-        ))
-
-        #expect(directive == .unavailable("proxy-endpoint-invalid"))
-    }
-
-    @Test("CFNetwork PAC DIRECT result maps to direct egress")
-    func pacDirectParsing() {
-        let result: NSDictionary = [
-            kCFProxyTypeKey as String: kCFProxyTypeNone,
-        ]
-
-        #expect(SystemProxyResolver.directive(from: result) == .direct)
-    }
-
-    @Test("DIRECT does not probe a stale explicit endpoint or proxy egress")
-    func directSkipsStaleProxy() async {
-        let connectorRecorder = ProxyConnectorTestRecorder()
-        let egressRecorder = ProxyEgressTestRecorder()
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: RecordingProxyConnector(reachable: false, recorder: connectorRecorder),
-            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected", recorder: egressRecorder),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(await connectorRecorder.endpoints.isEmpty)
-        #expect(await egressRecorder.requests.isEmpty)
-    }
-
-    @Test("routed tunnel interface is recognized as the proxy route")
-    func tunneledRoutingIsRecognized() async {
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: StubProxyConnector(reachable: false),
-            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
-            tunnelReader: StubProxyTunnelStateReader(interface: "utun98")
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .normal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.tunnel_routes.summary",
-            comment: "Network self-check tunneled proxy route result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.http.route-type", value: "tunnel")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.route-type", value: "tunnel")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.tunnel-interface", value: "utun98")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.tunnel-interface", value: "utun98")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.tunnel-detection-source", value: "nwpath")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.tunnel-detection-source", value: "nwpath")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.egress-status", value: "base-check")))
-    }
-
-    @Test("active interface tunnel detection uses the softer summary")
-    func activeInterfaceTunnelUsesSofterSummary() async {
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: StubProxyConnector(reachable: false),
-            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
-            tunnelReader: StubProxyTunnelStateReader(
-                interface: "utun98",
-                source: .activeInterface
-            )
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .normal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.tunnel_routes_active.summary",
-            comment: "Network self-check active tunnel interface proxy route result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.http.route-type", value: "tunnel")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.tunnel-detection-source", value: "active-interface")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.tunnel-detection-source", value: "active-interface")))
-    }
-
-    @Test("tunnel candidate prefers the routed interface then an active ipv4 tunnel")
-    func tunnelCandidatePriority() {
-        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
-            pathRouted: "utun3",
-            activeIPv4Tunnels: ["utun98"]
-        ) == ProxyTunnelState(interface: "utun3", source: .nwpath))
-        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
-            pathRouted: nil,
-            activeIPv4Tunnels: ["utun98"]
-        ) == ProxyTunnelState(interface: "utun98", source: .activeInterface))
-        #expect(SystemProxyTunnelStateReader.candidateTunnelState(
-            pathRouted: nil,
-            activeIPv4Tunnels: []
-        ) == nil)
-    }
-
-    @Test("tunnel path wait returns nil when the timeout fires before any path")
-    func tunnelPathWaitTimeoutWins() async {
-        let streamTerminated = LockedFlag()
-        let neverEnding = AsyncStream<NWPath> { continuation in
-            continuation.onTermination = { _ in streamTerminated.set() }
-        }
-
-        let path = await SystemProxyTunnelStateReader.firstPath(
-            from: neverEnding,
-            timeout: {}
-        )
-
-        #expect(path == nil)
-        #expect(streamTerminated.isSet)
-    }
-
-    @Test("tunnel path wait cancels the pending timeout when the path side completes first")
-    func tunnelPathWaitCancelsPendingTimeout() async {
-        let probe = TunnelTimeoutCancellationProbe()
-        let finished = AsyncStream<NWPath> { continuation in
-            continuation.finish()
-        }
-
-        let path = await SystemProxyTunnelStateReader.firstPath(
-            from: finished,
-            timeout: { await probe.park() }
-        )
-
-        #expect(path == nil)
-        #expect(probe.didCancel)
-    }
-
-    @Test("failed proxy candidate falls back to DIRECT for the same target")
-    func failedProxyCandidateFallsBackToDirect() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let staleEndpoint = ProxyEndpoint(host: "stale.example", port: 8080)
-        let connectorRecorder = ProxyConnectorTestRecorder()
-        let egressRecorder = ProxyEgressTestRecorder()
-        let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [
-                httpURL: .init(candidates: [.http(staleEndpoint), .direct], evidenceCodes: []),
-                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
-            ]),
-            connector: RecordingProxyConnector(reachable: false, recorder: connectorRecorder),
-            egressLoader: StubProxyEgressLoader(
-                statusCode: 200,
-                recorder: egressRecorder
-            ),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(code: "proxy.http.endpoint-status", value: "unavailable")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.candidate-index", value: "1")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.route-type", value: "direct")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.fallback-used", value: "true")))
-        #expect(await connectorRecorder.endpoints == [staleEndpoint])
-        #expect(await egressRecorder.requests.isEmpty)
-    }
-
-    @Test("failed first proxy tries the next proxy candidate")
-    func failedFirstProxyTriesNextProxy() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let staleEndpoint = ProxyEndpoint(host: "stale.example", port: 8080)
-        let workingEndpoint = ProxyEndpoint(host: "working.example", port: 8081)
-        let selectedProxy = EffectiveProxy.http(workingEndpoint)
-        let connector = SequencedProxyConnector(outcomes: [false, true])
-        let egressRecorder = ProxyEgressTestRecorder()
-        let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [
-                httpURL: .init(
-                    candidates: [.http(staleEndpoint), selectedProxy],
-                    evidenceCodes: []
-                ),
-                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
-            ]),
-            connector: connector,
-            egressLoader: StubProxyEgressLoader(statusCode: 204, recorder: egressRecorder),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(await connector.endpoints == [staleEndpoint, workingEndpoint])
-        #expect(await egressRecorder.requests.map(\.proxy) == [selectedProxy])
-        #expect(result.evidence.contains(.init(code: "proxy.http.candidate-index", value: "1")))
-        #expect(result.evidence.contains(.init(code: "proxy.http.fallback-used", value: "true")))
-    }
-
-    @Test("candidate attempts share one controlled overall timeout")
-    func proxyCandidateAttemptsShareTimeout() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
-        let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
-        let connector = SequencedProxyConnector(outcomes: [true, true])
-        let egressLoader = SequencedProxyEgressLoader(
-            responses: [
-                .init(statusCode: nil, errorCode: "timed-out"),
-                .init(statusCode: 200, errorCode: nil),
-            ],
-            delays: [.zero, .zero]
-        )
-        let clock = SequencedProxyCheckClock(offsets: [
-            .zero,
-            .zero,
-            .milliseconds(250),
-            .milliseconds(1_200),
-            .milliseconds(1_300),
-        ])
-        let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [:]),
-            connector: connector,
-            egressLoader: egressLoader,
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-            timeout: .seconds(2),
-            clock: clock
-        )
-
-        let result = await check.evaluate(
-            target: target,
-            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
-            timeout: .seconds(2)
-        )
-
-        #expect(result.status == .proxied)
-        #expect(result.selectedCandidateIndex == 1)
-        #expect(result.selectedProxy == secondProxy)
-        #expect(await connector.endpoints == [
-            .init(host: "first.example", port: 8080),
-            .init(host: "second.example", port: 8081),
-        ])
-        #expect(await connector.timeouts == [.seconds(1), .milliseconds(800)])
-        #expect(await egressLoader.timeouts == [.milliseconds(750), .milliseconds(700)])
-    }
-
-    @Test("an expired overall proxy timeout does not start another candidate")
-    func expiredProxyTimeoutStopsCandidateFallback() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let firstProxy = EffectiveProxy.http(.init(host: "first.example", port: 8080))
-        let secondProxy = EffectiveProxy.http(.init(host: "second.example", port: 8081))
-        let connector = SequencedProxyConnector(outcomes: [true, true])
-        let egressLoader = SequencedProxyEgressLoader(
-            responses: [.init(statusCode: nil, errorCode: "timed-out")],
-            delays: [.zero]
-        )
-        let clock = SequencedProxyCheckClock(offsets: [
-            .zero,
-            .zero,
-            .milliseconds(250),
-            .milliseconds(2_100),
-        ])
-        let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [:]),
-            connector: connector,
-            egressLoader: egressLoader,
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-            timeout: .seconds(2),
-            clock: clock
-        )
-
-        let result = await check.evaluate(
-            target: target,
-            resolution: .init(candidates: [firstProxy, secondProxy], evidenceCodes: []),
-            timeout: .seconds(2)
-        )
-
-        #expect(result.status == .unavailable)
-        #expect(await connector.endpoints == [.init(host: "first.example", port: 8080)])
-        #expect(await connector.timeouts == [.seconds(1)])
-        #expect(await egressLoader.timeouts == [.milliseconds(750)])
-        #expect(result.evidence.contains(.init(code: "proxy.http.timeout", value: "expired")))
-    }
-
-    @Test("proxy check resolves the HTTP and HTTPS targets independently")
-    func proxyTargetsAreResolvedIndependently() async {
-        let recorder = ProxyResolutionTestRecorder()
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let httpsProxy = EffectiveProxy.https(.init(host: "secure-proxy.example", port: 8443))
-        let resolver = RecordingProxyResolver(
-            resolutions: [
-                httpURL: .init(candidates: [.direct], evidenceCodes: []),
-                httpsURL: .init(candidates: [httpsProxy], evidenceCodes: []),
-            ],
-            recorder: recorder
-        )
-        let check = SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-        let resolvedURLs = await recorder.urls
-
-        #expect(resolvedURLs.count == 2)
-        #expect(Set(resolvedURLs) == Set([httpURL.absoluteString, httpsURL.absoluteString]))
-        #expect(result.status == .indeterminate)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.mixed_routing.summary",
-            comment: "Network self-check mixed target proxy routing result summary"
-        ))
-    }
-
-    @Test("both tested targets can use direct routes without a global disabled claim")
-    func bothProxyTargetsDirect() async {
-        let recorder = ProxyResolutionTestRecorder()
-        let resolver = RecordingProxyResolver(
-            defaultResolution: .init(candidates: [.direct], evidenceCodes: []),
-            recorder: recorder
-        )
-
-        let result = await SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: false),
-            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "unexpected"),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.direct_routes.summary",
-            comment: "Network self-check direct target routes result summary"
-        ))
-        #expect(result.summary != String(
-            localized: "network_diagnostics.proxy.disabled.summary",
-            comment: "Network self-check system proxy disabled result summary"
-        ))
-        #expect(Set(await recorder.urls) == Set([
-            "http://www.msftconnecttest.com/connecttest.txt",
-            "https://www.apple.com/",
-        ]))
-    }
-
-    @Test("both tested proxy routes are available")
-    func bothProxyTargetsProxied() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let resolver = RecordingProxyResolver(resolutions: [
-            httpURL: .init(
-                candidates: [.http(.init(host: "proxy.example", port: 8080))],
-                evidenceCodes: []
-            ),
-            httpsURL: .init(
-                candidates: [.https(.init(host: "proxy.example", port: 8443))],
-                evidenceCodes: []
-            ),
-        ])
-
-        let result = await SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .normal)
-        #expect(result.proxyFacts == .init(http: .available, https: .available))
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.routes_available.summary",
-            comment: "Network self-check proxy target routes available result summary"
-        ))
-    }
-
-    @Test("a tested target reports proxy authentication required")
-    func proxyTargetAuthenticationRequired() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let resolver = RecordingProxyResolver(resolutions: [
-            httpURL: .init(
-                candidates: [.http(.init(host: "proxy.example", port: 8080))],
-                evidenceCodes: []
-            ),
-            httpsURL: .init(candidates: [.direct], evidenceCodes: []),
-        ])
-
-        let result = await SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 407),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.authentication_required.summary",
-            comment: "Network self-check proxy authentication required result summary"
-        ))
-        #expect(result.evidence.contains(.init(
-            code: "proxy.http.authentication-status",
-            value: "required"
-        )))
-        #expect(result.evidence.contains(.init(code: "proxy.http.egress-status", value: "407")))
-    }
-
-    @Test("configured candidates with no working route are unavailable")
-    func proxyTargetRouteUnavailable() async {
-        let resolver = RecordingProxyResolver(defaultResolution: .init(
-            candidates: [.http(.init(host: "stale.example", port: 8080))],
-            evidenceCodes: []
-        ))
-
-        let result = await SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: false),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.route_unavailable.summary",
-            comment: "Network self-check proxy target route unavailable result summary"
-        ))
-        #expect(result.evidence.contains(.init(
-            code: "proxy.http.endpoint-status",
-            value: "unavailable"
-        )))
-        #expect(result.evidence.contains(.init(
-            code: "proxy.https.endpoint-status",
-            value: "unavailable"
-        )))
-    }
-
-    @Test("empty target resolution is indeterminate")
-    func emptyProxyTargetResolutionIsIndeterminate() async {
-        let result = await SystemProxyCheck(
-            resolver: RecordingProxyResolver(defaultResolution: .init(
-                candidates: [],
-                evidenceCodes: ["resolution-empty"]
-            )),
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.unable_to_determine.summary",
-            comment: "Network self-check target proxy routing indeterminate result summary"
-        ))
-        #expect(result.evidence.contains(.init(
-            code: "proxy.http.resolution",
-            value: "resolution-empty"
-        )))
-        #expect(result.evidence.contains(.init(
-            code: "proxy.https.resolution",
-            value: "resolution-empty"
-        )))
-    }
-
-    @Test("PAC timeout is reported as PAC unavailable")
-    func pacTimeout() async {
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let check = SystemProxyCheck(
-            resolver: SystemProxyResolver(
-                configurationResolver: StubProxyConfigurationResolver(.pac(pacURL)),
-                pacResolver: StubPACResolver(.unavailable("pac-timeout"))
-            ),
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.unable_to_determine.summary",
-            comment: "Network self-check target proxy routing indeterminate result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.http.resolution", value: "pac-timeout")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.resolution", value: "pac-timeout")))
-    }
-
-    @Test("selected proxy endpoint failure is distinct from egress failure")
-    func selectedProxyEndpointUnavailable() async {
-        let egressRecorder = ProxyEgressTestRecorder()
-        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(proxy),
-            connector: StubProxyConnector(reachable: false),
-            egressLoader: StubProxyEgressLoader(statusCode: 200, recorder: egressRecorder),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.route_unavailable.summary",
-            comment: "Network self-check proxy target route unavailable result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.endpoint-unavailable", value: nil)))
-        #expect(await egressRecorder.requests.isEmpty)
-    }
-
-    @Test("HTTP 407 is proxy authentication required")
-    func proxyAuthenticationRequired() async {
-        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(proxy),
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 407),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.authentication_required.summary",
-            comment: "Network self-check proxy authentication required result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.authentication-required", value: "407")))
-        #expect(!result.evidence.contains(where: { $0.code == "proxy.endpoint-unavailable" }))
-    }
-
-    @Test("URL loading authentication challenge remains a proxy 407 result")
-    func proxyAuthenticationChallenge() {
-        let response = SystemProxyEgressLoader.response(
-            for: URLError(.userAuthenticationRequired)
-        )
-
-        #expect(response == ProxyEgressResponse(statusCode: 407, errorCode: nil))
-    }
-
-    @Test("production tunneled egress configuration disables selected proxy failover")
-    func selectedProxyDoesNotFailOver() throws {
-        let proxy = EffectiveProxy.https(ProxyEndpoint(host: "proxy.example", port: 8080))
-        let configuration = try #require(
-            SystemProxyEgressLoader.configuration(for: proxy, timeout: .seconds(3))
-        )
-
-        #expect(configuration.proxyConfigurations.count == 1)
-        #expect(configuration.proxyConfigurations[0].allowFailover == false)
-        #expect(configuration.connectionProxyDictionary?.isEmpty != false)
-        #expect(configuration.urlCredentialStorage == nil)
-    }
-
-    @Test("HTTP forward HTTPS tunnel and SOCKS candidates use distinct transport configurations")
-    func selectedProxyTransportConfigurationsPreserveSemantics() throws {
-        let endpoint = ProxyEndpoint(host: "proxy.example", port: 8080)
-        let httpConfiguration = try #require(SystemProxyEgressLoader.configuration(
-            for: .http(endpoint),
-            timeout: .seconds(3)
-        ))
-        let httpsConfiguration = try #require(SystemProxyEgressLoader.configuration(
-            for: .https(endpoint),
-            timeout: .seconds(3)
-        ))
-        let socksConfiguration = try #require(SystemProxyEgressLoader.configuration(
-            for: .socks(endpoint),
-            timeout: .seconds(3)
-        ))
-
-        let httpDictionary = try #require(httpConfiguration.connectionProxyDictionary)
-        #expect((httpDictionary[kCFNetworkProxiesHTTPEnable as String] as? NSNumber)?.boolValue == true)
-        #expect(httpDictionary[kCFNetworkProxiesHTTPProxy as String] as? String == endpoint.host)
-        #expect((httpDictionary[kCFNetworkProxiesHTTPPort as String] as? NSNumber)?.intValue == Int(endpoint.port))
-        #expect((httpDictionary[kCFNetworkProxiesHTTPSEnable as String] as? NSNumber)?.boolValue == false)
-        #expect((httpDictionary[kCFNetworkProxiesSOCKSEnable as String] as? NSNumber)?.boolValue == false)
-        #expect((httpDictionary[kCFNetworkProxiesProxyAutoConfigEnable as String] as? NSNumber)?.boolValue == false)
-        #expect((httpDictionary[kCFNetworkProxiesProxyAutoDiscoveryEnable as String] as? NSNumber)?.boolValue == false)
-        #expect(httpConfiguration.proxyConfigurations.isEmpty)
-
-        #expect(httpsConfiguration.connectionProxyDictionary?.isEmpty == true)
-        #expect(httpsConfiguration.proxyConfigurations.count == 1)
-        #expect(httpsConfiguration.proxyConfigurations[0].debugDescription.contains("http_connect"))
-        #expect(httpsConfiguration.proxyConfigurations[0].allowFailover == false)
-
-        #expect(socksConfiguration.connectionProxyDictionary?.isEmpty == true)
-        #expect(socksConfiguration.proxyConfigurations.count == 1)
-        #expect(socksConfiguration.proxyConfigurations[0].debugDescription.contains("socksv5"))
-        #expect(socksConfiguration.proxyConfigurations[0].allowFailover == false)
-    }
-
-    @Test("non-positive proxy timeout without an attempted endpoint is indeterminate")
-    func nonPositiveProxyTimeoutIsIndeterminate() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let endpoint = ProxyEndpoint(host: "proxy.example", port: 8080)
-        let connectorRecorder = ProxyConnectorTestRecorder()
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: RecordingProxyConnector(reachable: true, recorder: connectorRecorder),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let route = await check.evaluate(
-            target: target,
-            resolution: .init(candidates: [.http(endpoint)], evidenceCodes: []),
-            timeout: .zero
-        )
-
-        #expect(route.status == .indeterminate)
-        #expect(route.selectedCandidateIndex == nil)
-        #expect(route.selectedProxy == nil)
-        #expect(route.evidence.contains(.init(code: "proxy.http.timeout", value: "expired")))
-        #expect(await connectorRecorder.endpoints.isEmpty)
-    }
-
-    @Test("later success after 407 selects that candidate and skips the trailing route")
-    func proxySuccessAfterAuthenticationShortCircuitsTrailingCandidate() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let firstEndpoint = ProxyEndpoint(host: "auth.example", port: 8080)
-        let selectedEndpoint = ProxyEndpoint(host: "working.example", port: 8081)
-        let trailingEndpoint = ProxyEndpoint(host: "unused.example", port: 8082)
-        let first = EffectiveProxy.http(firstEndpoint)
-        let selected = EffectiveProxy.http(selectedEndpoint)
-        let trailing = EffectiveProxy.http(trailingEndpoint)
-        let connector = SequencedProxyConnector(outcomes: [true, true, true])
-        let egress = SequencedProxyEgressLoader(
-            responses: [
-                .init(statusCode: 407, errorCode: nil),
-                .init(statusCode: 204, errorCode: nil),
-                .init(statusCode: 200, errorCode: nil),
-            ],
-            delays: [.zero, .zero, .zero]
-        )
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: connector,
-            egressLoader: egress,
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let route = await check.evaluate(
-            target: target,
-            resolution: .init(candidates: [first, selected, trailing], evidenceCodes: []),
-            timeout: .seconds(3)
-        )
-
-        #expect(route.status == .proxied)
-        #expect(route.selectedCandidateIndex == 1)
-        #expect(route.selectedProxy == selected)
-        #expect(await connector.endpoints == [firstEndpoint, selectedEndpoint])
-        #expect(await egress.timeouts.count == 2)
-    }
-
-    @Test("authentication evidence takes precedence over an unavailable peer target")
-    func proxyMixedFailureSeverityPrefersAuthentication() async {
-        let httpURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let httpProxy = EffectiveProxy.http(.init(host: "auth.example", port: 8080))
-        let httpsProxy = EffectiveProxy.https(.init(host: "stale.example", port: 8443))
-        let connector = EndpointSelectiveProxyConnector(reachableHosts: ["auth.example"])
-        let result = await SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [
-                httpURL: .init(candidates: [httpProxy], evidenceCodes: []),
-                httpsURL: .init(candidates: [httpsProxy], evidenceCodes: []),
-            ]),
-            connector: connector,
-            egressLoader: StubProxyEgressLoader(statusCode: 407),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        ).run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.authentication_required.summary",
-            comment: "Network self-check proxy authentication required result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.http.authentication-status", value: "required")))
-        #expect(result.evidence.contains(.init(code: "proxy.https.endpoint-status", value: "unavailable")))
-    }
-
-    @Test("selected proxy transport failure is egress unavailable")
-    func proxyEgressUnavailable() async {
-        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(proxy),
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: nil, errorCode: "-1005"),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .abnormal)
-        #expect(result.summary == String(
-            localized: "network_diagnostics.proxy.route_unavailable.summary",
-            comment: "Network self-check proxy target route unavailable result summary"
-        ))
-        #expect(result.evidence.contains(.init(code: "proxy.egress-unavailable", value: "-1005")))
-    }
-
-    @Test("selected HTTP proxy probes the same control URL once")
-    func selectedProxyEgressSuccess() async {
-        let controlURL = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let httpsURL = URL(string: "https://www.apple.com/")!
-        let proxy = EffectiveProxy.http(ProxyEndpoint(host: "proxy.example", port: 8080))
-        let recorder = ProxyEgressTestRecorder()
-        let check = SystemProxyCheck(
-            resolver: RecordingProxyResolver(resolutions: [
-                controlURL: .init(candidates: [proxy], evidenceCodes: []),
-                httpsURL: .init(candidates: [.direct], evidenceCodes: []),
-            ]),
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200, recorder: recorder),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-
-        let result = await check.run()
-
-        #expect(result.status == .indeterminate)
-        #expect(await recorder.requests == [.init(url: controlURL, proxy: proxy)])
-    }
-
-    @Test("cancelled concurrent proxy resolution remains bounded")
-    func proxyCancellationStopsSecondTargetResolution() async {
-        let resolver = CancellationIgnoringProxyResolver()
-        let check = SystemProxyCheck(
-            resolver: resolver,
-            connector: StubProxyConnector(reachable: true),
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-        let task = Task { await check.run() }
-
-        await resolver.waitForInvocation()
-        task.cancel()
-        let result = await task.value
-
-        #expect(await resolver.urls.count <= 2)
-        #expect(result.status == .indeterminate)
-        #expect(result.evidence.contains(.init(
-            code: "proxy.cancelled",
-            value: "after-http-resolution"
-        )))
-    }
-
-    @Test("cancelled PAC resolution does not append later static candidates")
-    func proxyResolverCancellationStopsRemainingDirectives() async {
-        let pacURL = URL(string: "https://proxy.example/config.pac")!
-        let pacResolver = CancellationIgnoringPACResolver()
-        let resolver = SystemProxyResolver(
-            configurationResolver: StubProxyConfigurationResolver([
-                .pac(pacURL),
-                .http(.init(host: "unused.example", port: 8080)),
-            ]),
-            pacResolver: pacResolver
-        )
-        let task = Task {
-            await resolver.resolve(
-                for: URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-            )
-        }
-
-        await pacResolver.waitForInvocation()
-        task.cancel()
-        let resolution = await task.value
-
-        #expect(resolution.candidates.isEmpty)
-        #expect(resolution.evidenceCodes.contains("pac-cancelled"))
-        #expect(resolution.evidenceCodes.contains("resolution-cancelled"))
-    }
-
-    @Test("cancelling an endpoint attempt stops candidate fallback")
-    func proxyCancellationStopsAfterConnector() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let first = ProxyEndpoint(host: "first.example", port: 8080)
-        let second = ProxyEndpoint(host: "second.example", port: 8081)
-        let connector = CancellationIgnoringProxyConnector()
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: connector,
-            egressLoader: StubProxyEgressLoader(statusCode: 200),
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-        let task = Task {
-            await check.evaluate(
-                target: target,
-                resolution: .init(candidates: [.http(first), .http(second)], evidenceCodes: []),
-                timeout: .seconds(30)
-            )
-        }
-
-        await connector.waitForInvocation()
-        task.cancel()
-        let route = await task.value
-
-        #expect(await connector.endpoints == [first])
-        #expect(route.status == .indeterminate)
-        #expect(route.evidence.contains(.init(
-            code: "proxy.http.cancelled",
-            value: "endpoint"
-        )))
-    }
-
-    @Test("cancelling proxy egress stops connector and candidate fallback")
-    func proxyCancellationStopsAfterEgress() async {
-        let target = URL(string: "http://www.msftconnecttest.com/connecttest.txt")!
-        let first = ProxyEndpoint(host: "first.example", port: 8080)
-        let second = ProxyEndpoint(host: "second.example", port: 8081)
-        let connector = SequencedProxyConnector(outcomes: [true, true])
-        let egress = CancellationIgnoringProxyEgressLoader()
-        let check = SystemProxyCheck(
-            resolver: StubProxyResolver(.direct),
-            connector: connector,
-            egressLoader: egress,
-            tunnelReader: StubProxyTunnelStateReader(interface: nil),
-        )
-        let task = Task {
-            await check.evaluate(
-                target: target,
-                resolution: .init(candidates: [.http(first), .http(second)], evidenceCodes: []),
-                timeout: .seconds(30)
-            )
-        }
-
-        await egress.waitForInvocation()
-        task.cancel()
-        let route = await task.value
-
-        #expect(await connector.endpoints == [first])
-        #expect(await egress.invocationCount == 1)
-        #expect(route.status == .indeterminate)
-        #expect(route.evidence.contains(.init(
-            code: "proxy.http.cancelled",
-            value: "egress"
-        )))
-    }
-
-    @Test("view model starts idle and only runs after start")
-    @MainActor
-    func viewModelManualStart() async {
-        let recorder = DiagnosticTestRecorder()
-        let guidance = IsolatedGuidance()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: makeStubChecks(recorder: recorder),
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.phase == .idle)
-        #expect(viewModel.conclusion == nil)
-        #expect(await recorder.values.isEmpty)
-
-        #expect(viewModel.start())
-        #expect(!viewModel.start())
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.conclusion == .networkNormal)
-        #expect(viewModel.results.count == 3)
-        #expect(viewModel.executionPhases.values.allSatisfy { $0 == .completed })
-    }
-
-    @Test("fingerprint observation timeout does not wait for a cancellation-ignoring monitor")
-    @MainActor
-    func fingerprintObservationTimeoutIsBounded() async {
-        let monitor = CancellationIgnoringNetworkFingerprintMonitor()
-        let clock = ManualDiagnosticClock()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [],
-            fingerprintMonitor: monitor,
-            clock: clock
-        )
-
-        #expect(viewModel.start())
-        await monitor.waitForInvocation()
-        await clock.set(clock.origin.advanced(by: .seconds(1)))
-
-        for _ in 0..<100 {
-            if !viewModel.fingerprintMonitoringAvailable { break }
-            await Task.yield()
-        }
-
-        #expect(!viewModel.fingerprintMonitoringAvailable)
-        await monitor.release()
-        await viewModel.waitForCompletion()
-    }
-
-    @Test("network diagnostics keeps an isolated resettable log buffer")
-    func networkDiagnosticsLogStoreIsResettable() {
-        var store = NetworkDiagnosticsLogStore()
-
-        store.append("self-check started")
-        store.append("DNS resolved")
-
-        #expect(store.lines == ["self-check started", "DNS resolved"])
-        #expect(store.text == "self-check started\nDNS resolved")
-
-        store.reset()
-
-        #expect(store.lines.isEmpty)
-        #expect(store.text.isEmpty)
-    }
-
-    @Test("diagnostics log store keeps a bounded history and truncation marker")
-    func diagnosticsLogStoreHasFiniteCapacity() {
-        var store = NetworkDiagnosticsLogStore()
-
-        for index in 0..<501 {
-            store.append("event \(index)")
-        }
-
-        #expect(store.lines.count == NetworkDiagnosticsLogStore.capacity)
-        #expect(store.lines.contains(NetworkDiagnosticsLogStore.truncationMarker))
-        #expect(!store.text.contains("event 0\n"))
-        #expect(store.text.contains("event 500"))
-
-        var typedStore = NetworkDiagnosticsLogStore()
-        for index in 0..<501 {
-            typedStore.append(NetworkDiagnosticEvent(
-                runID: UUID(),
-                elapsedMilliseconds: Int64(index),
-                kind: .checkFinished,
-                checkID: .path,
-                reasonCode: nil
-            ))
-        }
-        #expect(typedStore.lines.count == NetworkDiagnosticsLogStore.capacity)
-        #expect(typedStore.events.count == NetworkDiagnosticsLogStore.capacity - 1)
-    }
-
-    @Test("typed diagnostic events only format allowlisted restart reasons")
-    func diagnosticEventFormattingAllowlist() {
-        let event = NetworkDiagnosticEvent(
-            runID: UUID(),
-            elapsedMilliseconds: 42,
-            kind: .restarted,
-            checkID: nil,
-            reasonCode: "raw-sensitive-value"
-        )
-
-        #expect(event.formatted() == "42ms · Network changed; restarting (network state)")
-        #expect(!event.formatted().contains("raw-sensitive-value"))
-    }
-
-    @Test("view model publishes its own diagnostic result logs")
-    @MainActor
-    func viewModelPublishesDiagnosticLogs() async {
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: makeStubChecks(recorder: DiagnosticTestRecorder()),
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
-        )
-
-        #expect(viewModel.logText.isEmpty)
-        #expect(viewModel.start())
-        await viewModel.waitForCompletion()
-
-        let stableLogLines = viewModel.logStore.lines.map { line in
-            guard let separator = line.range(of: " · ") else { return line }
-            return String(line[separator.upperBound...])
-        }
-        #expect(stableLogLines == [
-            "Session started",
-            "Run started",
-            "Checking Network Path…",
-            "Network Path finished",
-            "Checking DNS Resolution…",
-            "DNS Resolution finished",
-            "Checking System Proxy…",
-            "System Proxy finished",
-            "Check completed",
-        ])
-        #expect(viewModel.logStore.events.map(\.kind) == [
-            .sessionStarted,
-            .runStarted,
-            .checkStarted,
-            .checkFinished,
-            .checkStarted,
-            .checkFinished,
-            .checkStarted,
-            .checkFinished,
-            .completed,
-        ])
-
-        viewModel.clearLogs()
-        #expect(viewModel.logText.isEmpty)
-    }
-
-    @Test("view model clears the previous conclusion before a rerun")
-    @MainActor
-    func viewModelRerun() async {
-        let recorder = DiagnosticTestRecorder()
-        let guidance = IsolatedGuidance()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: makeStubChecks(recorder: recorder),
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await viewModel.waitForCompletion()
-        #expect(viewModel.conclusion == .networkNormal)
-
-        #expect(viewModel.start())
-        #expect(viewModel.conclusion == nil)
-        await viewModel.waitForCompletion()
-        #expect(await recorder.values.count == 6)
-    }
-
-    @Test("a changed fingerprint restarts network probes once and retains configuration results")
-    @MainActor
-    func fingerprintChangeRestartsOnce() async {
-        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
-        let guidance = IsolatedGuidance()
-        let configurationProbe = RestartableDiagnosticProbe()
-        let networkProbe = RestartableDiagnosticProbe(blockFirstInvocation: true)
-        let checks: [any DiagnosticCheck] = [
-            ProbeDiagnosticCheck(
-                id: .proxy,
-                result: .init(id: .proxy, status: .normal, summary: "configuration"),
-                rerunPolicy: .configurationOnly,
-                probe: configurationProbe
-            ),
-            ProbeDiagnosticCheck(
-                id: .path,
-                result: .init(id: .path, status: .normal, summary: "network"),
-                rerunPolicy: .networkSensitive,
-                probe: networkProbe
-            ),
-        ]
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: checks,
-            fingerprintMonitor: fingerprintMonitor,
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await networkProbe.waitForInvocationCount(1)
-        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 2))
-        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en2", dnsHash: 3))
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.conclusion == .networkNormal)
-        #expect(viewModel.automaticRestartCount == 1)
-        #expect(await configurationProbe.invocationCount == 1)
-        #expect(await networkProbe.invocationCount == 2)
-        #expect(viewModel.results[.proxy]?.summary == "configuration")
-        #expect(viewModel.results[.path]?.summary == "network")
-    }
-
-    @Test("an unchanged fingerprint does not restart an active probe")
-    @MainActor
-    func unchangedFingerprintDoesNotRestart() async {
-        let fingerprint = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: fingerprint)
-        let guidance = IsolatedGuidance()
-        let probe = RestartableDiagnosticProbe(blockFirstInvocation: true)
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [
-                ProbeDiagnosticCheck(
-                    id: .path,
-                    result: .init(id: .path, status: .normal, summary: "network"),
-                    rerunPolicy: .networkSensitive,
-                    probe: probe
-                ),
-            ],
-            fingerprintMonitor: fingerprintMonitor,
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(1)
-        await fingerprintMonitor.send(fingerprint)
-        await probe.releaseFirstInvocation()
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.automaticRestartCount == 0)
-        #expect(await probe.invocationCount == 1)
-    }
-
-    @Test("a second network change during the rerun starts a fresh run")
-    @MainActor
-    func repeatedFingerprintChangesRestartAgain() async {
-        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
-        let probe = BlockingDiagnosticProbe()
-        let guidance = IsolatedGuidance()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            fingerprintMonitor: fingerprintMonitor,
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(1)
-        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 2))
-        await probe.waitForInvocationCount(2)
-        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en2", dnsHash: 3))
-        await probe.waitForInvocationCount(3)
-        await probe.release(invocation: 3)
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.automaticRestartCount == 2)
-        #expect(await probe.invocationCount == 3)
-    }
-
-    @Test("the controller closes network-change intake before results are published")
-    func fingerprintControllerFinalizationGate() async {
-        let controller = NetworkDiagnosticRestartController()
-        let fingerprint = makeFingerprint(interfaceName: "en1", dnsHash: 2)
-
-        #expect(await controller.completeRun() == false)
-        #expect(await controller.observe(fingerprint) == false)
-    }
-
-    @Test("stability window starts from the latest network change")
-    func stabilityWindowUsesLatestChange() async {
-        let controller = NetworkDiagnosticRestartController()
-        let clock = ManualDiagnosticClock()
-        let base = clock.origin
-        let first = makeFingerprint(interfaceName: "en1", dnsHash: 2)
-        let second = makeFingerprint(interfaceName: "en2", dnsHash: 3)
-        let completion = OptionalBoolRecorder()
-
-        #expect(await controller.observe(first, at: base))
-        let waitTask = Task {
-            let result = await controller.waitForStability(
-                using: clock,
-                until: base.advanced(by: .seconds(2))
-            )
-            await completion.record(result)
-            return result
-        }
-
-        await clock.waitForSleeperCount(1)
-        await clock.set(base.advanced(by: .milliseconds(400)))
-        #expect(await controller.observe(
-            second,
-            at: base.advanced(by: .milliseconds(400))
-        ))
-
-        await clock.waitForSleeperCount(1)
-        await clock.set(base.advanced(by: .milliseconds(800)))
-        await Task.yield()
-        #expect(await completion.value == nil)
-
-        await clock.set(base.advanced(by: .milliseconds(900)))
-        #expect(await waitTask.value)
-        #expect(await completion.value == true)
-    }
-
-    @Test("explicit cancellation is latched before a run is installed")
-    func restartControllerLatchesCancellationBeforeInstall() async {
-        let controller = NetworkDiagnosticRestartController()
-        let run = Task<[NetworkDiagnosticResult], Never> {
-            try? await Task.sleep(for: .seconds(30))
-            return []
-        }
-
-        await controller.cancelCurrentRun()
-        await controller.install(run)
-
-        #expect(run.isCancelled)
-        run.cancel()
-        _ = await run.value
-    }
-
-    @Test("a duplicate path update is ignored")
-    func duplicatePathUpdateIsIgnored() async throws {
-        let baseline = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let path = NetworkPathFingerprint(
-            interfaceType: baseline.interfaceType,
-            interfaceName: baseline.interfaceName,
-            pathStatus: baseline.pathStatus
-        )
-        let monitor = SystemNetworkFingerprintMonitor(
-            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
-            pathSource: FiniteNetworkPathFingerprintSource(values: [path, path]),
-            settingsPoller: SilentNetworkFingerprintSettingsPoller()
-        )
-
-        let optionalObservation = await monitor.observation()
-        let observation = try #require(optionalObservation)
-        var changes: [NetworkFingerprint] = []
-        for await fingerprint in observation.changes {
-            changes.append(fingerprint)
-        }
-
-        #expect(observation.baseline == baseline)
-        #expect(changes.isEmpty)
-    }
-
-    @Test("baseline and an immediate path change share one buffered observation source")
-    func fingerprintObservationDoesNotLoseBaselineGapChange() async throws {
-        let baselinePath = NetworkPathFingerprint(
-            interfaceType: "wifi",
-            interfaceName: "en0",
-            pathStatus: .satisfied
-        )
-        let changedPath = NetworkPathFingerprint(
-            interfaceType: "wifi",
-            interfaceName: "en1",
-            pathStatus: .satisfied
-        )
-        let pathSource = BufferedGapNetworkPathFingerprintSource(
-            values: [baselinePath, changedPath]
-        )
-        let monitor = SystemNetworkFingerprintMonitor(
-            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
-            pathSource: pathSource,
-            settingsPoller: SilentNetworkFingerprintSettingsPoller()
-        )
-
-        let optionalObservation = await monitor.observation()
-        let observation = try #require(optionalObservation)
-        var iterator = observation.changes.makeAsyncIterator()
-        let change = await iterator.next()
-
-        #expect(observation.baseline.interfaceName == "en0")
-        #expect(change?.interfaceName == "en1")
-        #expect(pathSource.streamRequestCount == 1)
-    }
-
-    @Test("explicit cancellation stops an active diagnostics session")
-    @MainActor
-    func viewModelCancellation() async {
-        let probe = BlockingDiagnosticProbe()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
-        )
-
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(1)
-        viewModel.cancel()
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.conclusion == nil)
-        #expect(viewModel.endReason == .cancelled)
-    }
-
-    @Test("a cancelled run cannot overwrite a replacement run")
-    @MainActor
-    func cancelledRunCannotOverwriteReplacementRun() async {
-        let probe = CancellationIgnoringDiagnosticProbe()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
-        )
-
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(1)
-        viewModel.cancel()
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(2)
-
-        await probe.release(invocation: 1)
-        try? await Task.sleep(for: .milliseconds(10))
-        #expect(viewModel.phase == .running)
-        #expect(viewModel.results.isEmpty)
-
-        await probe.release(invocation: 2)
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.endReason == .completed)
-        #expect(viewModel.results[.path]?.status == .normal)
-    }
-
-    @Test("unstable network changes do not restore invalidated results")
-    @MainActor
-    func unstableNetworkChangeDoesNotRestoreOldResults() async {
-        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
-        let blockingProbe = BlockingDiagnosticProbe()
-        let clock = ManualDiagnosticClock()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [
-                StubDiagnosticCheck(
-                    id: .path,
-                    result: .init(id: .path, status: .normal, summary: "old path"),
-                    recorder: DiagnosticTestRecorder()
-                ),
-                BlockingProbeDiagnosticCheck(id: .dns, probe: blockingProbe),
-            ],
-            fingerprintMonitor: fingerprintMonitor,
-            clock: clock
-        )
-
-        #expect(viewModel.start())
-        await blockingProbe.waitForInvocationCount(1)
-        await clock.set(clock.origin.advanced(by: .milliseconds(29_800)))
-        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 1))
-        await clock.set(clock.origin.advanced(by: .milliseconds(30_100)))
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.endReason == .superseded)
-        #expect(viewModel.results.isEmpty)
-        #expect(viewModel.pendingCheckIDs == [.path, .dns])
-    }
-
-    @Test("a successful diagnostics run reports the completion moment exactly once")
-    @MainActor
-    func successfulRunReportsDiagnosticsMomentOnce() async {
-        let recorder = DiagnosticTestRecorder()
-        let guidance = IsolatedGuidance()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: makeStubChecks(recorder: recorder),
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        let loaded = guidance.store.load()
-        #expect(loaded.meaningfulCompletionCount == 1)
-        #expect(loaded.invitationPresentationCount == 0)
-        #expect(loaded.lastInvitationDate == nil)
-        #expect(guidance.events.filter { $0.name == "guidance.value_moment" }.count == 1)
-    }
-
-    @Test("a run that never reaches completion never reports the diagnostics moment")
-    @MainActor
-    func failingRunNeverReportsDiagnosticsMoment() async {
-        let probe = BlockingDiagnosticProbe()
-        let guidance = IsolatedGuidance()
-        let viewModel = NetworkDiagnosticsViewModel(
-            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
-            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
-            guidance: guidance.coordinator
-        )
-
-        #expect(viewModel.start())
-        await probe.waitForInvocationCount(1)
-        viewModel.cancel()
-        await viewModel.waitForCompletion()
-
-        #expect(viewModel.phase == .completed)
-        #expect(viewModel.conclusion == nil)
-        #expect(viewModel.endReason == .cancelled)
-        #expect(guidance.store.load().meaningfulCompletionCount == 0)
-        #expect(guidance.events.isEmpty)
-    }
-
-    @Test("system fingerprint monitor detects DNS settings changes without a path update")
-    func fingerprintDetectsSettingsOnlyChange() async throws {
-        let baseline = makeFingerprint(interfaceName: "en0", dnsHash: 1)
-        let path = NetworkPathFingerprint(
-            interfaceType: baseline.interfaceType,
-            interfaceName: baseline.interfaceName,
-            pathStatus: baseline.pathStatus
-        )
-        let settingsReader = SequencedFingerprintSettingsReader(dnsHashes: [1, 2], proxyHash: 7)
-        let monitor = SystemNetworkFingerprintMonitor(
-            settingsReader: settingsReader,
-            pathSource: FiniteNetworkPathFingerprintSource(values: [path]),
-            settingsPoller: ImmediateNetworkFingerprintSettingsPoller(),
-            settingsPollInterval: .milliseconds(10)
-        )
-
-        let optionalObservation = await monitor.observation()
-        let observation = try #require(optionalObservation)
-        var iterator = observation.changes.makeAsyncIterator()
-        let changedFingerprint = await iterator.next()
-
-        #expect(observation.baseline == baseline)
-        #expect(changedFingerprint?.interfaceName == "en0")
-        #expect(changedFingerprint?.dnsSettingsHash == 2)
-        #expect(changedFingerprint?.staticProxySettingsHash == 7)
-    }
-
-    @Test("system fingerprint monitor detects route changes without DNS or proxy changes")
-    func fingerprintDetectsRouteOnlyChange() async throws {
-        let baselinePath = NetworkPathFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied
-        )
-        let routeSource = SequencedFingerprintRouteStateSource(values: [
-            NetworkFingerprintRouteState(
-                interfaceName: "en7",
-                interfaceIndex: 12,
-                gateway: "192.0.2.1",
-                addresses: ["192.0.2.10"],
-                subnets: ["255.255.255.0"]
-            ),
-            NetworkFingerprintRouteState(
-                interfaceName: "en7",
-                interfaceIndex: 12,
-                gateway: "192.0.2.254",
-                addresses: ["192.0.2.10"],
-                subnets: ["255.255.255.0"]
-            ),
-            NetworkFingerprintRouteState(
-                interfaceName: nil,
-                interfaceIndex: nil,
-                gateway: nil
-            ),
-        ])
-        let monitor = SystemNetworkFingerprintMonitor(
-            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
-            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath]),
-            settingsPoller: FixedCountNetworkFingerprintSettingsPoller(count: 2),
-            routeStateSource: routeSource
-        )
-
-        let observation = try #require(await monitor.observation())
-        var iterator = observation.changes.makeAsyncIterator()
-        let change = await iterator.next()
-        let disappeared = await iterator.next()
-
-        #expect(observation.baseline.selectedGateway == "192.0.2.1")
-        #expect(change?.selectedGateway == "192.0.2.254")
-        #expect(disappeared?.selectedGateway == nil)
-        #expect(disappeared?.selectedInterfaceIndex == nil)
-        #expect(disappeared?.selectedInterfaceAddresses.isEmpty == true)
-    }
-
-    @Test("proxy fingerprint includes PAC and automatic discovery settings")
-    func proxyFingerprintIncludesAutomaticSettings() {
-        let baseline = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
-            "ProxyAutoConfigEnable": 0,
-            "ProxyAutoConfigURLString": "https://proxy.example/old.pac",
-            "ProxyAutoDiscoveryEnable": 0,
-        ])
-        let changedPAC = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
-            "ProxyAutoConfigEnable": 1,
-            "ProxyAutoConfigURLString": "https://proxy.example/new.pac",
-            "ProxyAutoDiscoveryEnable": 0,
-        ])
-        let changedDiscovery = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
-            "ProxyAutoConfigEnable": 0,
-            "ProxyAutoConfigURLString": "https://proxy.example/old.pac",
-            "ProxyAutoDiscoveryEnable": 1,
-        ])
-
-        #expect(changedPAC != baseline)
-        #expect(changedDiscovery != baseline)
-    }
-
-    @Test("VPN and TUN interface names are classified without VPN manager access")
-    func tunnelInterfaceClassification() {
-        let tunnels = NetworkTunnelInterfaceClassifier.tunnelInterfaces(from: [
-            "en0", "utun3", "ipsec0", "ppp0", "bridge0", "utun2"
-        ])
-
-        #expect(tunnels == ["ipsec0", "ppp0", "utun2", "utun3"])
-        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
-            activeInterfaceName: "utun3",
-            tunnelInterfaces: tunnels
-        ) == "utun3")
-        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
-            activeInterfaceName: "en0",
-            tunnelInterfaces: tunnels
-        ) == nil)
-    }
-
-    @Test("tunnel presence and routed interface changes are fingerprint changes")
-    func tunnelFingerprintChangesTriggerObservation() async throws {
-        let baselinePath = NetworkPathFingerprint(
-            interfaceType: "wifi",
-            interfaceName: "en0",
-            pathStatus: .satisfied,
-            tunnelInterfaces: [],
-            routedTunnelInterface: nil
-        )
-        let changedPath = NetworkPathFingerprint(
-            interfaceType: "wifi",
-            interfaceName: "en0",
-            pathStatus: .satisfied,
-            tunnelInterfaces: ["utun3"],
-            routedTunnelInterface: "utun3"
-        )
-        let monitor = SystemNetworkFingerprintMonitor(
-            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
-            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath, changedPath]),
-            settingsPoller: SilentNetworkFingerprintSettingsPoller()
-        )
-
-        let observation = try #require(await monitor.observation())
-        var iterator = observation.changes.makeAsyncIterator()
-        let change = await iterator.next()
-
-        #expect(observation.baseline.tunnelInterfaces.isEmpty)
-        #expect(change?.tunnelInterfaces == ["utun3"])
-        #expect(change?.routedTunnelInterface == "utun3")
-    }
-
-    @Test("gateway target identity includes interface index and address state")
-    func fingerprintIncludesRouteAndAddressIdentity() {
-        let first = NetworkFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied,
-            dnsSettingsHash: 1,
-            staticProxySettingsHash: 7,
-            selectedInterfaceIndex: 12,
-            selectedInterfaceAddresses: ["192.0.2.10"],
-            selectedInterfaceSubnets: ["255.255.255.0"],
-            selectedGateway: "192.0.2.1",
-            ipv4PrimaryServiceIdentity: "service-a",
-            ipv6PrimaryServiceIdentity: "service-v6"
-        )
-        let changedAddress = NetworkFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied,
-            dnsSettingsHash: 1,
-            staticProxySettingsHash: 7,
-            selectedInterfaceIndex: 12,
-            selectedInterfaceAddresses: ["192.0.2.11"],
-            selectedInterfaceSubnets: ["255.255.255.0"],
-            selectedGateway: "192.0.2.1",
-            ipv4PrimaryServiceIdentity: "service-a",
-            ipv6PrimaryServiceIdentity: "service-v6"
-        )
-        let changedRoute = NetworkFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied,
-            dnsSettingsHash: 1,
-            staticProxySettingsHash: 7,
-            selectedInterfaceIndex: 12,
-            selectedInterfaceAddresses: ["192.0.2.10"],
-            selectedInterfaceSubnets: ["255.255.255.0"],
-            selectedGateway: "192.0.2.254",
-            ipv4PrimaryServiceIdentity: "service-a",
-            ipv6PrimaryServiceIdentity: "service-v6"
-        )
-
-        #expect(first != changedAddress)
-        #expect(first != changedRoute)
-    }
-
-    @Test("fingerprint comparison ignores address and tunnel collection order")
-    func fingerprintNormalizesUnorderedCollections() {
-        let first = NetworkFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied,
-            dnsSettingsHash: 1,
-            staticProxySettingsHash: 7,
-            tunnelInterfaces: ["utun3", "utun2"],
-            selectedInterfaceAddresses: ["192.0.2.11", "192.0.2.10"],
-            selectedInterfaceSubnets: ["255.255.255.0", "255.255.0.0"]
-        )
-        let reordered = NetworkFingerprint(
-            interfaceType: "ethernet",
-            interfaceName: "en7",
-            pathStatus: .satisfied,
-            dnsSettingsHash: 1,
-            staticProxySettingsHash: 7,
-            tunnelInterfaces: ["utun2", "utun3"],
-            selectedInterfaceAddresses: ["192.0.2.10", "192.0.2.11"],
-            selectedInterfaceSubnets: ["255.255.0.0", "255.255.255.0"]
-        )
-
-        #expect(first == reordered)
-        #expect(first.restartReason(comparedWith: reordered) == .path)
-    }
-
-    private func makeResults(
+    func makeResults(
         path: NetworkDiagnosticStatus,
         gateway: NetworkDiagnosticStatus = .normal,
         dns: NetworkDiagnosticStatus,
@@ -3495,7 +25,7 @@ struct NetworkDiagnosticsTests {
         ]
     }
 
-    private func makeFingerprint(
+    func makeFingerprint(
         interfaceName: String,
         dnsHash: UInt64
     ) -> NetworkFingerprint {
@@ -3508,7 +38,7 @@ struct NetworkDiagnosticsTests {
         )
     }
 
-    private func makeStubChecks(recorder: DiagnosticTestRecorder) -> [any DiagnosticCheck] {
+    func makeStubChecks(recorder: DiagnosticTestRecorder) -> [any DiagnosticCheck] {
         [.path, .dns, .proxy].map { id in
             StubDiagnosticCheck(
                 id: id,
@@ -3519,20 +49,20 @@ struct NetworkDiagnosticsTests {
     }
 }
 
-private struct AppLocalNetworkUsageDescription {
+struct AppLocalNetworkUsageDescription {
     let target: String
     let configuration: String
     let baseConfiguration: String
     let value: String
 }
 
-private func appLocalNetworkUsageDescriptions() throws -> [AppLocalNetworkUsageDescription] {
+func appLocalNetworkUsageDescriptions() throws -> [AppLocalNetworkUsageDescription] {
     let projectURL = try privacyCopyProjectURL()
     let project = try String(contentsOf: projectURL, encoding: .utf8)
     return try appLocalNetworkUsageDescriptions(from: project)
 }
 
-private func appLocalNetworkUsageDescriptions(
+func appLocalNetworkUsageDescriptions(
     from project: String
 ) throws -> [AppLocalNetworkUsageDescription] {
     let settingPrefix = "INFOPLIST_KEY_NSLocalNetworkUsageDescription = \""
@@ -3604,7 +134,7 @@ private func appLocalNetworkUsageDescriptions(
     }
 }
 
-private func nativeTarget(named name: String, in project: String) throws -> String {
+func nativeTarget(named name: String, in project: String) throws -> String {
     let marker = " /* \(name) */ = {\n\t\t\tisa = PBXNativeTarget;"
     let markerRange = try requiredRange(of: marker, in: project, context: "\(name) PBXNativeTarget")
     let lineStart = project[..<markerRange.lowerBound].lastIndex(of: "\n")
@@ -3615,7 +145,7 @@ private func nativeTarget(named name: String, in project: String) throws -> Stri
     return try pbxObject(id: identifier, in: project, context: "\(name) PBXNativeTarget")
 }
 
-private func pbxObject(id: String, in project: String, context: String) throws -> String {
+func pbxObject(id: String, in project: String, context: String) throws -> String {
     let header = "\t\t\(id) "
     let start: String.Index
     if project.hasPrefix(header) {
@@ -3633,7 +163,7 @@ private func pbxObject(id: String, in project: String, context: String) throws -
     return String(suffix[..<end])
 }
 
-private func buildConfigurationIDs(in configurationList: String) throws -> [String] {
+func buildConfigurationIDs(in configurationList: String) throws -> [String] {
     let start = try requiredRange(
         of: "buildConfigurations = (",
         in: configurationList,
@@ -3652,7 +182,7 @@ private func buildConfigurationIDs(in configurationList: String) throws -> [Stri
         }
 }
 
-private func pbxIdentifier(after prefix: String, in object: String, context: String) throws -> String {
+func pbxIdentifier(after prefix: String, in object: String, context: String) throws -> String {
     let value = try pbxValue(after: prefix, in: object, context: context)
     guard !value.isEmpty else {
         throw projectConfigurationError("\(context) must name a PBX object identifier.")
@@ -3660,28 +190,28 @@ private func pbxIdentifier(after prefix: String, in object: String, context: Str
     return value
 }
 
-private func pbxValue(after prefix: String, in object: String, context: String) throws -> String {
+func pbxValue(after prefix: String, in object: String, context: String) throws -> String {
     let valueStart = try requiredRange(of: prefix, in: object, context: context).upperBound
     let valueEnd = try requiredIndex(of: ";", in: object[valueStart...], context: "\(context) terminator")
     let value = object[valueStart..<valueEnd].trimmingCharacters(in: .whitespaces)
     return value.split(separator: " ").first.map(String.init) ?? ""
 }
 
-private func requiredMatch(_ candidates: [String], in value: String, context: String) throws -> String {
+func requiredMatch(_ candidates: [String], in value: String, context: String) throws -> String {
     guard let match = candidates.first(where: value.contains) else {
         throw projectConfigurationError("\(context) must reference OSS.xcconfig or PRO.xcconfig.")
     }
     return match
 }
 
-private func requiredRange(of needle: String, in value: String, context: String) throws -> Range<String.Index> {
+func requiredRange(of needle: String, in value: String, context: String) throws -> Range<String.Index> {
     guard let range = value.range(of: needle) else {
         throw projectConfigurationError("Missing \(context).")
     }
     return range
 }
 
-private func requiredIndex(
+func requiredIndex(
     of character: Character,
     in value: Substring,
     context: String
@@ -3692,7 +222,7 @@ private func requiredIndex(
     return index
 }
 
-private func projectConfigurationError(_ description: String) -> NSError {
+func projectConfigurationError(_ description: String) -> NSError {
     NSError(
         domain: "NetworkDiagnosticsTests",
         code: 1,
@@ -3700,7 +230,7 @@ private func projectConfigurationError(_ description: String) -> NSError {
     )
 }
 
-private func privacyCopyProjectURL() throws -> URL {
+func privacyCopyProjectURL() throws -> URL {
     var directory = URL(filePath: #filePath).deletingLastPathComponent()
     let marker = "WiFiLens/WiFiLens.xcodeproj/project.pbxproj"
 
@@ -3719,103 +249,7 @@ private func privacyCopyProjectURL() throws -> URL {
     )
 }
 
-private let privacyCopyProjectFixture = """
-\t\tOSS_TARGET /* WiFiLens */ = {
-\t\t\tisa = PBXNativeTarget;
-\t\t\tbuildConfigurationList = OSS_LIST /* Build configuration list for PBXNativeTarget \"WiFiLens\" */;
-\t\t\tname = WiFiLens;
-\t\t\tproductType = \"com.apple.product-type.application\";
-\t\t};
-\t\tPRO_TARGET /* WiFiLensPro */ = {
-\t\t\tisa = PBXNativeTarget;
-\t\t\tbuildConfigurationList = PRO_LIST /* Build configuration list for PBXNativeTarget \"WiFiLensPro\" */;
-\t\t\tname = WiFiLensPro;
-\t\t\tproductType = \"com.apple.product-type.application\";
-\t\t};
-\t\tDECOY_TARGET /* OtherApp */ = {
-\t\t\tisa = PBXNativeTarget;
-\t\t\tbuildConfigurationList = DECOY_LIST /* Build configuration list for PBXNativeTarget \"OtherApp\" */;
-\t\t\tname = OtherApp;
-\t\t\tproductType = \"com.apple.product-type.application\";
-\t\t};
-\t\tOSS_LIST /* Build configuration list */ = {
-\t\t\tisa = XCConfigurationList;
-\t\t\tbuildConfigurations = (
-\t\t\t\tOSS_DEBUG /* Debug */,
-\t\t\t\tOSS_RELEASE /* Release */,
-\t\t\t);
-\t\t};
-\t\tPRO_LIST /* Build configuration list */ = {
-\t\t\tisa = XCConfigurationList;
-\t\t\tbuildConfigurations = (
-\t\t\t\tPRO_DEBUG /* Debug */,
-\t\t\t\tPRO_RELEASE /* Release */,
-\t\t\t);
-\t\t};
-\t\tDECOY_LIST /* Build configuration list */ = {
-\t\t\tisa = XCConfigurationList;
-\t\t\tbuildConfigurations = (
-\t\t\t\tDECOY_DEBUG /* Debug */,
-\t\t\t\tDECOY_RELEASE /* Release */,
-\t\t\t);
-\t\t};
-\t\tOSS_DEBUG /* Debug */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = OSS_BASE /* OSS.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"WiFiLens-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"expected app copy\";
-\t\t\t};
-\t\t\tname = Debug;
-\t\t};
-\t\tOSS_RELEASE /* Release */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = OSS_BASE /* OSS.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"WiFiLens-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"expected app copy\";
-\t\t\t};
-\t\t\tname = Release;
-\t\t};
-\t\tPRO_DEBUG /* Debug */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = PRO_BASE /* PRO.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"WiFiLensPro-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"expected app copy\";
-\t\t\t};
-\t\t\tname = Debug;
-\t\t};
-\t\tPRO_RELEASE /* Release */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = PRO_BASE /* PRO.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"WiFiLensPro-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"expected app copy\";
-\t\t\t};
-\t\t\tname = Release;
-\t\t};
-\t\tDECOY_DEBUG /* Debug */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = DECOY_BASE /* OSS.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"Other-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"decoy copy\";
-\t\t\t};
-\t\t\tname = Debug;
-\t\t};
-\t\tDECOY_RELEASE /* Release */ = {
-\t\t\tisa = XCBuildConfiguration;
-\t\t\tbaseConfigurationReference = DECOY_BASE /* OSS.xcconfig */;
-\t\t\tbuildSettings = {
-\t\t\t\tINFOPLIST_FILE = \"Other-Info.plist\";
-\t\t\t\tINFOPLIST_KEY_NSLocalNetworkUsageDescription = \"decoy copy\";
-\t\t\t};
-\t\t\tname = Release;
-\t\t};
-"""
-
-private struct StubPathSource: NetworkPathChecking {
+struct StubPathSource: NetworkPathChecking {
     let state: NetworkPathState?
 
     init(_ state: NetworkPathState?) {
@@ -3827,9 +261,9 @@ private struct StubPathSource: NetworkPathChecking {
     }
 }
 
-private actor ConcurrentDNSResolver: DNSResolving {
+actor ConcurrentDNSResolver: DNSResolving {
     private(set) var maximumInFlight = 0
-    private var inFlight = 0
+    var inFlight = 0
 
     func resolve(host: String, timeout: Duration) async -> DNSResolutionOutcome {
         inFlight += 1
@@ -3840,9 +274,9 @@ private actor ConcurrentDNSResolver: DNSResolving {
     }
 }
 
-private actor ConcurrentControlLoader: ControlEndpointLoading {
+actor ConcurrentControlLoader: ControlEndpointLoading {
     private(set) var maximumInFlight = 0
-    private var inFlight = 0
+    var inFlight = 0
 
     func load(url: URL, timeout: Duration) async -> ControlEndpointLoadResult {
         inFlight += 1
@@ -3856,7 +290,7 @@ private actor ConcurrentControlLoader: ControlEndpointLoading {
     }
 }
 
-private struct MetricsControlLoader: ControlEndpointLoading {
+struct MetricsControlLoader: ControlEndpointLoading {
     let metrics: ControlEndpointMetrics
 
     func load(url: URL, timeout: Duration) async -> ControlEndpointLoadResult {
@@ -3867,9 +301,9 @@ private struct MetricsControlLoader: ControlEndpointLoading {
     }
 }
 
-private actor BudgetAwareDiagnosticProbe {
-    private var didStart = false
-    private var invocationContinuation: CheckedContinuation<Void, Never>?
+actor BudgetAwareDiagnosticProbe {
+    var didStart = false
+    var invocationContinuation: CheckedContinuation<Void, Never>?
     private(set) var wasCancelled = false
 
     func run() async {
@@ -3897,10 +331,10 @@ private actor BudgetAwareDiagnosticProbe {
     }
 }
 
-private actor ManualDiagnosticClock: DiagnosticClock {
+actor ManualDiagnosticClock: DiagnosticClock {
     let origin: ContinuousClock.Instant
-    private var current: ContinuousClock.Instant
-    private var sleepers: [UUID: (deadline: ContinuousClock.Instant, continuation: CheckedContinuation<Void, Never>)] = [:]
+    var current: ContinuousClock.Instant
+    var sleepers: [UUID: (deadline: ContinuousClock.Instant, continuation: CheckedContinuation<Void, Never>)] = [:]
 
     init(origin: ContinuousClock.Instant = ContinuousClock.now) {
         self.origin = origin
@@ -3946,13 +380,13 @@ private actor ManualDiagnosticClock: DiagnosticClock {
         }
     }
 
-    private func cancelSleep(id: UUID) {
+    func cancelSleep(id: UUID) {
         guard let sleeper = sleepers.removeValue(forKey: id) else { return }
         sleeper.continuation.resume()
     }
 }
 
-private actor OptionalBoolRecorder {
+actor OptionalBoolRecorder {
     private(set) var value: Bool?
 
     func record(_ value: Bool) {
@@ -3960,7 +394,7 @@ private actor OptionalBoolRecorder {
     }
 }
 
-private struct BudgetAwareDiagnosticCheck: DiagnosticCheck {
+struct BudgetAwareDiagnosticCheck: DiagnosticCheck {
     let id: NetworkDiagnosticCheckID = .path
     let probe: BudgetAwareDiagnosticProbe
 
@@ -3970,9 +404,9 @@ private struct BudgetAwareDiagnosticCheck: DiagnosticCheck {
     }
 }
 
-private actor StubDNSResolver: DNSResolving {
-    private var outcomes: [DNSResolutionOutcome]
-    private var outcomeIndex = 0
+actor StubDNSResolver: DNSResolving {
+    var outcomes: [DNSResolutionOutcome]
+    var outcomeIndex = 0
     private(set) var invocationCount = 0
 
     init(_ outcome: DNSResolutionOutcome) {
@@ -3991,7 +425,7 @@ private actor StubDNSResolver: DNSResolving {
     }
 }
 
-private struct MappingDNSResolver: DNSResolving {
+struct MappingDNSResolver: DNSResolving {
     let outcomes: [String: DNSResolutionOutcome]
 
     func resolve(host: String, timeout: Duration) async -> DNSResolutionOutcome {
@@ -3999,8 +433,8 @@ private struct MappingDNSResolver: DNSResolving {
     }
 }
 
-private actor CancellationAwareDNSResolver: DNSResolving {
-    private var invocationWaiter: CheckedContinuation<Void, Never>?
+actor CancellationAwareDNSResolver: DNSResolving {
+    var invocationWaiter: CheckedContinuation<Void, Never>?
     private(set) var invocationCount = 0
 
     func resolve(host: String, timeout: Duration) async -> DNSResolutionOutcome {
@@ -4017,7 +451,7 @@ private actor CancellationAwareDNSResolver: DNSResolving {
     }
 }
 
-private struct StubControlLoader: ControlEndpointLoading {
+struct StubControlLoader: ControlEndpointLoading {
     let httpsStatus: Int?
     let httpsErrorCode: String?
     let httpStatus: Int?
@@ -4050,7 +484,7 @@ private struct StubControlLoader: ControlEndpointLoading {
     }
 }
 
-private struct StubIPv6Loader: IPv6ControlEndpointLoading {
+struct StubIPv6Loader: IPv6ControlEndpointLoading {
     let outcome: IPv6ControlEndpointLoadOutcome
 
     init(_ outcome: IPv6ControlEndpointLoadOutcome) {
@@ -4062,7 +496,7 @@ private struct StubIPv6Loader: IPv6ControlEndpointLoading {
     }
 }
 
-private struct StubGlobalIPv6AddressSource: GlobalIPv6AddressSourcing {
+struct StubGlobalIPv6AddressSource: GlobalIPv6AddressSourcing {
     let hasAddress: Bool
 
     func hasGlobalIPv6Address() -> Bool {
@@ -4070,7 +504,7 @@ private struct StubGlobalIPv6AddressSource: GlobalIPv6AddressSourcing {
     }
 }
 
-private struct StubIPv6AddressResolver: IPv6AddressResolving {
+struct StubIPv6AddressResolver: IPv6AddressResolving {
     let addresses: [String]
 
     func resolveAAAA(host: String, timeout: Duration) async -> [String] {
@@ -4078,7 +512,7 @@ private struct StubIPv6AddressResolver: IPv6AddressResolving {
     }
 }
 
-private actor RecordingIPv6AddressResolver: IPv6AddressResolving {
+actor RecordingIPv6AddressResolver: IPv6AddressResolving {
     let addresses: [String]
     private(set) var hosts: [String] = []
 
@@ -4092,14 +526,14 @@ private actor RecordingIPv6AddressResolver: IPv6AddressResolving {
     }
 }
 
-private struct IPv6LoaderTestRequest: Equatable, Sendable {
+struct IPv6LoaderTestRequest: Equatable, Sendable {
     let url: URL
     let ipv6Address: String
     let serverName: String
     let timeout: Duration
 }
 
-private actor IPv6LoaderTestRecorder {
+actor IPv6LoaderTestRecorder {
     private(set) var requests: [IPv6LoaderTestRequest] = []
 
     func record(_ request: IPv6LoaderTestRequest) {
@@ -4107,7 +541,7 @@ private actor IPv6LoaderTestRecorder {
     }
 }
 
-private struct RecordingIPv6HTTPSConnector: IPv6HTTPSConnecting {
+struct RecordingIPv6HTTPSConnector: IPv6HTTPSConnecting {
     let succeeds: Bool
     let recorder: IPv6LoaderTestRecorder
 
@@ -4127,7 +561,7 @@ private struct RecordingIPv6HTTPSConnector: IPv6HTTPSConnecting {
     }
 }
 
-private struct StubIPv6HTTPSConnector: IPv6HTTPSConnecting {
+struct StubIPv6HTTPSConnector: IPv6HTTPSConnecting {
     let succeeds: Bool
 
     func load(
@@ -4140,7 +574,7 @@ private struct StubIPv6HTTPSConnector: IPv6HTTPSConnecting {
     }
 }
 
-private actor SequencedIPv6HTTPSConnector: IPv6HTTPSConnecting {
+actor SequencedIPv6HTTPSConnector: IPv6HTTPSConnecting {
     let successfulAddress: String
     private(set) var addresses: [String] = []
     private(set) var timeouts: [Duration] = []
@@ -4161,7 +595,7 @@ private actor SequencedIPv6HTTPSConnector: IPv6HTTPSConnecting {
     }
 }
 
-private actor ControlEndpointTestRecorder {
+actor ControlEndpointTestRecorder {
     private(set) var urls: [String] = []
     private(set) var timeouts: [Duration] = []
 
@@ -4171,7 +605,7 @@ private actor ControlEndpointTestRecorder {
     }
 }
 
-private struct StubProxyConfigurationResolver: ProxyConfigurationResolving {
+struct StubProxyConfigurationResolver: ProxyConfigurationResolving {
     let storedResolutions: [ProxyResolutionDirective]
 
     init(_ resolution: ProxyResolutionDirective) {
@@ -4187,13 +621,13 @@ private struct StubProxyConfigurationResolver: ProxyConfigurationResolving {
     }
 }
 
-private struct PACResolutionTestRequest: Equatable, Sendable {
+struct PACResolutionTestRequest: Equatable, Sendable {
     let pacURL: URL
     let targetURL: URL
     let timeout: Duration
 }
 
-private actor PACResolutionTestRecorder {
+actor PACResolutionTestRecorder {
     private(set) var requests: [PACResolutionTestRequest] = []
 
     func record(pacURL: URL, targetURL: URL, timeout: Duration) {
@@ -4201,14 +635,14 @@ private actor PACResolutionTestRecorder {
     }
 }
 
-private struct PACCallbackTestRequest: Equatable, Sendable {
+struct PACCallbackTestRequest: Equatable, Sendable {
     let source: PACSource
     let targetURL: URL
 }
 
-private final class ControlledPACCallbackExecution: PACCallbackExecution, @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
+final class ControlledPACCallbackExecution: PACCallbackExecution, @unchecked Sendable {
+    let lock = NSLock()
+    var cancelled = false
 
     var isCancelled: Bool {
         lock.withLock { cancelled }
@@ -4219,12 +653,12 @@ private final class ControlledPACCallbackExecution: PACCallbackExecution, @unche
     }
 }
 
-private final class ControlledPACCallbackExecutor: PACCallbackExecuting, @unchecked Sendable {
-    private let lock = NSLock()
-    private let requestStream: AsyncStream<PACCallbackTestRequest>
-    private let requestContinuation: AsyncStream<PACCallbackTestRequest>.Continuation
-    private var callback: (@Sendable (PACCallbackOutcome) -> Void)?
-    private var execution: ControlledPACCallbackExecution?
+final class ControlledPACCallbackExecutor: PACCallbackExecuting, @unchecked Sendable {
+    let lock = NSLock()
+    let requestStream: AsyncStream<PACCallbackTestRequest>
+    let requestContinuation: AsyncStream<PACCallbackTestRequest>.Continuation
+    var callback: (@Sendable (PACCallbackOutcome) -> Void)?
+    var execution: ControlledPACCallbackExecution?
 
     init() {
         let pair = AsyncStream<PACCallbackTestRequest>.makeStream()
@@ -4267,7 +701,7 @@ private final class ControlledPACCallbackExecutor: PACCallbackExecuting, @unchec
     }
 }
 
-private struct StubPACResolver: PACResolving {
+struct StubPACResolver: PACResolving {
     let resolution: ProxyCandidateResolution
     let recorder: PACResolutionTestRecorder?
 
@@ -4296,9 +730,9 @@ private struct StubPACResolver: PACResolving {
     }
 }
 
-private actor CancellationIgnoringPACResolver: PACResolving {
-    private var invocationWaiters: [CheckedContinuation<Void, Never>] = []
-    private var hasInvoked = false
+actor CancellationIgnoringPACResolver: PACResolving {
+    var invocationWaiters: [CheckedContinuation<Void, Never>] = []
+    var hasInvoked = false
 
     func resolve(
         pacURL: URL,
@@ -4318,7 +752,7 @@ private actor CancellationIgnoringPACResolver: PACResolving {
     }
 }
 
-private struct StubProxyResolver: ProxyResolving {
+struct StubProxyResolver: ProxyResolving {
     let resolution: ProxyCandidateResolution
 
     init(_ resolution: EffectiveProxy) {
@@ -4339,7 +773,7 @@ private struct StubProxyResolver: ProxyResolving {
     }
 }
 
-private struct StubProxyTunnelStateReader: ProxyTunnelStateReading {
+struct StubProxyTunnelStateReader: ProxyTunnelStateReading {
     let state: ProxyTunnelState?
 
     init(
@@ -4356,10 +790,10 @@ private struct StubProxyTunnelStateReader: ProxyTunnelStateReading {
     }
 }
 
-private final class TunnelTimeoutCancellationProbe: @unchecked Sendable {
-    private let lock = NSLock()
-    private var parkedContinuation: CheckedContinuation<Void, Never>?
-    private var cancelled = false
+final class TunnelTimeoutCancellationProbe: @unchecked Sendable {
+    let lock = NSLock()
+    var parkedContinuation: CheckedContinuation<Void, Never>?
+    var cancelled = false
 
     var didCancel: Bool {
         lock.lock()
@@ -4389,9 +823,9 @@ private final class TunnelTimeoutCancellationProbe: @unchecked Sendable {
     }
 }
 
-private final class LockedFlag: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value = false
+final class LockedFlag: @unchecked Sendable {
+    let lock = NSLock()
+    var value = false
 
     var isSet: Bool {
         lock.lock()
@@ -4406,7 +840,7 @@ private final class LockedFlag: @unchecked Sendable {
     }
 }
 
-private actor ProxyResolutionTestRecorder {
+actor ProxyResolutionTestRecorder {
     private(set) var urls: [String] = []
 
     func record(_ url: URL) {
@@ -4414,7 +848,7 @@ private actor ProxyResolutionTestRecorder {
     }
 }
 
-private struct RecordingProxyResolver: ProxyResolving {
+struct RecordingProxyResolver: ProxyResolving {
     let resolutions: [URL: ProxyCandidateResolution]
     let defaultResolution: ProxyCandidateResolution?
     let recorder: ProxyResolutionTestRecorder?
@@ -4445,9 +879,9 @@ private struct RecordingProxyResolver: ProxyResolving {
     }
 }
 
-private actor CancellationIgnoringProxyResolver: ProxyResolving {
+actor CancellationIgnoringProxyResolver: ProxyResolving {
     private(set) var urls: [String] = []
-    private var invocationWaiters: [CheckedContinuation<Void, Never>] = []
+    var invocationWaiters: [CheckedContinuation<Void, Never>] = []
 
     func resolve(for url: URL) async -> ProxyCandidateResolution {
         urls.append(url.absoluteString)
@@ -4465,7 +899,7 @@ private actor CancellationIgnoringProxyResolver: ProxyResolving {
     }
 }
 
-private func proxyDictionary(
+func proxyDictionary(
     type: CFString,
     host: String? = nil,
     port: Int? = nil
@@ -4477,12 +911,12 @@ private func proxyDictionary(
     return dictionary
 }
 
-private struct ProxyEgressTestRequest: Equatable, Sendable {
+struct ProxyEgressTestRequest: Equatable, Sendable {
     let url: URL
     let proxy: EffectiveProxy
 }
 
-private actor ProxyEgressTestRecorder {
+actor ProxyEgressTestRecorder {
     private(set) var requests: [ProxyEgressTestRequest] = []
 
     func record(url: URL, proxy: EffectiveProxy) {
@@ -4490,7 +924,7 @@ private actor ProxyEgressTestRecorder {
     }
 }
 
-private struct StubProxyEgressLoader: ProxyEgressLoading {
+struct StubProxyEgressLoader: ProxyEgressLoading {
     let statusCode: Int?
     let errorCode: String?
     let recorder: ProxyEgressTestRecorder?
@@ -4515,11 +949,11 @@ private struct StubProxyEgressLoader: ProxyEgressLoading {
     }
 }
 
-private actor SequencedProxyEgressLoader: ProxyEgressLoading {
+actor SequencedProxyEgressLoader: ProxyEgressLoading {
     let responses: [ProxyEgressResponse]
     let delays: [Duration]
     private(set) var timeouts: [Duration] = []
-    private var invocationCount = 0
+    var invocationCount = 0
 
     init(responses: [ProxyEgressResponse], delays: [Duration]) {
         self.responses = responses
@@ -4544,10 +978,10 @@ private actor SequencedProxyEgressLoader: ProxyEgressLoading {
     }
 }
 
-private final class SequencedProxyCheckClock: ProxyCheckClock, @unchecked Sendable {
-    private let lock = NSLock()
-    private let instants: [ContinuousClock.Instant]
-    private var index = 0
+final class SequencedProxyCheckClock: ProxyCheckClock, @unchecked Sendable {
+    let lock = NSLock()
+    let instants: [ContinuousClock.Instant]
+    var index = 0
 
     init(offsets: [Duration]) {
         let origin = ContinuousClock().now
@@ -4563,8 +997,8 @@ private final class SequencedProxyCheckClock: ProxyCheckClock, @unchecked Sendab
     }
 }
 
-private actor CancellationIgnoringProxyEgressLoader: ProxyEgressLoading {
-    private var invocationWaiters: [CheckedContinuation<Void, Never>] = []
+actor CancellationIgnoringProxyEgressLoader: ProxyEgressLoading {
+    var invocationWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var invocationCount = 0
 
     func load(
@@ -4587,7 +1021,7 @@ private actor CancellationIgnoringProxyEgressLoader: ProxyEgressLoading {
     }
 }
 
-private struct StubProxyConnector: ProxyEndpointConnecting {
+struct StubProxyConnector: ProxyEndpointConnecting {
     let reachable: Bool
 
     func canConnect(to endpoint: ProxyEndpoint, timeout: Duration) async -> Bool {
@@ -4595,7 +1029,7 @@ private struct StubProxyConnector: ProxyEndpointConnecting {
     }
 }
 
-private struct EndpointSelectiveProxyConnector: ProxyEndpointConnecting {
+struct EndpointSelectiveProxyConnector: ProxyEndpointConnecting {
     let reachableHosts: Set<String>
 
     func canConnect(to endpoint: ProxyEndpoint, timeout: Duration) async -> Bool {
@@ -4603,7 +1037,7 @@ private struct EndpointSelectiveProxyConnector: ProxyEndpointConnecting {
     }
 }
 
-private actor ProxyConnectorTestRecorder {
+actor ProxyConnectorTestRecorder {
     private(set) var endpoints: [ProxyEndpoint] = []
 
     func record(_ endpoint: ProxyEndpoint) {
@@ -4611,11 +1045,11 @@ private actor ProxyConnectorTestRecorder {
     }
 }
 
-private actor SequencedProxyConnector: ProxyEndpointConnecting {
+actor SequencedProxyConnector: ProxyEndpointConnecting {
     let outcomes: [Bool]
     private(set) var endpoints: [ProxyEndpoint] = []
     private(set) var timeouts: [Duration] = []
-    private var invocationCount = 0
+    var invocationCount = 0
 
     init(outcomes: [Bool]) {
         self.outcomes = outcomes
@@ -4630,8 +1064,8 @@ private actor SequencedProxyConnector: ProxyEndpointConnecting {
     }
 }
 
-private actor CancellationIgnoringProxyConnector: ProxyEndpointConnecting {
-    private var invocationWaiters: [CheckedContinuation<Void, Never>] = []
+actor CancellationIgnoringProxyConnector: ProxyEndpointConnecting {
+    var invocationWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var endpoints: [ProxyEndpoint] = []
 
     func canConnect(to endpoint: ProxyEndpoint, timeout: Duration) async -> Bool {
@@ -4650,7 +1084,7 @@ private actor CancellationIgnoringProxyConnector: ProxyEndpointConnecting {
     }
 }
 
-private struct RecordingProxyConnector: ProxyEndpointConnecting {
+struct RecordingProxyConnector: ProxyEndpointConnecting {
     let reachable: Bool
     let recorder: ProxyConnectorTestRecorder
 
@@ -4660,7 +1094,7 @@ private struct RecordingProxyConnector: ProxyEndpointConnecting {
     }
 }
 
-private actor DiagnosticTestRecorder {
+actor DiagnosticTestRecorder {
     private(set) var values: [NetworkDiagnosticCheckID] = []
 
     func record(_ value: NetworkDiagnosticCheckID) {
@@ -4672,17 +1106,17 @@ private actor DiagnosticTestRecorder {
 /// sink. Keeps diagnostics view-model tests hermetic (no real UserDefaults,
 /// no Launch Services queries).
 @MainActor
-private final class IsolatedGuidance {
+final class IsolatedGuidance {
     let store: InMemoryGuidanceStateStore
     let coordinator: GuidanceCoordinator
-    private let eventBox: EventBox
+    let eventBox: DiagnosticGuidanceEventBox
 
     var events: [GuidanceEvent] { eventBox.events }
 
     init(completionCount: Int = 0) {
         let calendar = Self.makeCalendar()
         let now = calendar.date(from: DateComponents(year: 2026, month: 8, day: 5, hour: 12))!
-        let box = EventBox()
+        let box = DiagnosticGuidanceEventBox()
         store = InMemoryGuidanceStateStore(initial: GuidanceState(
             activeDays: ["2026-07-01", "2026-07-02"],
             meaningfulCompletionCount: completionCount
@@ -4711,11 +1145,11 @@ private final class IsolatedGuidance {
 }
 
 @MainActor
-private final class EventBox {
+final class DiagnosticGuidanceEventBox {
     var events: [GuidanceEvent] = []
 }
 
-private struct StubDiagnosticCheck: DiagnosticCheck {
+struct StubDiagnosticCheck: DiagnosticCheck {
     let id: NetworkDiagnosticCheckID
     let result: NetworkDiagnosticResult
     let recorder: DiagnosticTestRecorder
@@ -4726,10 +1160,10 @@ private struct StubDiagnosticCheck: DiagnosticCheck {
     }
 }
 
-private actor RestartableDiagnosticProbe {
-    private let blockFirstInvocation: Bool
-    private var firstInvocationContinuation: CheckedContinuation<Void, Never>?
-    private var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+actor RestartableDiagnosticProbe {
+    let blockFirstInvocation: Bool
+    var firstInvocationContinuation: CheckedContinuation<Void, Never>?
+    var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private(set) var invocationCount = 0
 
     init(blockFirstInvocation: Bool = false) {
@@ -4768,7 +1202,7 @@ private actor RestartableDiagnosticProbe {
     }
 }
 
-private struct ProbeDiagnosticCheck: DiagnosticCheck {
+struct ProbeDiagnosticCheck: DiagnosticCheck {
     let id: NetworkDiagnosticCheckID
     let result: NetworkDiagnosticResult
     let rerunPolicy: DiagnosticCheckRerunPolicy
@@ -4780,9 +1214,9 @@ private struct ProbeDiagnosticCheck: DiagnosticCheck {
     }
 }
 
-private actor BlockingDiagnosticProbe {
-    private var continuations: [Int: CheckedContinuation<Void, Never>] = [:]
-    private var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+actor BlockingDiagnosticProbe {
+    var continuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private(set) var invocationCount = 0
 
     func run() async {
@@ -4811,7 +1245,7 @@ private actor BlockingDiagnosticProbe {
     }
 }
 
-private struct BlockingProbeDiagnosticCheck: DiagnosticCheck {
+struct BlockingProbeDiagnosticCheck: DiagnosticCheck {
     let id: NetworkDiagnosticCheckID
     let probe: BlockingDiagnosticProbe
 
@@ -4821,9 +1255,9 @@ private struct BlockingProbeDiagnosticCheck: DiagnosticCheck {
     }
 }
 
-private actor CancellationIgnoringDiagnosticProbe {
-    private var continuations: [Int: CheckedContinuation<Void, Never>] = [:]
-    private var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+actor CancellationIgnoringDiagnosticProbe {
+    var continuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    var invocationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private(set) var invocationCount = 0
 
     func run() async {
@@ -4850,7 +1284,7 @@ private actor CancellationIgnoringDiagnosticProbe {
     }
 }
 
-private struct CancellationIgnoringProbeDiagnosticCheck: DiagnosticCheck {
+struct CancellationIgnoringProbeDiagnosticCheck: DiagnosticCheck {
     let id: NetworkDiagnosticCheckID = .path
     let probe: CancellationIgnoringDiagnosticProbe
 
@@ -4860,11 +1294,11 @@ private struct CancellationIgnoringProbeDiagnosticCheck: DiagnosticCheck {
     }
 }
 
-private actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
+actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
     let initial: NetworkFingerprint
-    private var lastFingerprint: NetworkFingerprint
-    private var continuation: AsyncStream<NetworkFingerprint>.Continuation?
-    private var pending: [NetworkFingerprint] = []
+    var lastFingerprint: NetworkFingerprint
+    var continuation: AsyncStream<NetworkFingerprint>.Continuation?
+    var pending: [NetworkFingerprint] = []
 
     init(initial: NetworkFingerprint) {
         self.initial = initial
@@ -4887,7 +1321,7 @@ private actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring 
         continuation.yield(fingerprint)
     }
 
-    private func install(_ continuation: AsyncStream<NetworkFingerprint>.Continuation) {
+    func install(_ continuation: AsyncStream<NetworkFingerprint>.Continuation) {
         self.continuation = continuation
         for fingerprint in pending {
             continuation.yield(fingerprint)
@@ -4896,8 +1330,8 @@ private actor ControlledNetworkFingerprintMonitor: NetworkFingerprintMonitoring 
     }
 }
 
-private actor CancellationIgnoringNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
-    private var continuation: CheckedContinuation<NetworkFingerprintObservation?, Never>?
+actor CancellationIgnoringNetworkFingerprintMonitor: NetworkFingerprintMonitoring {
+    var continuation: CheckedContinuation<NetworkFingerprintObservation?, Never>?
 
     func observation() async -> NetworkFingerprintObservation? {
         await withCheckedContinuation { continuation in
@@ -4917,13 +1351,13 @@ private actor CancellationIgnoringNetworkFingerprintMonitor: NetworkFingerprintM
     }
 }
 
-private struct SilentNetworkPathFingerprintSource: NetworkPathFingerprintSourcing {
+struct SilentNetworkPathFingerprintSource: NetworkPathFingerprintSourcing {
     func pathFingerprintChanges() -> AsyncStream<NetworkPathFingerprint> {
         AsyncStream { $0.finish() }
     }
 }
 
-private struct FiniteNetworkPathFingerprintSource: NetworkPathFingerprintSourcing {
+struct FiniteNetworkPathFingerprintSource: NetworkPathFingerprintSourcing {
     let values: [NetworkPathFingerprint]
 
     func pathFingerprintChanges() -> AsyncStream<NetworkPathFingerprint> {
@@ -4934,10 +1368,10 @@ private struct FiniteNetworkPathFingerprintSource: NetworkPathFingerprintSourcin
     }
 }
 
-private final class BufferedGapNetworkPathFingerprintSource: NetworkPathFingerprintSourcing, @unchecked Sendable {
-    private let lock = NSLock()
-    private let values: [NetworkPathFingerprint]
-    private var requestCount = 0
+final class BufferedGapNetworkPathFingerprintSource: NetworkPathFingerprintSourcing, @unchecked Sendable {
+    let lock = NSLock()
+    let values: [NetworkPathFingerprint]
+    var requestCount = 0
 
     init(values: [NetworkPathFingerprint]) {
         self.values = values
@@ -4956,7 +1390,7 @@ private final class BufferedGapNetworkPathFingerprintSource: NetworkPathFingerpr
     }
 }
 
-private struct ImmediateNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
+struct ImmediateNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
     func ticks(every interval: Duration) -> AsyncStream<Void> {
         AsyncStream { continuation in
             continuation.yield(())
@@ -4965,7 +1399,7 @@ private struct ImmediateNetworkFingerprintSettingsPoller: NetworkFingerprintSett
     }
 }
 
-private struct FixedCountNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
+struct FixedCountNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
     let count: Int
 
     func ticks(every interval: Duration) -> AsyncStream<Void> {
@@ -4978,16 +1412,16 @@ private struct FixedCountNetworkFingerprintSettingsPoller: NetworkFingerprintSet
     }
 }
 
-private struct SilentNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
+struct SilentNetworkFingerprintSettingsPoller: NetworkFingerprintSettingsPolling {
     func ticks(every interval: Duration) -> AsyncStream<Void> {
         AsyncStream { $0.finish() }
     }
 }
 
-private final class MutableFingerprintSettingsReader: NetworkFingerprintSettingsReading, @unchecked Sendable {
-    private let lock = NSLock()
-    private var dnsHash: UInt64
-    private let proxyHash: UInt64
+final class MutableFingerprintSettingsReader: NetworkFingerprintSettingsReading, @unchecked Sendable {
+    let lock = NSLock()
+    var dnsHash: UInt64
+    let proxyHash: UInt64
 
     init(dnsHash: UInt64, proxyHash: UInt64) {
         self.dnsHash = dnsHash
@@ -5007,9 +1441,9 @@ private final class MutableFingerprintSettingsReader: NetworkFingerprintSettings
     }
 }
 
-private actor SequencedFingerprintRouteStateSource: NetworkFingerprintRouteStateSourcing {
-    private let values: [NetworkFingerprintRouteState]
-    private var index = 0
+actor SequencedFingerprintRouteStateSource: NetworkFingerprintRouteStateSourcing {
+    let values: [NetworkFingerprintRouteState]
+    var index = 0
 
     init(values: [NetworkFingerprintRouteState]) {
         precondition(!values.isEmpty)
@@ -5022,11 +1456,11 @@ private actor SequencedFingerprintRouteStateSource: NetworkFingerprintRouteState
     }
 }
 
-private final class SequencedFingerprintSettingsReader: NetworkFingerprintSettingsReading, @unchecked Sendable {
-    private let lock = NSLock()
-    private let dnsHashes: [UInt64]
-    private let proxyHash: UInt64
-    private var dnsIndex = 0
+final class SequencedFingerprintSettingsReader: NetworkFingerprintSettingsReading, @unchecked Sendable {
+    let lock = NSLock()
+    let dnsHashes: [UInt64]
+    let proxyHash: UInt64
+    var dnsIndex = 0
 
     init(dnsHashes: [UInt64], proxyHash: UInt64) {
         self.dnsHashes = dnsHashes
@@ -5047,7 +1481,7 @@ private final class SequencedFingerprintSettingsReader: NetworkFingerprintSettin
     }
 }
 
-private struct StubNetworkInterfaceSource: NetworkInterfaceInfoSourcing {
+struct StubNetworkInterfaceSource: NetworkInterfaceInfoSourcing {
     let interface: NetworkInterfaceInfo?
 
     func currentInterface() async -> NetworkInterfaceInfo? {
@@ -5055,7 +1489,7 @@ private struct StubNetworkInterfaceSource: NetworkInterfaceInfoSourcing {
     }
 }
 
-private actor RecordingGatewayPingProcessRunner: GatewayPingProcessRunning {
+actor RecordingGatewayPingProcessRunner: GatewayPingProcessRunning {
     let latency: Double?
     private(set) var executablePath: String?
     private(set) var arguments: [String] = []
@@ -5073,7 +1507,7 @@ private actor RecordingGatewayPingProcessRunner: GatewayPingProcessRunning {
     func cancel() async {}
 }
 
-private actor RecordingDiagnosticGatewayMeasurer: DiagnosticGatewayMeasuring {
+actor RecordingDiagnosticGatewayMeasurer: DiagnosticGatewayMeasuring {
     private(set) var targets: [DiagnosticGatewayTarget] = []
 
     func measure(target: DiagnosticGatewayTarget) async -> GatewayLatencyResult {
@@ -5086,9 +1520,9 @@ private actor RecordingDiagnosticGatewayMeasurer: DiagnosticGatewayMeasuring {
     }
 }
 
-private actor SequencedDiagnosticRouteSource: DiagnosticRouteSourcing {
-    private let values: [DiagnosticRouteSelection]
-    private var index = 0
+actor SequencedDiagnosticRouteSource: DiagnosticRouteSourcing {
+    let values: [DiagnosticRouteSelection]
+    var index = 0
     private(set) var invocationCount = 0
 
     init(values: [DiagnosticRouteSelection]) {
@@ -5103,7 +1537,7 @@ private actor SequencedDiagnosticRouteSource: DiagnosticRouteSourcing {
     }
 }
 
-private struct StubNetworkInterfaceSnapshotSource: NetworkInterfaceSnapshotSourcing {
+struct StubNetworkInterfaceSnapshotSource: NetworkInterfaceSnapshotSourcing {
     let interfaces: [NetworkInterfaceInfo]
 
     func capture(cycleID: UUID) async -> NetworkInterfaceSnapshot {
@@ -5115,7 +1549,7 @@ private struct StubNetworkInterfaceSnapshotSource: NetworkInterfaceSnapshotSourc
     }
 }
 
-private struct StubGatewayLatencyProvider: GatewayLatencyProviding {
+struct StubGatewayLatencyProvider: GatewayLatencyProviding {
     let result: GatewayLatencyResult
 
     func measure(routerIP: String?) async -> GatewayLatencyResult {
@@ -5123,7 +1557,7 @@ private struct StubGatewayLatencyProvider: GatewayLatencyProviding {
     }
 }
 
-private func makeNetworkInterface(name: String = "en0", router: String?) -> NetworkInterfaceInfo {
+func makeNetworkInterface(name: String = "en0", router: String?) -> NetworkInterfaceInfo {
     NetworkInterfaceInfo(
         interfaceName: name,
         hardwareMAC: "00:11:22:33:44:55",
@@ -5142,7 +1576,7 @@ private func makeNetworkInterface(name: String = "en0", router: String?) -> Netw
     )
 }
 
-private func makeDiagnosticContext(
+func makeDiagnosticContext(
     pathState: NetworkPathState?,
     route: DiagnosticRouteSelection,
     interfaces: [NetworkInterfaceInfo] = []

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -2397,8 +2397,8 @@ struct NetworkDiagnosticsTests {
         _ = await run.value
     }
 
-    @Test("a later same-interface path update is still a network change")
-    func sameInterfacePathUpdateIsDetected() async throws {
+    @Test("a duplicate path update is ignored")
+    func duplicatePathUpdateIsIgnored() async throws {
         let baseline = makeFingerprint(interfaceName: "en0", dnsHash: 1)
         let path = NetworkPathFingerprint(
             interfaceType: baseline.interfaceType,
@@ -2419,7 +2419,7 @@ struct NetworkDiagnosticsTests {
         }
 
         #expect(observation.baseline == baseline)
-        #expect(changes == [baseline])
+        #expect(changes.isEmpty)
     }
 
     @Test("baseline and an immediate path change share one buffered observation source")

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsTests.swift
@@ -1507,6 +1507,42 @@ actor RecordingGatewayPingProcessRunner: GatewayPingProcessRunning {
     func cancel() async {}
 }
 
+actor ControlledGatewayPingProcessRunner: GatewayPingProcessRunning {
+    private var activeContinuations: [Int: CheckedContinuation<Double?, Never>] = [:]
+    private var invocationWaiters: [(target: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private(set) var invocationCount = 0
+    private(set) var cancelledInvocationIDs: [Int] = []
+
+    func run(executablePath: String, arguments: [String]) async -> Double? {
+        invocationCount += 1
+        let invocationID = invocationCount
+        resumeInvocationWaiters()
+        return await withCheckedContinuation { continuation in
+            activeContinuations[invocationID] = continuation
+        }
+    }
+
+    func cancel() {
+        guard let invocationID = activeContinuations.keys.max(),
+              let continuation = activeContinuations.removeValue(forKey: invocationID) else {
+            return
+        }
+        cancelledInvocationIDs.append(invocationID)
+        continuation.resume(returning: nil)
+    }
+
+    func waitUntilInvocationCount(_ target: Int) async {
+        if invocationCount >= target { return }
+        await withCheckedContinuation { invocationWaiters.append((target, $0)) }
+    }
+
+    private func resumeInvocationWaiters() {
+        let ready = invocationWaiters.filter { invocationCount >= $0.target }
+        invocationWaiters.removeAll { invocationCount >= $0.target }
+        ready.forEach { $0.continuation.resume() }
+    }
+}
+
 actor RecordingDiagnosticGatewayMeasurer: DiagnosticGatewayMeasuring {
     private(set) var targets: [DiagnosticGatewayTarget] = []
 

--- a/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsViewModelTests.swift
+++ b/WiFiLens/Tests/WiFiLensTests/NetworkDiagnostics/NetworkDiagnosticsViewModelTests.swift
@@ -1,0 +1,713 @@
+import CFNetwork
+import Foundation
+import Network
+import Testing
+@testable import WiFi_Lens
+
+extension NetworkDiagnosticsTests {
+    @Test("view model starts idle and only runs after start")
+    @MainActor
+    func viewModelManualStart() async {
+        let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: recorder),
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.phase == .idle)
+        #expect(viewModel.conclusion == nil)
+        #expect(await recorder.values.isEmpty)
+
+        #expect(viewModel.start())
+        #expect(!viewModel.start())
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.conclusion == .networkNormal)
+        #expect(viewModel.results.count == 3)
+        #expect(viewModel.executionPhases.values.allSatisfy { $0 == .completed })
+    }
+
+    @Test("fingerprint observation timeout does not wait for a cancellation-ignoring monitor")
+    @MainActor
+    func fingerprintObservationTimeoutIsBounded() async {
+        let monitor = CancellationIgnoringNetworkFingerprintMonitor()
+        let clock = ManualDiagnosticClock()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [],
+            fingerprintMonitor: monitor,
+            clock: clock
+        )
+
+        #expect(viewModel.start())
+        await monitor.waitForInvocation()
+        await clock.set(clock.origin.advanced(by: .seconds(1)))
+
+        for _ in 0..<100 {
+            if !viewModel.fingerprintMonitoringAvailable { break }
+            await Task.yield()
+        }
+
+        #expect(!viewModel.fingerprintMonitoringAvailable)
+        await monitor.release()
+        await viewModel.waitForCompletion()
+    }
+
+    @Test("diagnostics log store keeps a bounded history and truncation marker")
+    func diagnosticsLogStoreHasFiniteCapacity() {
+        var store = NetworkDiagnosticsLogStore()
+
+        for index in 0..<501 {
+            store.append("event \(index)")
+        }
+
+        #expect(store.lines.count == NetworkDiagnosticsLogStore.capacity)
+        #expect(store.lines.contains(NetworkDiagnosticsLogStore.truncationMarker))
+        #expect(!store.text.contains("event 0\n"))
+        #expect(store.text.contains("event 500"))
+
+        var typedStore = NetworkDiagnosticsLogStore()
+        for index in 0..<501 {
+            typedStore.append(NetworkDiagnosticEvent(
+                runID: UUID(),
+                elapsedMilliseconds: Int64(index),
+                kind: .checkFinished,
+                checkID: .path,
+                reasonCode: nil
+            ))
+        }
+        #expect(typedStore.lines.count == NetworkDiagnosticsLogStore.capacity)
+        #expect(typedStore.events.count == NetworkDiagnosticsLogStore.capacity - 1)
+    }
+
+    @Test("typed diagnostic events only format allowlisted restart reasons")
+    func diagnosticEventFormattingAllowlist() {
+        let event = NetworkDiagnosticEvent(
+            runID: UUID(),
+            elapsedMilliseconds: 42,
+            kind: .restarted,
+            checkID: nil,
+            reasonCode: "raw-sensitive-value"
+        )
+
+        #expect(event.formatted() == "42ms · Network changed; restarting (network state)")
+        #expect(!event.formatted().contains("raw-sensitive-value"))
+    }
+
+    @Test("view model publishes its own diagnostic result logs")
+    @MainActor
+    func viewModelPublishesDiagnosticLogs() async {
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: DiagnosticTestRecorder()),
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+        )
+
+        #expect(viewModel.logText.isEmpty)
+        #expect(viewModel.start())
+        await viewModel.waitForCompletion()
+
+        let stableLogLines = viewModel.logStore.lines.map { line in
+            guard let separator = line.range(of: " · ") else { return line }
+            return String(line[separator.upperBound...])
+        }
+        #expect(stableLogLines == [
+            "Session started",
+            "Run started",
+            "Checking Network Path…",
+            "Network Path finished",
+            "Checking DNS Resolution…",
+            "DNS Resolution finished",
+            "Checking System Proxy…",
+            "System Proxy finished",
+            "Check completed",
+        ])
+        #expect(viewModel.logStore.events.map(\.kind) == [
+            .sessionStarted,
+            .runStarted,
+            .checkStarted,
+            .checkFinished,
+            .checkStarted,
+            .checkFinished,
+            .checkStarted,
+            .checkFinished,
+            .completed,
+        ])
+
+        viewModel.clearLogs()
+        #expect(viewModel.logText.isEmpty)
+    }
+
+    @Test("view model clears the previous conclusion before a rerun")
+    @MainActor
+    func viewModelRerun() async {
+        let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: recorder),
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await viewModel.waitForCompletion()
+        #expect(viewModel.conclusion == .networkNormal)
+
+        #expect(viewModel.start())
+        #expect(viewModel.conclusion == nil)
+        await viewModel.waitForCompletion()
+        #expect(await recorder.values.count == 6)
+    }
+
+    @Test("a changed fingerprint restarts network probes once and retains configuration results")
+    @MainActor
+    func fingerprintChangeRestartsOnce() async {
+        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
+        let guidance = IsolatedGuidance()
+        let configurationProbe = RestartableDiagnosticProbe()
+        let networkProbe = RestartableDiagnosticProbe(blockFirstInvocation: true)
+        let checks: [any DiagnosticCheck] = [
+            ProbeDiagnosticCheck(
+                id: .proxy,
+                result: .init(id: .proxy, status: .normal, summary: "configuration"),
+                rerunPolicy: .configurationOnly,
+                probe: configurationProbe
+            ),
+            ProbeDiagnosticCheck(
+                id: .path,
+                result: .init(id: .path, status: .normal, summary: "network"),
+                rerunPolicy: .networkSensitive,
+                probe: networkProbe
+            ),
+        ]
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: checks,
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await networkProbe.waitForInvocationCount(1)
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 2))
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en2", dnsHash: 3))
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.conclusion == .networkNormal)
+        #expect(viewModel.automaticRestartCount == 1)
+        #expect(await configurationProbe.invocationCount == 1)
+        #expect(await networkProbe.invocationCount == 2)
+        #expect(viewModel.results[.proxy]?.summary == "configuration")
+        #expect(viewModel.results[.path]?.summary == "network")
+    }
+
+    @Test("an unchanged fingerprint does not restart an active probe")
+    @MainActor
+    func unchangedFingerprintDoesNotRestart() async {
+        let fingerprint = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: fingerprint)
+        let guidance = IsolatedGuidance()
+        let probe = RestartableDiagnosticProbe(blockFirstInvocation: true)
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [
+                ProbeDiagnosticCheck(
+                    id: .path,
+                    result: .init(id: .path, status: .normal, summary: "network"),
+                    rerunPolicy: .networkSensitive,
+                    probe: probe
+                ),
+            ],
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        await fingerprintMonitor.send(fingerprint)
+        await probe.releaseFirstInvocation()
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.automaticRestartCount == 0)
+        #expect(await probe.invocationCount == 1)
+    }
+
+    @Test("a second network change during the rerun starts a fresh run")
+    @MainActor
+    func repeatedFingerprintChangesRestartAgain() async {
+        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
+        let probe = BlockingDiagnosticProbe()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
+            fingerprintMonitor: fingerprintMonitor,
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 2))
+        await probe.waitForInvocationCount(2)
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en2", dnsHash: 3))
+        await probe.waitForInvocationCount(3)
+        await probe.release(invocation: 3)
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.automaticRestartCount == 2)
+        #expect(await probe.invocationCount == 3)
+    }
+
+    @Test("stability window starts from the latest network change")
+    func stabilityWindowUsesLatestChange() async {
+        let controller = NetworkDiagnosticRestartController()
+        let clock = ManualDiagnosticClock()
+        let base = clock.origin
+        let first = makeFingerprint(interfaceName: "en1", dnsHash: 2)
+        let second = makeFingerprint(interfaceName: "en2", dnsHash: 3)
+        let completion = OptionalBoolRecorder()
+
+        #expect(await controller.observe(first, at: base))
+        let waitTask = Task {
+            let result = await controller.waitForStability(
+                using: clock,
+                until: base.advanced(by: .seconds(2))
+            )
+            await completion.record(result)
+            return result
+        }
+
+        await clock.waitForSleeperCount(1)
+        await clock.set(base.advanced(by: .milliseconds(400)))
+        #expect(await controller.observe(
+            second,
+            at: base.advanced(by: .milliseconds(400))
+        ))
+
+        await clock.waitForSleeperCount(1)
+        await clock.set(base.advanced(by: .milliseconds(800)))
+        await Task.yield()
+        #expect(await completion.value == nil)
+
+        await clock.set(base.advanced(by: .milliseconds(900)))
+        #expect(await waitTask.value)
+        #expect(await completion.value == true)
+    }
+
+    @Test("explicit cancellation is latched before a run is installed")
+    func restartControllerLatchesCancellationBeforeInstall() async {
+        let controller = NetworkDiagnosticRestartController()
+        let run = Task<[NetworkDiagnosticResult], Never> {
+            try? await Task.sleep(for: .seconds(30))
+            return []
+        }
+
+        await controller.cancelCurrentRun()
+        await controller.install(run)
+
+        #expect(run.isCancelled)
+        run.cancel()
+        _ = await run.value
+    }
+
+    @Test("a duplicate path update is ignored")
+    func duplicatePathUpdateIsIgnored() async throws {
+        let baseline = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let path = NetworkPathFingerprint(
+            interfaceType: baseline.interfaceType,
+            interfaceName: baseline.interfaceName,
+            pathStatus: baseline.pathStatus
+        )
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: FiniteNetworkPathFingerprintSource(values: [path, path]),
+            settingsPoller: SilentNetworkFingerprintSettingsPoller()
+        )
+
+        let optionalObservation = await monitor.observation()
+        let observation = try #require(optionalObservation)
+        var changes: [NetworkFingerprint] = []
+        for await fingerprint in observation.changes {
+            changes.append(fingerprint)
+        }
+
+        #expect(observation.baseline == baseline)
+        #expect(changes.isEmpty)
+    }
+
+    @Test("baseline and an immediate path change share one buffered observation source")
+    func fingerprintObservationDoesNotLoseBaselineGapChange() async throws {
+        let baselinePath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en0",
+            pathStatus: .satisfied
+        )
+        let changedPath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en1",
+            pathStatus: .satisfied
+        )
+        let pathSource = BufferedGapNetworkPathFingerprintSource(
+            values: [baselinePath, changedPath]
+        )
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: pathSource,
+            settingsPoller: SilentNetworkFingerprintSettingsPoller()
+        )
+
+        let optionalObservation = await monitor.observation()
+        let observation = try #require(optionalObservation)
+        var iterator = observation.changes.makeAsyncIterator()
+        let change = await iterator.next()
+
+        #expect(observation.baseline.interfaceName == "en0")
+        #expect(change?.interfaceName == "en1")
+        #expect(pathSource.streamRequestCount == 1)
+    }
+
+    @Test("explicit cancellation stops an active diagnostics session")
+    @MainActor
+    func viewModelCancellation() async {
+        let probe = BlockingDiagnosticProbe()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        viewModel.cancel()
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.conclusion == nil)
+        #expect(viewModel.endReason == .cancelled)
+    }
+
+    @Test("a cancelled run cannot overwrite a replacement run")
+    @MainActor
+    func cancelledRunCannotOverwriteReplacementRun() async {
+        let probe = CancellationIgnoringDiagnosticProbe()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [CancellationIgnoringProbeDiagnosticCheck(probe: probe)],
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor()
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        viewModel.cancel()
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(2)
+
+        await probe.release(invocation: 1)
+        try? await Task.sleep(for: .milliseconds(10))
+        #expect(viewModel.phase == .running)
+        #expect(viewModel.results.isEmpty)
+
+        await probe.release(invocation: 2)
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.endReason == .completed)
+        #expect(viewModel.results[.path]?.status == .normal)
+    }
+
+    @Test("unstable network changes do not restore invalidated results")
+    @MainActor
+    func unstableNetworkChangeDoesNotRestoreOldResults() async {
+        let initial = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let fingerprintMonitor = ControlledNetworkFingerprintMonitor(initial: initial)
+        let blockingProbe = BlockingDiagnosticProbe()
+        let clock = ManualDiagnosticClock()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [
+                StubDiagnosticCheck(
+                    id: .path,
+                    result: .init(id: .path, status: .normal, summary: "old path"),
+                    recorder: DiagnosticTestRecorder()
+                ),
+                BlockingProbeDiagnosticCheck(id: .dns, probe: blockingProbe),
+            ],
+            fingerprintMonitor: fingerprintMonitor,
+            clock: clock
+        )
+
+        #expect(viewModel.start())
+        await blockingProbe.waitForInvocationCount(1)
+        await clock.set(clock.origin.advanced(by: .milliseconds(29_800)))
+        await fingerprintMonitor.send(makeFingerprint(interfaceName: "en1", dnsHash: 1))
+        await clock.set(clock.origin.advanced(by: .milliseconds(30_100)))
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.endReason == .superseded)
+        #expect(viewModel.results.isEmpty)
+        #expect(viewModel.pendingCheckIDs == [.path, .dns])
+    }
+
+    @Test("a successful diagnostics run reports the completion moment exactly once")
+    @MainActor
+    func successfulRunReportsDiagnosticsMomentOnce() async {
+        let recorder = DiagnosticTestRecorder()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: makeStubChecks(recorder: recorder),
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        let loaded = guidance.store.load()
+        #expect(loaded.meaningfulCompletionCount == 1)
+        #expect(loaded.invitationPresentationCount == 0)
+        #expect(loaded.lastInvitationDate == nil)
+        #expect(guidance.events.filter { $0.name == "guidance.value_moment" }.count == 1)
+    }
+
+    @Test("a run that never reaches completion never reports the diagnostics moment")
+    @MainActor
+    func failingRunNeverReportsDiagnosticsMoment() async {
+        let probe = BlockingDiagnosticProbe()
+        let guidance = IsolatedGuidance()
+        let viewModel = NetworkDiagnosticsViewModel(
+            checks: [BlockingProbeDiagnosticCheck(id: .path, probe: probe)],
+            fingerprintMonitor: DisabledNetworkFingerprintMonitor(),
+            guidance: guidance.coordinator
+        )
+
+        #expect(viewModel.start())
+        await probe.waitForInvocationCount(1)
+        viewModel.cancel()
+        await viewModel.waitForCompletion()
+
+        #expect(viewModel.phase == .completed)
+        #expect(viewModel.conclusion == nil)
+        #expect(viewModel.endReason == .cancelled)
+        #expect(guidance.store.load().meaningfulCompletionCount == 0)
+        #expect(guidance.events.isEmpty)
+    }
+
+    @Test("system fingerprint monitor detects DNS settings changes without a path update")
+    func fingerprintDetectsSettingsOnlyChange() async throws {
+        let baseline = makeFingerprint(interfaceName: "en0", dnsHash: 1)
+        let path = NetworkPathFingerprint(
+            interfaceType: baseline.interfaceType,
+            interfaceName: baseline.interfaceName,
+            pathStatus: baseline.pathStatus
+        )
+        let settingsReader = SequencedFingerprintSettingsReader(dnsHashes: [1, 2], proxyHash: 7)
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: settingsReader,
+            pathSource: FiniteNetworkPathFingerprintSource(values: [path]),
+            settingsPoller: ImmediateNetworkFingerprintSettingsPoller(),
+            settingsPollInterval: .milliseconds(10)
+        )
+
+        let optionalObservation = await monitor.observation()
+        let observation = try #require(optionalObservation)
+        var iterator = observation.changes.makeAsyncIterator()
+        let changedFingerprint = await iterator.next()
+
+        #expect(observation.baseline == baseline)
+        #expect(changedFingerprint?.interfaceName == "en0")
+        #expect(changedFingerprint?.dnsSettingsHash == 2)
+        #expect(changedFingerprint?.staticProxySettingsHash == 7)
+    }
+
+    @Test("system fingerprint monitor detects route changes without DNS or proxy changes")
+    func fingerprintDetectsRouteOnlyChange() async throws {
+        let baselinePath = NetworkPathFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied
+        )
+        let routeSource = SequencedFingerprintRouteStateSource(values: [
+            NetworkFingerprintRouteState(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                gateway: "192.0.2.1",
+                addresses: ["192.0.2.10"],
+                subnets: ["255.255.255.0"]
+            ),
+            NetworkFingerprintRouteState(
+                interfaceName: "en7",
+                interfaceIndex: 12,
+                gateway: "192.0.2.254",
+                addresses: ["192.0.2.10"],
+                subnets: ["255.255.255.0"]
+            ),
+            NetworkFingerprintRouteState(
+                interfaceName: nil,
+                interfaceIndex: nil,
+                gateway: nil
+            ),
+        ])
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath]),
+            settingsPoller: FixedCountNetworkFingerprintSettingsPoller(count: 2),
+            routeStateSource: routeSource
+        )
+
+        let observation = try #require(await monitor.observation())
+        var iterator = observation.changes.makeAsyncIterator()
+        let change = await iterator.next()
+        let disappeared = await iterator.next()
+
+        #expect(observation.baseline.selectedGateway == "192.0.2.1")
+        #expect(change?.selectedGateway == "192.0.2.254")
+        #expect(disappeared?.selectedGateway == nil)
+        #expect(disappeared?.selectedInterfaceIndex == nil)
+        #expect(disappeared?.selectedInterfaceAddresses.isEmpty == true)
+    }
+
+    @Test("proxy fingerprint includes PAC and automatic discovery settings")
+    func proxyFingerprintIncludesAutomaticSettings() {
+        let baseline = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
+            "ProxyAutoConfigEnable": 0,
+            "ProxyAutoConfigURLString": "https://proxy.example/old.pac",
+            "ProxyAutoDiscoveryEnable": 0,
+        ])
+        let changedPAC = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
+            "ProxyAutoConfigEnable": 1,
+            "ProxyAutoConfigURLString": "https://proxy.example/new.pac",
+            "ProxyAutoDiscoveryEnable": 0,
+        ])
+        let changedDiscovery = SystemNetworkFingerprintSettingsReader.proxySettingsHash(for: [
+            "ProxyAutoConfigEnable": 0,
+            "ProxyAutoConfigURLString": "https://proxy.example/old.pac",
+            "ProxyAutoDiscoveryEnable": 1,
+        ])
+
+        #expect(changedPAC != baseline)
+        #expect(changedDiscovery != baseline)
+    }
+
+    @Test("VPN and TUN interface names are classified without VPN manager access")
+    func tunnelInterfaceClassification() {
+        let tunnels = NetworkTunnelInterfaceClassifier.tunnelInterfaces(from: [
+            "en0", "utun3", "ipsec0", "ppp0", "bridge0", "utun2"
+        ])
+
+        #expect(tunnels == ["ipsec0", "ppp0", "utun2", "utun3"])
+        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
+            activeInterfaceName: "utun3",
+            tunnelInterfaces: tunnels
+        ) == "utun3")
+        #expect(NetworkTunnelInterfaceClassifier.routedTunnelInterface(
+            activeInterfaceName: "en0",
+            tunnelInterfaces: tunnels
+        ) == nil)
+    }
+
+    @Test("tunnel presence and routed interface changes are fingerprint changes")
+    func tunnelFingerprintChangesTriggerObservation() async throws {
+        let baselinePath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en0",
+            pathStatus: .satisfied,
+            tunnelInterfaces: [],
+            routedTunnelInterface: nil
+        )
+        let changedPath = NetworkPathFingerprint(
+            interfaceType: "wifi",
+            interfaceName: "en0",
+            pathStatus: .satisfied,
+            tunnelInterfaces: ["utun3"],
+            routedTunnelInterface: "utun3"
+        )
+        let monitor = SystemNetworkFingerprintMonitor(
+            settingsReader: MutableFingerprintSettingsReader(dnsHash: 1, proxyHash: 7),
+            pathSource: FiniteNetworkPathFingerprintSource(values: [baselinePath, changedPath]),
+            settingsPoller: SilentNetworkFingerprintSettingsPoller()
+        )
+
+        let observation = try #require(await monitor.observation())
+        var iterator = observation.changes.makeAsyncIterator()
+        let change = await iterator.next()
+
+        #expect(observation.baseline.tunnelInterfaces.isEmpty)
+        #expect(change?.tunnelInterfaces == ["utun3"])
+        #expect(change?.routedTunnelInterface == "utun3")
+    }
+
+    @Test("gateway target identity includes interface index and address state")
+    func fingerprintIncludesRouteAndAddressIdentity() {
+        let first = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.1",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+        let changedAddress = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.11"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.1",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+        let changedRoute = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            selectedInterfaceIndex: 12,
+            selectedInterfaceAddresses: ["192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0"],
+            selectedGateway: "192.0.2.254",
+            ipv4PrimaryServiceIdentity: "service-a",
+            ipv6PrimaryServiceIdentity: "service-v6"
+        )
+
+        #expect(first != changedAddress)
+        #expect(first != changedRoute)
+    }
+
+    @Test("fingerprint comparison ignores address and tunnel collection order")
+    func fingerprintNormalizesUnorderedCollections() {
+        let first = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            tunnelInterfaces: ["utun3", "utun2"],
+            selectedInterfaceAddresses: ["192.0.2.11", "192.0.2.10"],
+            selectedInterfaceSubnets: ["255.255.255.0", "255.255.0.0"]
+        )
+        let reordered = NetworkFingerprint(
+            interfaceType: "ethernet",
+            interfaceName: "en7",
+            pathStatus: .satisfied,
+            dnsSettingsHash: 1,
+            staticProxySettingsHash: 7,
+            tunnelInterfaces: ["utun2", "utun3"],
+            selectedInterfaceAddresses: ["192.0.2.10", "192.0.2.11"],
+            selectedInterfaceSubnets: ["255.255.0.0", "255.255.255.0"]
+        )
+
+        #expect(first == reordered)
+        #expect(first.restartReason(comparedWith: reordered) == .path)
+    }
+}
+

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -477,6 +477,15 @@
 		MV0000000000000000000049 /* mac-vendor-database.json in Resources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000050 /* mac-vendor-database.json */; };
 		MV0000000000000000000051 /* mac-vendor-database.json in Resources */ = {isa = PBXBuildFile; fileRef = MV0000000000000000000050 /* mac-vendor-database.json */; };
 		ND0000000000000000000001 /* NetworkDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000002 /* NetworkDiagnosticsTests.swift */; };
+		ND0000000000000000000101 /* NetworkDiagnosticsConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000102 /* NetworkDiagnosticsConfigurationTests.swift */; };
+		ND0000000000000000000103 /* NetworkDiagnosticsRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000104 /* NetworkDiagnosticsRouteTests.swift */; };
+		ND0000000000000000000105 /* NetworkDiagnosticsRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000106 /* NetworkDiagnosticsRunnerTests.swift */; };
+		ND0000000000000000000107 /* NetworkDiagnosticsAssessmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000108 /* NetworkDiagnosticsAssessmentTests.swift */; };
+		ND0000000000000000000109 /* NetworkDiagnosticsPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND000000000000000000010A /* NetworkDiagnosticsPresentationTests.swift */; };
+		ND000000000000000000010B /* NetworkDiagnosticsControlEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND000000000000000000010C /* NetworkDiagnosticsControlEndpointTests.swift */; };
+		ND000000000000000000010D /* NetworkDiagnosticsDNSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND000000000000000000010E /* NetworkDiagnosticsDNSTests.swift */; };
+		ND000000000000000000010F /* NetworkDiagnosticsProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000110 /* NetworkDiagnosticsProxyTests.swift */; };
+		ND0000000000000000000111 /* NetworkDiagnosticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000112 /* NetworkDiagnosticsViewModelTests.swift */; };
 		ND0000000000000000000010 /* NetworkDiagnosticModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000020 /* NetworkDiagnosticModels.swift */; };
 		ND0000000000000000000011 /* DiagnosticRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000021 /* DiagnosticRunner.swift */; };
 		ND0000000000000000000012 /* NetworkDiagnosticModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000020 /* NetworkDiagnosticModels.swift */; };
@@ -925,6 +934,15 @@
 		MV0000000000000000000047 /* MACVendorBundledDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MACVendorBundledDatabase.swift; sourceTree = "<group>"; };
 		MV0000000000000000000050 /* mac-vendor-database.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mac-vendor-database.json"; sourceTree = "<group>"; };
 		ND0000000000000000000002 /* NetworkDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000102 /* NetworkDiagnosticsConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsConfigurationTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000104 /* NetworkDiagnosticsRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsRouteTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000106 /* NetworkDiagnosticsRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsRunnerTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000108 /* NetworkDiagnosticsAssessmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsAssessmentTests.swift; sourceTree = "<group>"; };
+		ND000000000000000000010A /* NetworkDiagnosticsPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsPresentationTests.swift; sourceTree = "<group>"; };
+		ND000000000000000000010C /* NetworkDiagnosticsControlEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsControlEndpointTests.swift; sourceTree = "<group>"; };
+		ND000000000000000000010E /* NetworkDiagnosticsDNSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsDNSTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000110 /* NetworkDiagnosticsProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsProxyTests.swift; sourceTree = "<group>"; };
+		ND0000000000000000000112 /* NetworkDiagnosticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticsViewModelTests.swift; sourceTree = "<group>"; };
 		ND0000000000000000000020 /* NetworkDiagnosticModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticModels.swift; sourceTree = "<group>"; };
 		ND0000000000000000000021 /* DiagnosticRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticRunner.swift; sourceTree = "<group>"; };
 		ND0000000000000000000022 /* NetworkConnectivityCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheck.swift; sourceTree = "<group>"; };
@@ -1724,6 +1742,15 @@
 			isa = PBXGroup;
 			children = (
 				ND0000000000000000000002 /* NetworkDiagnosticsTests.swift */,
+				ND0000000000000000000102 /* NetworkDiagnosticsConfigurationTests.swift */,
+				ND0000000000000000000104 /* NetworkDiagnosticsRouteTests.swift */,
+				ND0000000000000000000106 /* NetworkDiagnosticsRunnerTests.swift */,
+				ND0000000000000000000108 /* NetworkDiagnosticsAssessmentTests.swift */,
+				ND000000000000000000010A /* NetworkDiagnosticsPresentationTests.swift */,
+				ND000000000000000000010C /* NetworkDiagnosticsControlEndpointTests.swift */,
+				ND000000000000000000010E /* NetworkDiagnosticsDNSTests.swift */,
+				ND0000000000000000000110 /* NetworkDiagnosticsProxyTests.swift */,
+				ND0000000000000000000112 /* NetworkDiagnosticsViewModelTests.swift */,
 			);
 			path = NetworkDiagnostics;
 			sourceTree = "<group>";
@@ -2306,6 +2333,15 @@
 				G900000000000000000000F2 /* WhatsNewCoordinatorTests.swift in Sources */,
 				G900000000000000000000C7 /* OnboardingEditionTests.swift in Sources */,
 				ND0000000000000000000001 /* NetworkDiagnosticsTests.swift in Sources */,
+				ND0000000000000000000101 /* NetworkDiagnosticsConfigurationTests.swift in Sources */,
+				ND0000000000000000000103 /* NetworkDiagnosticsRouteTests.swift in Sources */,
+				ND0000000000000000000105 /* NetworkDiagnosticsRunnerTests.swift in Sources */,
+				ND0000000000000000000107 /* NetworkDiagnosticsAssessmentTests.swift in Sources */,
+				ND0000000000000000000109 /* NetworkDiagnosticsPresentationTests.swift in Sources */,
+				ND000000000000000000010B /* NetworkDiagnosticsControlEndpointTests.swift in Sources */,
+				ND000000000000000000010D /* NetworkDiagnosticsDNSTests.swift in Sources */,
+				ND000000000000000000010F /* NetworkDiagnosticsProxyTests.swift in Sources */,
+				ND0000000000000000000111 /* NetworkDiagnosticsViewModelTests.swift in Sources */,
 				67B6475699ADED9C42E8F7CC /* BLEModelTests.swift in Sources */,
 				2A8E470AAD8FCE2CC1D14305 /* BandChartViewModelTests.swift in Sources */,
 				A10000000000000000000014 /* ChannelQualityViewModeTests.swift in Sources */,

--- a/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
+++ b/WiFiLens/WiFiLens.xcodeproj/project.pbxproj
@@ -499,6 +499,18 @@
 		ND0000000000000000000059 /* IPv6ControlEndpointCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000056 /* IPv6ControlEndpointCheck.swift */; };
 		ND0000000000000000000060 /* NetworkFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000057 /* NetworkFingerprint.swift */; };
 		ND0000000000000000000061 /* NetworkFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000057 /* NetworkFingerprint.swift */; };
+		ND0000000000000000000062 /* DiagnosticGatewayTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000064 /* DiagnosticGatewayTarget.swift */; };
+		ND0000000000000000000063 /* DiagnosticGatewayTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000064 /* DiagnosticGatewayTarget.swift */; };
+		ND0000000000000000000066 /* SystemDiagnosticRouteSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000065 /* SystemDiagnosticRouteSource.swift */; };
+		ND0000000000000000000067 /* SystemDiagnosticRouteSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000065 /* SystemDiagnosticRouteSource.swift */; };
+		ND0000000000000000000071 /* DiagnosticRunOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000073 /* DiagnosticRunOutcome.swift */; };
+		ND0000000000000000000072 /* DiagnosticRunOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000073 /* DiagnosticRunOutcome.swift */; };
+		ND0000000000000000000075 /* NetworkDiagnosticAssessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000077 /* NetworkDiagnosticAssessment.swift */; };
+		ND0000000000000000000076 /* NetworkDiagnosticAssessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000077 /* NetworkDiagnosticAssessment.swift */; };
+		ND0000000000000000000079 /* NetworkDiagnosticEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000081 /* NetworkDiagnosticEvent.swift */; };
+		ND0000000000000000000080 /* NetworkDiagnosticEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000081 /* NetworkDiagnosticEvent.swift */; };
+		ND0000000000000000000069 /* DiagnosticNetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000068 /* DiagnosticNetworkContext.swift */; };
+		ND0000000000000000000070 /* DiagnosticNetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = ND0000000000000000000068 /* DiagnosticNetworkContext.swift */; };
 		OB0000000000000000000011 /* WiFiObservationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB0000000000000000000001 /* WiFiObservationError.swift */; };
 		OB0000000000000000000012 /* WiFiCurrentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB0000000000000000000002 /* WiFiCurrentStatus.swift */; };
 		OB0000000000000000000013 /* WiFiNetworkCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB0000000000000000000003 /* WiFiNetworkCapabilities.swift */; };
@@ -924,6 +936,12 @@
 		ND0000000000000000000053 /* ProxyResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyResolution.swift; sourceTree = "<group>"; };
 		ND0000000000000000000056 /* IPv6ControlEndpointCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPv6ControlEndpointCheck.swift; sourceTree = "<group>"; };
 		ND0000000000000000000057 /* NetworkFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFingerprint.swift; sourceTree = "<group>"; };
+		ND0000000000000000000064 /* DiagnosticGatewayTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticGatewayTarget.swift; sourceTree = "<group>"; };
+		ND0000000000000000000065 /* SystemDiagnosticRouteSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemDiagnosticRouteSource.swift; sourceTree = "<group>"; };
+		ND0000000000000000000068 /* DiagnosticNetworkContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticNetworkContext.swift; sourceTree = "<group>"; };
+		ND0000000000000000000073 /* DiagnosticRunOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticRunOutcome.swift; sourceTree = "<group>"; };
+		ND0000000000000000000077 /* NetworkDiagnosticAssessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticAssessment.swift; sourceTree = "<group>"; };
+		ND0000000000000000000081 /* NetworkDiagnosticEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiagnosticEvent.swift; sourceTree = "<group>"; };
 		OB0000000000000000000001 /* WiFiObservationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiObservationError.swift; sourceTree = "<group>"; };
 		OB0000000000000000000002 /* WiFiCurrentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiCurrentStatus.swift; sourceTree = "<group>"; };
 		OB0000000000000000000003 /* WiFiNetworkCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiNetworkCapabilities.swift; sourceTree = "<group>"; };
@@ -1722,6 +1740,12 @@
 				ND0000000000000000000053 /* ProxyResolution.swift */,
 				ND0000000000000000000056 /* IPv6ControlEndpointCheck.swift */,
 				ND0000000000000000000057 /* NetworkFingerprint.swift */,
+				ND0000000000000000000064 /* DiagnosticGatewayTarget.swift */,
+				ND0000000000000000000065 /* SystemDiagnosticRouteSource.swift */,
+				ND0000000000000000000068 /* DiagnosticNetworkContext.swift */,
+				ND0000000000000000000073 /* DiagnosticRunOutcome.swift */,
+				ND0000000000000000000077 /* NetworkDiagnosticAssessment.swift */,
+				ND0000000000000000000081 /* NetworkDiagnosticEvent.swift */,
 				ND0000000000000000000042 /* NetworkDiagnosticsViewModel.swift */,
 				ND0000000000000000000045 /* NetworkDiagnosticsView.swift */,
 			);
@@ -2106,6 +2130,12 @@
 				ND0000000000000000000054 /* ProxyResolution.swift in Sources */,
 				ND0000000000000000000058 /* IPv6ControlEndpointCheck.swift in Sources */,
 				ND0000000000000000000060 /* NetworkFingerprint.swift in Sources */,
+				ND0000000000000000000062 /* DiagnosticGatewayTarget.swift in Sources */,
+				ND0000000000000000000066 /* SystemDiagnosticRouteSource.swift in Sources */,
+				ND0000000000000000000069 /* DiagnosticNetworkContext.swift in Sources */,
+				ND0000000000000000000071 /* DiagnosticRunOutcome.swift in Sources */,
+				ND0000000000000000000075 /* NetworkDiagnosticAssessment.swift in Sources */,
+				ND0000000000000000000079 /* NetworkDiagnosticEvent.swift in Sources */,
 				ND0000000000000000000040 /* NetworkDiagnosticsViewModel.swift in Sources */,
 				ND0000000000000000000043 /* NetworkDiagnosticsView.swift in Sources */,
 				237EB0EBBBFBAC33EAE1380B /* BluetoothPermissionManager.swift in Sources */,
@@ -2377,6 +2407,12 @@
 				ND0000000000000000000055 /* ProxyResolution.swift in Sources */,
 				ND0000000000000000000059 /* IPv6ControlEndpointCheck.swift in Sources */,
 				ND0000000000000000000061 /* NetworkFingerprint.swift in Sources */,
+				ND0000000000000000000063 /* DiagnosticGatewayTarget.swift in Sources */,
+				ND0000000000000000000067 /* SystemDiagnosticRouteSource.swift in Sources */,
+				ND0000000000000000000070 /* DiagnosticNetworkContext.swift in Sources */,
+				ND0000000000000000000072 /* DiagnosticRunOutcome.swift in Sources */,
+				ND0000000000000000000076 /* NetworkDiagnosticAssessment.swift in Sources */,
+				ND0000000000000000000080 /* NetworkDiagnosticEvent.swift in Sources */,
 				ND0000000000000000000041 /* NetworkDiagnosticsViewModel.swift in Sources */,
 				ND0000000000000000000044 /* NetworkDiagnosticsView.swift in Sources */,
 				EC20000000000000000000004 /* ProEditionComposition.swift in Sources */,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory contains project documentation for human maintainers and agents.
 | [ISSUES.md](ISSUES.md) | Current known defects, regressions, and deferred items |
 | [2026-09-02-aggregate-spectrum-heatmap.md](superpowers/plans/2026-09-02-aggregate-spectrum-heatmap.md) | Implementation plan for the aggregate Spectrum Heatmap |
 | [2026-09-03-gpu-heatmap-computation.md](superpowers/plans/2026-09-03-gpu-heatmap-computation.md) | Implementation plan for Metal-backed Heatmap field computation |
+| [2026-09-09-network-diagnostics-hardening.md](superpowers/plans/2026-09-09-network-diagnostics-hardening.md) | Complete self-check hardening plan, prioritizing correct gateway selection and interface-bound probing |
 
 `TODO.md` records work that has not been done yet. Completed items are removed
 rather than archived. `ISSUES.md` records active problems and explicitly
@@ -21,6 +22,7 @@ context.
 | File | Purpose |
 |------|---------|
 | [2026-09-02-aggregate-spectrum-heatmap-design.md](superpowers/specs/2026-09-02-aggregate-spectrum-heatmap-design.md) | Aggregate current-scan Heatmap using shared Spectrum envelopes |
+| [2026-09-09-network-diagnostics-hardening-design.md](superpowers/specs/2026-09-09-network-diagnostics-hardening-design.md) | Proposed network self-check fixes for route selection, partial reports, proxy assessment, and bounded reruns |
 
 ## Agent-oriented technical references
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,6 +10,7 @@
 
 ## Engineering
 
+- [x] Complete Network Self-Check hardening: correct default-route gateway selection and interface-bound probing first, then partial reports, bounded reruns, proxy/stage assessment, evidence-based remediation, and bounded logs. See the [implementation plan](superpowers/plans/2026-09-09-network-diagnostics-hardening.md); local verification complete, with live dual-adapter and network-switch coverage still requiring manual hardware testing.
 - [ ] UI / integration tests (9 UI test files exist in `WiFiLensUITests`; excluded from the default test plan per AGENTS.md and not yet wired into CI — pending decision: run in a dedicated CI job, or prune)
 - [ ] Add a small verification matrix for UI regressions across light/dark mode, localization, and no-permission / no-data states
 - [x] Before the next Mac App Store submission, update `NSLocalNetworkUsageDescription` for both OSS and Pro targets to disclose that Network Self-Check may connect to a configured local proxy, in addition to the existing MCP server use case (done: both targets already disclose MCP server + Network Self-Check proxy use)


### PR DESCRIPTION
## Summary

- Select the diagnostic interface and gateway from the complete default-route fingerprint, including route disappearance.
- Bound route command execution by terminating timed-out processes without waiting for unbounded pipe EOF.
- Prevent cancelled diagnostic runs from mutating replacement runs and recompute the network stability window from the latest change.
- Preserve only configuration results when a network change invalidates an unstable run.
- Keep PAC resolution failures and DNS/path uncertainty visible, and classify a single HTTPS failure conservatively as needsAttention.
- Add regression coverage for route changes, route process timeouts, stale runs, stability timing, proxy/PAC assessment, and conservative connectivity conclusions.

## Validation

- bash .agents/skills/verify-build/scripts/verify.sh
- OSS Debug build passed.
- Pro Debug build passed.
- WiFiLensTests: 1233 tests / 126 suites passed.
- UI tests, CI, and live overseas network validation were not run.
